### PR TITLE
Add pip list to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 
 script:
   - pip install .
+  - pip list
   - pip install .[tests]
   - pip install dash[testing]
   - black --check webviz_subsurface tests setup.py


### PR DESCRIPTION
Some deployment systems require that all direct AND indirect runtime dependencies are listed, with version numbers. To facilitate this, `pip list` during CI to show the whole indirect+direct dependency list.