### PR TITLE
Update system `numpy` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - pip3 install --upgrade pip
-  - python3 -m venv env
-  - source ./env/bin/activate
+  - pip install --upgrade pip
 
 install:
   - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
@@ -23,8 +21,8 @@ install:
   - export PATH=$PATH:$PWD
 
 script:
-  - pip install .
-  - pip install .[tests]
+  - pip install --upgrade --upgrade-strategy eager .
+  - pip install --upgrade --upgrade-strategy eager .[tests]
   - pycodestyle webviz_subsurface/containers webviz_subsurface/datainput tests
   - pytest tests
   - git clone https://github.com/equinor/webviz-config.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - pip3 install --upgrade pip3
+  - pip3 install --upgrade pip
   - python3 -m venv env
   - source ./env/bin/activate
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - pip install --upgrade pip
-  - python -m venv env
+  - pip3 install --upgrade pip3
+  - python3 -m venv env
   - source ./env/bin/activate
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - pip install --upgrade pip
+  - pip install --upgrade pip numpy
 
 install:
   - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
@@ -21,8 +21,8 @@ install:
   - export PATH=$PATH:$PWD
 
 script:
-  - pip install --upgrade .
-  - pip install --upgrade .[tests]
+  - pip install .
+  - pip install .[tests]
   - pycodestyle webviz_subsurface/containers webviz_subsurface/datainput tests
   - pytest tests
   - git clone https://github.com/equinor/webviz-config.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - pip install --upgrade pip
-  - pip install venv
   - python -m venv env
   - source ./env/bin/activate
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ install:
   - export PATH=$PATH:$PWD
 
 script:
-  - pip install --upgrade --upgrade-strategy eager .
-  - pip install --upgrade --upgrade-strategy eager .[tests]
+  - pip install --upgrade .
+  - pip install --upgrade .[tests]
   - pycodestyle webviz_subsurface/containers webviz_subsurface/datainput tests
   - pytest tests
   - git clone https://github.com/equinor/webviz-config.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - pip install --upgrade pip
+  - pip install venv
+  - python -m venv env
+  - source ./env/bin/activate
 
 install:
   - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip


### PR DESCRIPTION
The default system `numpy` version on Travis is in conflict with `pyarrow`, failing documentation build and deploy using Travis.

Resolves #22.