### PR TITLE
PEP8 group imports

### DIFF
--- a/webviz_subsurface/containers/_disk_usage.py
+++ b/webviz_subsurface/containers/_disk_usage.py
@@ -1,5 +1,6 @@
 import os
 from uuid import uuid4
+
 import pandas as pd
 import dash_html_components as html
 import dash_core_components as dcc

--- a/webviz_subsurface/containers/_history_match.py
+++ b/webviz_subsurface/containers/_history_match.py
@@ -1,11 +1,13 @@
 import json
-import numpy as np
 from uuid import uuid4
 from pathlib import Path
+
+import numpy as np
 from scipy.stats import chi2
 import dash_html_components as html
-from webviz_config.containers import WebvizContainer
 import webviz_subsurface_components as wsc
+from webviz_config.containers import WebvizContainer
+
 from ..datainput import extract_mismatch
 
 

--- a/webviz_subsurface/containers/_inplace_volumes.py
+++ b/webviz_subsurface/containers/_inplace_volumes.py
@@ -1,12 +1,14 @@
 from uuid import uuid4
+
 import numpy as np
+import dash_table
 import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
-import dash_table
 from dash.dependencies import Input, Output
 from webviz_config.common_cache import cache
 from webviz_config.containers import WebvizContainer
+
 from ..datainput import extract_volumes
 
 

--- a/webviz_subsurface/containers/_intersect.py
+++ b/webviz_subsurface/containers/_intersect.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 from glob import glob
 from pathlib import PurePath
 from collections import OrderedDict
+
 import numpy as np
 import pandas as pd
 import dash_html_components as html
@@ -11,6 +12,7 @@ from dash.dependencies import Input, Output, State
 from dash_table import DataTable
 from webviz_config.common_cache import cache
 from webviz_config.containers import WebvizContainer
+
 from ..datainput import scratch_ensemble, load_surface, get_wfence, get_hfence
 
 

--- a/webviz_subsurface/containers/_morris_plot.py
+++ b/webviz_subsurface/containers/_morris_plot.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 from pathlib import Path
+
 import pandas as pd
 import dash_html_components as html
 import dash_core_components as dcc

--- a/webviz_subsurface/containers/_parameter_correlation.py
+++ b/webviz_subsurface/containers/_parameter_correlation.py
@@ -1,13 +1,15 @@
 from uuid import uuid4
+
 import pandas as pd
+import dash_daq as daq
 import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
 from dash.dependencies import Input, Output
-import dash_daq as daq
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import cache
 from webviz_config.containers import WebvizContainer
+
 from ..datainput import scratch_ensemble
 
 

--- a/webviz_subsurface/containers/_parameter_distribution.py
+++ b/webviz_subsurface/containers/_parameter_distribution.py
@@ -1,13 +1,15 @@
 from uuid import uuid4
+
 import dash
-from dash.exceptions import PreventUpdate
+import plotly.express as px
 import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
+from dash.exceptions import PreventUpdate
 from dash.dependencies import Input, Output, State
 from webviz_config.containers import WebvizContainer
-from webviz_subsurface.datainput import load_parameters
-import plotly.express as px
+
+from ..datainput import load_parameters
 
 
 class ParameterDistribution(WebvizContainer):

--- a/webviz_subsurface/containers/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/containers/_reservoir_simulation_timeseries.py
@@ -1,5 +1,6 @@
 import itertools
 from uuid import uuid4
+
 import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
@@ -8,7 +9,8 @@ from webviz_config.containers import WebvizContainer
 from webviz_config.common_cache import cache
 from plotly.colors import DEFAULT_PLOTLY_COLORS
 import plotly.graph_objs as go
