### PR TITLE
More readable timeseries dropdown

### DIFF
--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -344,6 +344,7 @@ Plot options:
                                         "marginBottom": "5px",
                                         "fontSize": ".95em",
                                     },
+                                    optionHeight=55,
                                     id=self.ids("vector1"),
                                     clearable=False,
                                     multi=False,
@@ -354,6 +355,7 @@ Plot options:
                                 ),
                                 dcc.Dropdown(
                                     style={"marginBottom": "5px", "fontSize": ".95em"},
+                                    optionHeight=55,
                                     id=self.ids("vector2"),
                                     clearable=True,
                                     multi=False,
@@ -363,6 +365,7 @@ Plot options:
                                 ),
                                 dcc.Dropdown(
                                     style={"fontSize": ".95em"},
+                                    optionHeight=55,
                                     id=self.ids("vector3"),
                                     clearable=True,
                                     multi=False,


### PR DESCRIPTION
Closes #205  by increasing spacing between items.
The alternative of decreasing font size would require external css overwrite of the `Select-menu-outer` class.

![image](https://user-images.githubusercontent.com/16436291/73448958-60510580-4362-11ea-8ab0-da30f3444c14.png)
