### PR TITLE
Remove pip cache from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-cache: pip
 
 addons:
     chrome: stable
@@ -14,6 +13,7 @@ before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - pip install --upgrade pip
 
 install:
   - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip


### PR DESCRIPTION
Travis fails randomly with `ContextualVersionConflict` on `pip` installed packages. This is an attempt to see if removal of `pip` caching on Travis improves the CI success rate.