-from webviz_subsurface.datainput import (
+
+from ..datainput import (
     get_time_series_data,
     get_time_series_statistics,
     get_time_series_delta_ens,

--- a/webviz_subsurface/containers/_subsurface_map.py
+++ b/webviz_subsurface/containers/_subsurface_map.py
@@ -1,11 +1,13 @@
-from uuid import uuid4
 import json
+from uuid import uuid4
+
 import pandas as pd
 import dash_html_components as html
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import cache
 from webviz_config.containers import WebvizContainer
 from webviz_subsurface_components import Map
+
 from ..datainput import scratch_ensemble
 
 

--- a/webviz_subsurface/datainput/_fmu_input.py
+++ b/webviz_subsurface/datainput/_fmu_input.py
@@ -1,11 +1,10 @@
 import pandas as pd
-
+from webviz_config.common_cache import cache
+from webviz_config.webviz_store import webvizstore
 try:
     from fmu.ensemble import ScratchEnsemble, EnsembleSet
 except ImportError:
     pass
-from webviz_config.common_cache import cache
-from webviz_config.webviz_store import webvizstore
 
 
 @cache.memoize(timeout=cache.TIMEOUT)

--- a/webviz_subsurface/datainput/_fmu_input.py
+++ b/webviz_subsurface/datainput/_fmu_input.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from webviz_config.common_cache import cache
 from webviz_config.webviz_store import webvizstore
+
 try:
     from fmu.ensemble import ScratchEnsemble, EnsembleSet
 except ImportError:

--- a/webviz_subsurface/datainput/_history_match.py
+++ b/webviz_subsurface/datainput/_history_match.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pandas as pd
 from webviz_config.common_cache import cache
 from webviz_config.webviz_store import webvizstore
+
 try:
     import fmu.ensemble
 except ImportError:  # fmu.ensemble is an optional dependency, e.g.

--- a/webviz_subsurface/datainput/_history_match.py
+++ b/webviz_subsurface/datainput/_history_match.py
@@ -1,12 +1,12 @@
+from pathlib import Path
+
+import pandas as pd
+from webviz_config.common_cache import cache
+from webviz_config.webviz_store import webvizstore
 try:
     import fmu.ensemble
 except ImportError:  # fmu.ensemble is an optional dependency, e.g.
     pass  # for a portable webviz instance, it is never used.
-
-import pandas as pd
-from pathlib import Path
-from webviz_config.common_cache import cache
-from webviz_config.webviz_store import webvizstore
 
 
 @cache.memoize(timeout=cache.TIMEOUT)

--- a/webviz_subsurface/datainput/_inplace_volumes.py
+++ b/webviz_subsurface/datainput/_inplace_volumes.py
@@ -1,13 +1,12 @@
 import os
 
+import pandas as pd
+from webviz_config.common_cache import cache
+from webviz_config.webviz_store import webvizstore
 try:
     import fmu.ensemble
 except ImportError:  # fmu.ensemble is an optional dependency, e.g.
     pass  # for a portable webviz instance, it is never used.
-
-import pandas as pd
-from webviz_config.common_cache import cache
-from webviz_config.webviz_store import webvizstore
 
 
 @cache.memoize(timeout=cache.TIMEOUT)

--- a/webviz_subsurface/datainput/_inplace_volumes.py
+++ b/webviz_subsurface/datainput/_inplace_volumes.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 from webviz_config.common_cache import cache
 from webviz_config.webviz_store import webvizstore
+
 try:
     import fmu.ensemble
 except ImportError:  # fmu.ensemble is an optional dependency, e.g.

--- a/webviz_subsurface/datainput/_intersect.py
+++ b/webviz_subsurface/datainput/_intersect.py
@@ -2,6 +2,7 @@ import os
 
 import pandas as pd
 from webviz_config.common_cache import cache
+
 try:
     import xtgeo
 except ImportError:

--- a/webviz_subsurface/datainput/_intersect.py
+++ b/webviz_subsurface/datainput/_intersect.py
@@ -1,11 +1,11 @@
 import os
-import pandas as pd
 
+import pandas as pd
+from webviz_config.common_cache import cache
 try:
     import xtgeo
 except ImportError:
     pass
-from webviz_config.common_cache import cache
 
 
 @cache.memoize(timeout=cache.TIMEOUT)

--- a/webviz_subsurface/datainput/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/datainput/_reservoir_simulation_timeseries.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from webviz_config.common_cache import cache
 from webviz_config.webviz_store import webvizstore
+
 try:
     from fmu.ensemble import EnsembleSet
 except ImportError:  # fmu.ensemble is an optional dependency, e.g.

--- a/webviz_subsurface/datainput/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/datainput/_reservoir_simulation_timeseries.py
@@ -1,19 +1,11 @@
-# -*- coding: utf-8 -*-
-""" time-series data-input functions
-    - Process ensemble-data (read, filter, compare)
-    - Treated as ensembleset-object (independent of n-ensembles)
-"""
-
-
+import pandas as pd
+from webviz_config.common_cache import cache
+from webviz_config.webviz_store import webvizstore
 try:
     from fmu.ensemble import EnsembleSet
 except ImportError:  # fmu.ensemble is an optional dependency, e.g.
     pass  # for a portable webviz instance, it is never used.
 
-
-import pandas as pd
-from webviz_config.common_cache import cache
-from webviz_config.webviz_store import webvizstore
 from ..datainput import scratch_ensemble
 
 

--- a/webviz_subsurface/datainput/layeredmap/_image_processing.py
+++ b/webviz_subsurface/datainput/layeredmap/_image_processing.py
@@ -1,5 +1,6 @@
 import io
 import base64
+
 import numpy as np
 from matplotlib import cm
 from PIL import Image

--- a/webviz_subsurface/datainput/layeredmap/_layered_fence.py
+++ b/webviz_subsurface/datainput/layeredmap/_layered_fence.py
@@ -1,6 +1,7 @@
 import numpy as np
-from ._image_processing import get_colormap, array_to_png
 from xtgeo import RegularSurface, Cube, Grid, GridProperty
+
+from ._image_processing import get_colormap, array_to_png
 
 
 class LayeredFence:

--- a/webviz_subsurface/datainput/layeredmap/_layered_surface.py
+++ b/webviz_subsurface/datainput/layeredmap/_layered_surface.py
@@ -1,6 +1,7 @@
 import numpy as np
-from ._image_processing import get_colormap, array_to_png
 from xtgeo.surface import RegularSurface
+
+from ._image_processing import get_colormap, array_to_png
 
 
 class LayeredSurface:


### PR DESCRIPTION
Group according to PEP8 guide + remove two instances of unused imports.

> Imports should be grouped in the following order:
> 
> 1. Standard library imports.
> 2. Related third party imports.
> 3. Local application/library specific imports.
>
> You should put a blank line between each group of imports.