### PR TITLE
Prefix callback functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[VARIABLES]
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,0 @@
-[VARIABLES]
-
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks=cb_,_cb

--- a/webviz_subsurface/containers/_disk_usage.py
+++ b/webviz_subsurface/containers/_disk_usage.py
@@ -57,7 +57,7 @@ showing disk usage, per user, either as a pie chart or as a bar chart.
     def set_callbacks(self, app):
         @app.callback(Output(self.chart_id, 'figure'),
                       [Input(self.plot_type_id, 'value')])
-        def update_plot(plot_type):
+        def cb_update_plot(plot_type):
             if plot_type == 'Pie chart':
                 data = [{
                     'values': self.usage,

--- a/webviz_subsurface/containers/_disk_usage.py
+++ b/webviz_subsurface/containers/_disk_usage.py
@@ -57,7 +57,7 @@ showing disk usage, per user, either as a pie chart or as a bar chart.
     def set_callbacks(self, app):
         @app.callback(Output(self.chart_id, 'figure'),
                       [Input(self.plot_type_id, 'value')])
-        def cb_update_plot(plot_type):
+        def _update_plot(plot_type):
             if plot_type == 'Pie chart':
                 data = [{
                     'values': self.usage,

--- a/webviz_subsurface/containers/_inplace_volumes.py
+++ b/webviz_subsurface/containers/_inplace_volumes.py
@@ -235,7 +235,7 @@ csv files stored on standard format.
         @app.callback(
             Output(self.chart_id, 'children'),
             self.vol_callback_inputs)
-        def cb_render_vol_chart(*args):
+        def _render_vol_chart(*args):
             '''Renders a volume visualization which could either by a dcc.Graph
             or a Dash table object.
             The arguments are given by the vol_callback_inputs property
@@ -282,7 +282,7 @@ csv files stored on standard format.
             [Output(self.selectors_id['ENSEMBLE'], 'multi'),
              Output(self.selectors_id['ENSEMBLE'], 'value')],
             [Input(self.radio_selectors_id, 'value')])
-        def cb_set_iteration_selector(group_by):
+        def _set_iteration_selector(group_by):
             '''If iteration is selected as group by set the iteration
             selector to allow multiple selections, else use single selection
             '''
@@ -295,7 +295,7 @@ csv files stored on standard format.
             [Output(self.selectors_id['SOURCE'], 'multi'),
              Output(self.selectors_id['SOURCE'], 'value')],
             [Input(self.radio_selectors_id, 'value')])
-        def cb_set_source_selector(group_by):
+        def _set_source_selector(group_by):
             '''If iteration is selected as group by set the iteration
             selector to allow multiple selections, else use single selection
             '''

--- a/webviz_subsurface/containers/_inplace_volumes.py
+++ b/webviz_subsurface/containers/_inplace_volumes.py
@@ -235,7 +235,7 @@ csv files stored on standard format.
         @app.callback(
             Output(self.chart_id, 'children'),
             self.vol_callback_inputs)
-        def render_vol_chart(*args):
+        def cb_render_vol_chart(*args):
             '''Renders a volume visualization which could either by a dcc.Graph
             or a Dash table object.
             The arguments are given by the vol_callback_inputs property
@@ -282,7 +282,7 @@ csv files stored on standard format.
             [Output(self.selectors_id['ENSEMBLE'], 'multi'),
              Output(self.selectors_id['ENSEMBLE'], 'value')],
             [Input(self.radio_selectors_id, 'value')])
-        def set_iteration_selector(group_by):
+        def cb_set_iteration_selector(group_by):
             '''If iteration is selected as group by set the iteration
             selector to allow multiple selections, else use single selection
             '''
@@ -295,7 +295,7 @@ csv files stored on standard format.
             [Output(self.selectors_id['SOURCE'], 'multi'),
              Output(self.selectors_id['SOURCE'], 'value')],
             [Input(self.radio_selectors_id, 'value')])
-        def set_source_selector(group_by):
+        def cb_set_source_selector(group_by):
             '''If iteration is selected as group by set the iteration
             selector to allow multiple selections, else use single selection
             '''

--- a/webviz_subsurface/containers/_intersect.py
+++ b/webviz_subsurface/containers/_intersect.py
@@ -193,7 +193,7 @@ and a folder of well files stored in RMS well format.
              Input(self.surf_list_id, 'value'),
              Input(self.well_tvd_id, 'value'),
              Input(self.zoom_state_id, 'value')])
