### PR TITLE
Adding support for 'find_files' for UNSMRY files

### DIFF
--- a/webviz_subsurface/containers/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/containers/_reservoir_simulation_timeseries.py
@@ -63,7 +63,8 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
         )
         self.unsmry_files = tuple(
             (ensemble, container_settings["unsmry_files"][ensemble])
-            for ensemble in ensembles if "unsmry_files" in container_settings
+            for ensemble in ensembles
+            if "unsmry_files" in container_settings
         )
         self.base_ensembles = tuple(
             base_ensembles if base_ensembles else [i[0] for i in self.ensemble_paths]
@@ -84,7 +85,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                     ensemble_paths=self.ensemble_paths,
                     time_index=self.time_index,
                     column_keys=self.column_keys,
-                    unsmry_files=self.unsmry_files
+                    unsmry_files=self.unsmry_files,
                 )
                 .drop(columns=["DATE", "REAL", "ENSEMBLE"])
                 .columns

--- a/webviz_subsurface/containers/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/containers/_reservoir_simulation_timeseries.py
@@ -61,6 +61,10 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
             (ensemble, container_settings["scratch_ensembles"][ensemble])
             for ensemble in ensembles
         )
+        self.unsmry_files = tuple(
+            (ensemble, container_settings["unsmry_files"][ensemble])
+            for ensemble in ensembles if "unsmry_files" in container_settings
+        )
         self.base_ensembles = tuple(
             base_ensembles if base_ensembles else [i[0] for i in self.ensemble_paths]
         )
@@ -80,6 +84,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                     ensemble_paths=self.ensemble_paths,
                     time_index=self.time_index,
                     column_keys=self.column_keys,
+                    unsmry_files=self.unsmry_files
                 )
                 .drop(columns=["DATE", "REAL", "ENSEMBLE"])
                 .columns
@@ -259,6 +264,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
 
                 return render_realization_plot(
                     ensemble_paths=self.ensemble_paths,
+                    unsmry_files=self.unsmry_files,
                     column_keys=self.column_keys,
                     time_index=self.time_index,
                     vector=vector,
@@ -276,6 +282,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
 
                 return render_stat_plot(
                     ensemble_paths=self.ensemble_paths,
+                    unsmry_files=self.unsmry_files,
                     column_keys=self.column_keys,
                     time_index=self.time_index,
                     ensemble_set_name=self.title,
@@ -326,6 +333,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         column_keys=self.column_keys,
                         base_ensembles=self.base_ensembles,
                         delta_ensembles=self.delta_ensembles,
+                        unsmry_files=self.unsmry_files,
                         ensemble_set_name=self.title,
                     ).filter(items=[vector, "DATE", "IROENS - REFENS", "REAL"])
 
@@ -336,6 +344,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         ensemble_paths=self.ensemble_paths,
                         column_keys=self.column_keys,
                         time_index=self.time_index,
+                        unsmry_files=self.unsmry_files,
                         ensemble_set_name=self.title,
                     ).filter(items=[vector, "DATE", "ENSEMBLE", "REAL"])
 
@@ -350,6 +359,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         time_index=self.time_index,
                         base_ensembles=self.base_ensembles,
                         delta_ensembles=self.delta_ensembles,
+                        unsmry_files=self.unsmry_files,
                         ensemble_set_name=self.title,
                     ).filter(items=["STATISTIC", vector, "DATE", "IROENS - REFENS"])
 
@@ -360,6 +370,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         ensemble_paths=self.ensemble_paths,
                         column_keys=self.column_keys,
                         time_index=self.time_index,
+                        unsmry_files=self.unsmry_files,
                     ).filter(items=["STATISTIC", vector, "DATE", "ENSEMBLE"])
 
             return (
@@ -388,6 +399,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         "ensemble_paths": self.ensemble_paths,
                         "column_keys": self.column_keys,
                         "time_index": self.time_index,
+                        "unsmry_files": self.unsmry_files,
                         "ensemble_set_name": self.title,
                     }
                 ],
@@ -399,6 +411,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         "ensemble_paths": self.ensemble_paths,
                         "time_index": self.time_index,
                         "column_keys": self.column_keys,
+                        "unsmry_files": self.unsmry_files,
                     }
                 ],
             ),
@@ -411,6 +424,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         "column_keys": self.column_keys,
                         "base_ensembles": self.base_ensembles,
                         "delta_ensembles": self.delta_ensembles,
