### PR TITLE
Dash test dependencies and align with Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
 
 before_install:
   - sudo apt-get -qq update
-  - export DISPLAY=:99.0
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y
   - pip install --upgrade pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,14 @@ before_install:
   - pip install --upgrade pip numpy
 
 install:
-  - wget https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip
+  - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - export PATH=$PATH:$PWD
 
 script:
   - pip install .
   - pip install .[tests]
+  - pip install dash[testing]
   - pycodestyle webviz_subsurface/containers webviz_subsurface/datainput tests
   - pytest tests
   - git clone https://github.com/equinor/webviz-config.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 addons:
     chrome: stable
@@ -13,7 +14,8 @@ before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - pip install --upgrade pip numpy
+  - pip freeze | grep -vw "pip" | xargs pip uninstall -y
+  - pip install --upgrade pip
 
 install:
   - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
-cache: pip
+dist: bionic
 
 addons:
-    chrome: stable
+  chrome: stable
+
+services:
+  - xvfb
 
 python:
   - "3.6"
@@ -13,7 +16,6 @@ matrix:
 before_install:
   - sudo apt-get -qq update
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - pip freeze | grep -vw "pip" | xargs pip uninstall -y
   - pip install --upgrade pip
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ tests_require = [
     'selenium>=3.141.0',
     'flake8',
     'pylint',
-    'pytest-dash>=2.1.2',
     'mock'
 ]
 

--- a/tests/test_parameter_distribution.py
+++ b/tests/test_parameter_distribution.py
@@ -1,7 +1,6 @@
 import mock
 import dash
 import pandas as pd
-from pytest_dash.wait_for import wait_for_element_by_css_selector
 from webviz_config.common_cache import cache
 from webviz_config.containers import ParameterDistribution
 

--- a/tests/test_parameter_distribution.py
+++ b/tests/test_parameter_distribution.py
@@ -10,14 +10,13 @@ get_parameters = 'webviz_subsurface.containers'\
                 '._parameter_distribution.get_parameters'
 
 
-def test_parameter_dist(dash_threaded):
+def test_parameter_dist(dash_duo):
 
     app = dash.Dash(__name__)
     app.css.config.serve_locally = True
     app.scripts.config.serve_locally = True
     app.config.suppress_callback_exceptions = True
     cache.init_app(app.server)
-    driver = dash_threaded.driver
     container_settings = {'scratch_ensembles': {'iter-0': ''}}
     ensembles = ['iter-0']
 
@@ -27,11 +26,9 @@ def test_parameter_dist(dash_threaded):
         p = ParameterDistribution(app, container_settings, ensembles)
 
         app.layout = p.layout
-        dash_threaded(app)
+        dash_duo.start_server(app)
 
-        my_component = wait_for_element_by_css_selector(
-                           driver,
-                           f'#{p.ens_matrix_id}'
-                       )
+        my_component = dash_duo.find_element(f'#{p.ens_matrix_id}')
+
         if not my_component.text.startswith('iter-0'):
             raise AssertionError()


### PR DESCRIPTION
Comply with [recent change in `dash`](https://github.com/plotly/dash/blob/master/dash/CHANGELOG.md#101---2019-07-09) wrt. to how test dependencies are installed and tests are written.

In addition:
- Update chrome driver in `.travis.yml` (since Travis has jumped to Chrome version 76).
- Update to _Ubuntu Bionic 18.04_ (from default Travis Ubuntu Trusty 14.04) as that [is now the recommended way of using `xvfb` in Travis](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui).