### PR TITLE
Rename ParameterDistribution to ParameterCorrelation

### DIFF
--- a/examples/basic_example.yaml
+++ b/examples/basic_example.yaml
@@ -25,7 +25,7 @@ pages:
  - title: Parameter distribution
    content: 
     - Some text...
-    - container: ParameterDistribution
+    - container: ParameterCorrelation
       ensembles:
         - iter-0
         - iter-1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     entry_points={
         'webviz_config_containers': [
-            'ParameterDistribution = webviz_subsurface.containers:ParameterDistribution',
+            'ParameterCorrelation = webviz_subsurface.containers:ParameterCorrelation',
             'DiskUsage = webviz_subsurface.containers:DiskUsage',
             'SubsurfaceMap = webviz_subsurface.containers:SubsurfaceMap',
             'HistoryMatch = webviz_subsurface.containers:HistoryMatch',

--- a/tests/test_parameter_correlation.py
+++ b/tests/test_parameter_correlation.py
@@ -2,14 +2,14 @@ import mock
 import dash
 import pandas as pd
 from webviz_config.common_cache import cache
-from webviz_config.containers import ParameterDistribution
+from webviz_config.containers import ParameterCorrelation
 
 # mocked functions
 get_parameters = 'webviz_subsurface.containers'\
-                '._parameter_distribution.get_parameters'
+                '._parameter_correlation.get_parameters'
 
 
-def test_parameter_dist(dash_duo):
+def test_parameter_corr(dash_duo):
 
     app = dash.Dash(__name__)
     app.css.config.serve_locally = True
@@ -22,7 +22,7 @@ def test_parameter_dist(dash_duo):
     with mock.patch(get_parameters) as mock_parameters:
         mock_parameters.return_value = pd.read_csv('tests/data/parameters.csv')
 
-        p = ParameterDistribution(app, container_settings, ensembles)
+        p = ParameterCorrelation(app, container_settings, ensembles)
 
         app.layout = p.layout
         dash_duo.start_server(app)

--- a/webviz_subsurface/containers/__init__.py
+++ b/webviz_subsurface/containers/__init__.py
@@ -23,7 +23,7 @@ pages:
 ```
 '''
 
-from ._parameter_distribution import ParameterDistribution
+from ._parameter_correlation import ParameterCorrelation
 from ._disk_usage import DiskUsage
 from ._subsurface_map import SubsurfaceMap
 from ._history_match import HistoryMatch
@@ -33,7 +33,7 @@ from ._inplace_volumes import InplaceVolumes
 from ._reservoir_simulation_timeseries import ReservoirSimulationTimeSeries
 
 
-__all__ = ['ParameterDistribution',
+__all__ = ['ParameterCorrelation',
            'DiskUsage',
            'SubsurfaceMap',
            'HistoryMatch',

--- a/webviz_subsurface/containers/_parameter_correlation.py
+++ b/webviz_subsurface/containers/_parameter_correlation.py
@@ -22,11 +22,11 @@ class Widgets:
                             clearable=False)
 
 
-class ParameterDistribution(WebvizContainer):
-    '''### Parameter distribution
+class ParameterCorrelation(WebvizContainer):
+    '''### Parameter correlation
 
-This container shows parameter distribution as histogram,
-and correlation between the parameters as a correlation matrix.
+This container shows parameter correlation using a correlation matrix,
+and scatter plot for any given pair of parameters.
 
 * `ensembles`: Which ensembles in `container_settings` to visualize.
 * `drop_constants`: Drop constant parameters


### PR DESCRIPTION
The container currently named `ParameterDistribution` is geared more towards showing correlations. Rename.