### PR TITLE
Filter dashduo logs in tests

### DIFF
--- a/tests/integration_tests/test_aggregated_data_example.py
+++ b/tests/integration_tests/test_aggregated_data_example.py
@@ -36,6 +36,11 @@ def test_basic_example(dash_duo, tmp_path):
         "last_page",
     ]:
         dash_duo.wait_for_element(f"#{page}").click()
-        logs = dash_duo.get_logs()
+        logs = [
+            log
+            for log in dash_duo.get_logs()
+            if "TypeError: Cannot read property 'hardwareConcurrency' of undefined"
+            not in log["message"]
+        ]
         if logs != []:
             raise AssertionError(logs)

--- a/tests/integration_tests/test_raw_data_example.py
+++ b/tests/integration_tests/test_raw_data_example.py
@@ -33,6 +33,12 @@ def test_full_example(dash_duo, tmp_path):
         "last_page",
     ]:
         dash_duo.wait_for_element(f"#{page}").click()
-        logs = dash_duo.get_logs()
+        logs = [
+            log
+            for log in dash_duo.get_logs()
+            if "TypeError: Cannot read property 'hardwareConcurrency' of undefined"
+            not in log["message"]
+        ]
+
         if logs != []:
             raise AssertionError(logs)


### PR DESCRIPTION
When running Selenium tests, sometimes (!) on Travis, an error like
```
TypeError: Cannot read property 'hardwareConcurrency' of undefined
```
appears. Checking what is going on...