-        def set_fence(_well_path, _reals, _surfs, _tvdmin, _keep_zoom_state):
+        def cb_set_fence(_well_path, _reals, _surfs, _tvdmin, _keep_zoom_state):
             '''Callback to update intersection on data change'''
             if not isinstance(_surfs, list):
                 _surfs = [_surfs]
@@ -214,7 +214,7 @@ and a folder of well files stored in RMS well format.
                       [Input(self.intersection_id, 'hoverData')],
                       [State(self.intersection_id, 'figure'),
                        State(self.surf_list_id, 'value')])
-        def hover(_data, _fig, _surfaces):
+        def cb_hover(_data, _fig, _surfaces):
             '''Callback to update table on mouse over'''
             try:
                 graph = _fig['data']

--- a/webviz_subsurface/containers/_intersect.py
+++ b/webviz_subsurface/containers/_intersect.py
@@ -193,20 +193,20 @@ and a folder of well files stored in RMS well format.
              Input(self.surf_list_id, 'value'),
              Input(self.well_tvd_id, 'value'),
              Input(self.zoom_state_id, 'value')])
-        def cb_set_fence(_well_path, _reals, _surfs, _tvdmin, _keep_zoom_state):
+        def _set_fence(well_path, reals, surfs, tvdmin, keep_zoom_state):
             '''Callback to update intersection on data change'''
-            if not isinstance(_surfs, list):
-                _surfs = [_surfs]
-            if not isinstance(_reals, list):
-                _reals = [_reals]
-            if not _reals:
-                _reals = list(self.realizations.keys())
-            if not _surfs:
-                _surfs = self.surface_names
-            s_names = [s for s in self.surface_names if s in _surfs]
-            xsect = self.plot_xsection(_well_path, _reals, s_names, _tvdmin)
+            if not isinstance(surfs, list):
+                surfs = [surfs]
+            if not isinstance(reals, list):
+                reals = [reals]
+            if not reals:
+                reals = list(self.realizations.keys())
+            if not surfs:
+                surfs = self.surface_names
+            s_names = [s for s in self.surface_names if s in surfs]
+            xsect = self.plot_xsection(well_path, reals, s_names, tvdmin)
             layout = self.graph_layout
-            if _keep_zoom_state:
+            if keep_zoom_state:
                 layout['uirevision'] = 'keep'
             return {'data': xsect, 'layout': layout}
 
@@ -214,7 +214,7 @@ and a folder of well files stored in RMS well format.
                       [Input(self.intersection_id, 'hoverData')],
                       [State(self.intersection_id, 'figure'),
                        State(self.surf_list_id, 'value')])
-        def cb_hover(_data, _fig, _surfaces):
+        def _hover(_data, _fig, _surfaces):
             '''Callback to update table on mouse over'''
             try:
                 graph = _fig['data']

--- a/webviz_subsurface/containers/_morris_plot.py
+++ b/webviz_subsurface/containers/_morris_plot.py
@@ -53,7 +53,7 @@ effect with other parameters.
             Output(self.graph_id, 'parameter'),
             Output(self.graph_id, 'parameters')],
             [Input(self.vector_id, 'value')])
-        def update_plot(vector):
+        def cb_update_plot(vector):
             df = self.data[self.data['name'] == vector]
             df = df.sort_values('time')
             output = df[['mean', 'max', 'min', 'time']]\

--- a/webviz_subsurface/containers/_morris_plot.py
+++ b/webviz_subsurface/containers/_morris_plot.py
@@ -53,7 +53,7 @@ effect with other parameters.
             Output(self.graph_id, 'parameter'),
             Output(self.graph_id, 'parameters')],
             [Input(self.vector_id, 'value')])
-        def cb_update_plot(vector):
+        def _update_plot(vector):
             df = self.data[self.data['name'] == vector]
             df = df.sort_values('time')
             output = df[['mean', 'max', 'min', 'time']]\

--- a/webviz_subsurface/containers/_parameter_distribution.py
+++ b/webviz_subsurface/containers/_parameter_distribution.py
@@ -144,7 +144,7 @@ and correlation between the parameters as a correlation matrix.
                       [Input(self.ens_matrix_id, 'value'),
                        Input(self.p1_drop_id, 'value'),
                        Input(self.p2_drop_id, 'value')])