+                        "unsmry_files": self.unsmry_files,
                         "ensemble_set_name": self.title,
                     }
                 ],
@@ -424,6 +438,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
                         "column_keys": self.column_keys,
                         "base_ensembles": self.base_ensembles,
                         "delta_ensembles": self.delta_ensembles,
+                        "unsmry_files": self.unsmry_files,
                         "ensemble_set_name": self.title,
                     }
                 ],
@@ -439,6 +454,7 @@ class ReservoirSimulationTimeSeries(WebvizContainerABC):
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
 def render_realization_plot(
     ensemble_paths: tuple,
+    unsmry_files: tuple,
     time_index: str,
     column_keys: tuple,
     vector: str,
@@ -483,6 +499,7 @@ def render_realization_plot(
             ensemble_paths=ensemble_paths,
             column_keys=column_keys,
             time_index=time_index,
+            unsmry_files=unsmry_files,
             ensemble_set_name=ensemble_set_name,
         )[["REAL", "DATE", "ENSEMBLE", vector, history_vector]]
 
@@ -492,6 +509,7 @@ def render_realization_plot(
             ensemble_paths=ensemble_paths,
             column_keys=column_keys,
             time_index=time_index,
+            unsmry_files=unsmry_files,
             ensemble_set_name=ensemble_set_name,
         )[["REAL", "DATE", "ENSEMBLE", vector]]
 
@@ -502,6 +520,7 @@ def render_realization_plot(
             column_keys=column_keys,
             base_ensembles=base_ensembles,
             delta_ensembles=delta_ensembles,
+            unsmry_files=unsmry_files,
             ensemble_set_name=ensemble_set_name,
         )
 
@@ -555,6 +574,7 @@ def render_realization_plot(
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
 def render_stat_plot(
     ensemble_paths: tuple,
+    unsmry_files: tuple,
     time_index: str,
     column_keys: tuple,
     vector: str,
@@ -603,6 +623,7 @@ def render_stat_plot(
             ensemble_paths=ensemble_paths,
             column_keys=column_keys,
             time_index=time_index,
+            unsmry_files=unsmry_files,
         )
 
         data = []
@@ -622,6 +643,7 @@ def render_stat_plot(
             time_index=time_index,
             base_ensembles=base_ensembles,
             delta_ensembles=delta_ensembles,
+            unsmry_files=unsmry_files,
             ensemble_set_name=ensemble_set_name,
         )
 

--- a/webviz_subsurface/datainput/_history_match.py
+++ b/webviz_subsurface/datainput/_history_match.py
@@ -11,8 +11,10 @@ except ImportError:  # fmu.ensemble is an optional dependency, e.g.
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
-def scratch_ensemble(ensemble_name, ensemble_path,autodiscovery=True):
-    return fmu.ensemble.ScratchEnsemble(ensemble_name, ensemble_path,autodiscovery=autodiscovery)
+def scratch_ensemble(ensemble_name, ensemble_path, autodiscovery=True):
+    return fmu.ensemble.ScratchEnsemble(
+        ensemble_name, ensemble_path, autodiscovery=autodiscovery
+    )
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)

--- a/webviz_subsurface/datainput/_history_match.py
+++ b/webviz_subsurface/datainput/_history_match.py
@@ -11,8 +11,8 @@ except ImportError:  # fmu.ensemble is an optional dependency, e.g.
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
-def scratch_ensemble(ensemble_name, ensemble_path):
-    return fmu.ensemble.ScratchEnsemble(ensemble_name, ensemble_path)
+def scratch_ensemble(ensemble_name, ensemble_path,autodiscovery=True):
+    return fmu.ensemble.ScratchEnsemble(ensemble_name, ensemble_path,autodiscovery=autodiscovery)
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)

--- a/webviz_subsurface/datainput/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/datainput/_reservoir_simulation_timeseries.py
@@ -11,7 +11,11 @@ from ._history_match import scratch_ensemble
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
-def load_ensemble_set(ensemble_paths: tuple, ensemble_set_name: str = "EnsembleSet", unsmry_files: tuple = None):
+def load_ensemble_set(
+    ensemble_paths: tuple,
+    ensemble_set_name: str = "EnsembleSet",
+    unsmry_files: tuple = None,
+):
 
     ensembles = []
     if unsmry_files is not None:
@@ -19,15 +23,13 @@ def load_ensemble_set(ensemble_paths: tuple, ensemble_set_name: str = "EnsembleS
 
     for ens_name, ens_path in ensemble_paths:
         if unsmry_files is not None and ens_name in unsmry_files:
-            scratch_ens = scratch_ensemble(ens_name, ens_path,autodiscovery=False)
+            scratch_ens = scratch_ensemble(ens_name, ens_path, autodiscovery=False)
             scratch_ens.find_files(unsmry_files[ens_name])
             ensembles.append(scratch_ens)
-        else: 
+        else:
             ensembles.append(scratch_ensemble(ens_name, ens_path))
-    
-    ensset = EnsembleSet(
-        ensemble_set_name,
-        ensembles)
+
+    ensset = EnsembleSet(ensemble_set_name, ensembles)
 
     return ensset
 
@@ -35,11 +37,13 @@ def load_ensemble_set(ensemble_paths: tuple, ensemble_set_name: str = "EnsembleS
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
 @webvizstore
 def get_time_series_statistics(
-    ensemble_paths: tuple, time_index: str, column_keys: tuple, unsmry_files: tuple = None
+    ensemble_paths: tuple,
+    time_index: str,
+    column_keys: tuple,
+    unsmry_files: tuple = None,
 ) -> pd.DataFrame:
 
     column_keys = list(column_keys) if isinstance(column_keys, (list, tuple)) else None
-
 
     # Note: to be replaced by ensset.get_smry_stats()
     # when function is available.
@@ -51,9 +55,9 @@ def get_time_series_statistics(
 
     for ens_name, ens_path in ensemble_paths:
         if unsmry_files is not None and ens_name in unsmry_files:
-           ens = scratch_ensemble(ens_name, ens_path,autodiscovery=False)
-           ens.find_files(unsmry_files[ens_name])
-           ens_smry_stats = ens.get_smry_stats(
+            ens = scratch_ensemble(ens_name, ens_path, autodiscovery=False)
+            ens.find_files(unsmry_files[ens_name])
+            ens_smry_stats = ens.get_smry_stats(
                 time_index=time_index, column_keys=column_keys
             )
         else:
@@ -79,7 +83,9 @@ def get_time_series_data(
     column_keys = list(column_keys) if isinstance(column_keys, (list, tuple)) else None
 
     ensset = load_ensemble_set(
-        ensemble_paths=ensemble_paths, ensemble_set_name=ensemble_set_name, unsmry_files=unsmry_files
+        ensemble_paths=ensemble_paths,
+        ensemble_set_name=ensemble_set_name,
+        unsmry_files=unsmry_files,
     )
 
     return ensset.get_smry(time_index=time_index, column_keys=column_keys)
@@ -106,7 +112,9 @@ def get_time_series_delta_ens(
     column_keys = list(column_keys) if isinstance(column_keys, (list, tuple)) else None
 
     ensset = load_ensemble_set(
-        ensemble_paths=ensemble_paths, ensemble_set_name=ensemble_set_name, unsmry_files=unsmry_files
+        ensemble_paths=ensemble_paths,
+        ensemble_set_name=ensemble_set_name,
+        unsmry_files=unsmry_files,
     )
 
     delta_ens_dfs = []
@@ -142,7 +150,9 @@ def get_time_series_delta_ens_stats(
     column_keys = list(column_keys) if isinstance(column_keys, (list, tuple)) else None
 
     ensset = load_ensemble_set(
-        ensemble_paths=ensemble_paths, ensemble_set_name=ensemble_set_name, unsmry_files=unsmry_files
+        ensemble_paths=ensemble_paths,
+        ensemble_set_name=ensemble_set_name,
+        unsmry_files=unsmry_files,
     )
 
     delta_ens_stats_dfs = []


### PR DESCRIPTION
Added support for discovery of `UNSMRY` files in non standard location (or multiple `UNSMRY` files in same folder).
Usage in `yaml` config file:
```
container_settings:
  scratch_ensembles:
    iter-0: /path/to/scratch/case/realization-*/iter-0
    iter-0_ix: /path/to/scratch/case/realization-*/iter-0
  unsmry_files: 
    iter-0: eclipse/model/*.UNSMRY
    iter-0_ix: ix/model/*.UNSMRY