### PR TITLE
Extend CI to Python{3.7, 3.8}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ python:
   - "3.7"
   - "3.8"
 
-matrix:
+jobs:
   fast_finish: true
+  allow_failures:
+    - python: "3.8"
 
 before_install:
   - sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ services:
 
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 matrix:
   fast_finish: true
@@ -72,12 +74,14 @@ deploy:
       secure: Itu6xFJa/txPZVULLGKpWeb4h3FKevfa82w6IwA6WSQxiSiJPcnQIOjQeSV+xvq4hKtIIZWhLru6n71uXxkTa3ZB9KMzDBGFya4v3x4/QHOpUy8n0VkQh6hIIaROGLyRGdh1iXi5G+Ke+31vs8FycsDD7xScDIHaL9lFzQAgB6tBU+jwCCB8q7XOHzLZh8AEnkgtaMCzG9Vv9ATB7MZafssCVhmkIngBLODSuvctkZHLx4nn6qkLIVk36dKxA4rRY9ayNOL1LtcIcnrN8q0lg5RVp+tAV6NvgsIgeFwrLPXCcM7eGYlZDKNkOtsXjzYnCtjIV7WHNj9Y/hgZb2TYBnUyZjgKPki+CMnW0uYnp9u6LaHAdnWR5yKF74WarDKPdquiI3PAlGnUkWUhUtmQhYEX3uROE2SIKbUv319ihDebCdQMDsLnmPyZvm8oRseZGKUq+XoP9mcv4FgB1+eXeQxWQsIUjeJ83D8qoX6PN7OHPKxuw27Pp0H+JAbT6U6NK/8g+orFUeJMsUEKhmvvFqdwLaYj3jfKZIkwrbKYQ5Xz9EkK8ORWODPkk3CNbwlASw2ohQpSuKg3NzVwJ80oDLMhg1YaLXyf/kBiQwbgEyYeWITDWm3JPUWM81TJYqIXoA8MEGmTOzlRegzANpElhnRjtArY9pwc7WbW6oHY4/s=
     keep_history: true
     on:
+      python: "3.6"
       branch: master
       repo: equinor/webviz-subsurface
   - provider: script
     script: bash deploy_docker_image.sh
     skip_cleanup: true
     on:
+      python: "3.6"
       branch: master
       repo: equinor/webviz-subsurface
   - provider: pypi
@@ -85,5 +89,6 @@ deploy:
     password:
       secure: raZvnkESL4A7R2s/IW0amym1p4rOvg3WeJ1hpnS13+97OPWnj3QgusHFmxlbU8JV1LzeotDrLJKDFtNxUSJlqi52SuM1MnaGA4zrngF4yHCgfCNHIRNMYRh53jcEra8vE0QVMv3k+0uQHV2bHnvCkFDTa3ktJo6ovCIrBH+RBRSukz2KlzNiUToNZvvUX5fI9jBCk7vDarWOc9YJqew5gsKzeOPp7pdvis5Em3T0psB6Y3Gg56w8jZ/NrpEwtJ+otxBlgk+Qrwg4c/7PqJ8Ib8JHXmnLMKHv/SXdBpJObq+2lI8bdgxM8RDKXGwi+5/p29B5tmzaS37fmJZ25Js7ZfnND3hjvEnnJMiDKjBT4qEqsIA7wSZfbBVczRjd3uf8BoqVAE/O9/kG9LJn+zcvLy3+Neb4Gi7e1bgJ20DgPupRU6D6UR7TiFtkiksF97pjfcOYRQ5iM/y+y6Uhj1BT2mONg4XMgUa6PO/JF3OanOwbcz5EfEa3fAvQu90CV71o150hvIrarQiGhKoD7B533Ehh+gSWgvN8TF6rR26UvqIntqyaVGAbAzcGGFQmF1pE0ZRtrSlk9xShH4jxD5EPRnx7G9ip+sU/cfneNFRKG/HAPIh6AOiWqnKlZx0oDaF7eWB78/wGAk4K5YFb1C7nM6fyLzCDDxrJrgvtNXovTgw=
     on:
+      python: "3.6"
       tags: true
       repo: equinor/webviz-subsurface

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![PyPI version](https://badge.fury.io/py/webviz-subsurface.svg)](https://badge.fury.io/py/webviz-subsurface)
 [![Build Status](https://travis-ci.org/equinor/webviz-subsurface.svg?branch=master)](https://travis-ci.org/equinor/webviz-subsurface)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/9fd7a8b451754841a1eb6600c08be967)](https://www.codacy.com/manual/webviz/webviz-subsurface?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=equinor/webviz-subsurface&amp;utm_campaign=Badge_Grade)
-[![Python 3.6+](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/)
+[![Python 3.6 | 3.7](https://img.shields.io/badge/python-3.6%20|%203.7-blue.svg)](https://www.python.org/)
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
 
 ## Webviz subsurface configuration 


### PR DESCRIPTION
Currently running only CI on Python `3.6`. Extend to `[3.6, 3.7, 3.8]`.

`3.8` is set to currently be allowed to fail, as one or more upstream dependencies are not yet available for Python 3.8. See [this `xtgeo` wheel request](https://github.com/equinor/xtgeo/issues/218).