-        def cb_update_matrix(ens, p1, p2):
+        def _update_matrix(ens, p1, p2):
             '''Renders correlation matrix.
             Currently also re-renders matrix to update currently
             selected cell. This is not optimal, but hard to prevent
@@ -180,7 +180,7 @@ and correlation between the parameters as a correlation matrix.
                        Input(self.p2_drop_id, 'value'),
                        Input(self.scatter_color_id, 'value'),
                        Input(self.density_id, 'value')])
-        def cb_update_scatter(ens1, p1, ens2, p2, color, density):
+        def _update_scatter(ens1, p1, ens2, p2, color, density):
             return render_scatter(ens1, p1, ens2, p2, color, density)
 
         @app.callback([Output(self.p1_drop_id, 'value'),
@@ -190,7 +190,7 @@ and correlation between the parameters as a correlation matrix.
                       [Input(self.matrix_id, 'clickData'),
                        Input(self.ens_matrix_id, 'value')]
                       )
-        def cb_update_from_click(cd, ens):
+        def _update_from_click(cd, ens):
             try:
                 points = cd['points'][0]
             # TypeError is returned if no cells are clicked

--- a/webviz_subsurface/containers/_parameter_distribution.py
+++ b/webviz_subsurface/containers/_parameter_distribution.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 import pandas as pd
 import dash_html_components as html
 import dash_core_components as dcc
-from dash.dependencies import Input, Output, State
+from dash.dependencies import Input, Output
 import dash_daq as daq
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import cache
@@ -144,7 +144,7 @@ and correlation between the parameters as a correlation matrix.
                       [Input(self.ens_matrix_id, 'value'),
                        Input(self.p1_drop_id, 'value'),
                        Input(self.p2_drop_id, 'value')])
-        def update_matrix(ens, p1, p2):
+        def cb_update_matrix(ens, p1, p2):
             '''Renders correlation matrix.
             Currently also re-renders matrix to update currently
             selected cell. This is not optimal, but hard to prevent
@@ -180,7 +180,7 @@ and correlation between the parameters as a correlation matrix.
                        Input(self.p2_drop_id, 'value'),
                        Input(self.scatter_color_id, 'value'),
                        Input(self.density_id, 'value')])
-        def update_scatter(ens1, p1, ens2, p2, color, density):
+        def cb_update_scatter(ens1, p1, ens2, p2, color, density):
             return render_scatter(ens1, p1, ens2, p2, color, density)
 
         @app.callback([Output(self.p1_drop_id, 'value'),
@@ -190,7 +190,7 @@ and correlation between the parameters as a correlation matrix.
                       [Input(self.matrix_id, 'clickData'),
                        Input(self.ens_matrix_id, 'value')]
                       )
-        def update_from_click(cd, ens):
+        def cb_update_from_click(cd, ens):
             try:
                 points = cd['points'][0]
             # TypeError is returned if no cells are clicked

--- a/webviz_subsurface/containers/_summary_stats.py
+++ b/webviz_subsurface/containers/_summary_stats.py
@@ -99,7 +99,7 @@ class SummaryStats(WebvizContainer):
                       [Input(self.dropwdown_vector_id, 'value'),
                        Input(self.radio_plot_type_id, 'value'),
                        Input(self.show_history_uncertainty_id, 'value')])
-        def update_plot(
+        def cb_update_plot(
                 vector,
                 summary_plot_type,
                 show_history_uncertainty_id):

--- a/webviz_subsurface/containers/_summary_stats.py
+++ b/webviz_subsurface/containers/_summary_stats.py
@@ -99,7 +99,7 @@ class SummaryStats(WebvizContainer):
                       [Input(self.dropwdown_vector_id, 'value'),
                        Input(self.radio_plot_type_id, 'value'),
                        Input(self.show_history_uncertainty_id, 'value')])
-        def cb_update_plot(
+        def _update_plot(
                 vector,
                 summary_plot_type,
                 show_history_uncertainty_id):


### PR DESCRIPTION
`pylint` does not recognize that decorated callback functions are used within `dash`, and therefore falsely reports them as unused. This is solved by prefixing them with `_`, which at the same time indicates that these callback functions are defined (and used) within the container.