### PR TITLE
Remove now unnecessary Path → str conversion wrt. xtgeo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "scipy>=1.2",
         "webviz-config>=0.0.48",
         "webviz-subsurface-components>=0.0.23",
-        "xtgeo>=2.1",
+        "xtgeo>=2.8",
     ],
     tests_require=TESTS_REQUIRE,
     extras_require={"tests": TESTS_REQUIRE},

--- a/webviz_subsurface/plugins/_segy_viewer.py
+++ b/webviz_subsurface/plugins/_segy_viewer.py
@@ -320,7 +320,7 @@ The plots are linked and updates are done by clicking in the plots.
             if not state:
                 raise PreventUpdate
             state = json.loads(state)
-            cube = load_cube_data(str(get_path(state["cubepath"])))
+            cube = load_cube_data(get_path(state["cubepath"]))
             shapes = [
                 {
                     "type": "line",
@@ -370,7 +370,7 @@ The plots are linked and updates are done by clicking in the plots.
             if not state:
                 raise PreventUpdate
             state = json.loads(state)
-            cube = load_cube_data(str(get_path(state["cubepath"])))
+            cube = load_cube_data(get_path(state["cubepath"]))
             shapes = [
                 {
                     "type": "line",
@@ -416,7 +416,7 @@ The plots are linked and updates are done by clicking in the plots.
             if not state:
                 raise PreventUpdate
             state = json.loads(state)
-            cube = load_cube_data(str(get_path(state["cubepath"])))
+            cube = load_cube_data(get_path(state["cubepath"]))
             shapes = [
                 {
                     "type": "line",

--- a/webviz_subsurface/plugins/_surface_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_surface_viewer_fmu.py
@@ -371,9 +371,7 @@ and available for instant viewing.
             ]["RUNPATH"].unique()[0]
         )
 
-        return str(
-            get_path(str(runpath / "share" / "results" / "maps" / f"{data}.gri"))
-        )
+        return get_path(runpath / "share" / "results" / "maps" / f"{data}.gri")
 
     def get_ens_runpath(self, data, ensemble):
         data = make_fmu_filename(data)
@@ -381,7 +379,7 @@ and available for instant viewing.
             "RUNPATH"
         ].unique()
         return [
-            str((Path(runpath) / "share" / "results" / "maps" / f"{data}.gri"))
+            Path(runpath) / "share" / "results" / "maps" / f"{data}.gri"
             for runpath in runpaths
         ]
 
@@ -552,14 +550,14 @@ and available for instant viewing.
             for filename in filenames:
                 path = Path(runpath) / "share" / "results" / "maps" / filename
                 if path.exists():
-                    store_functions.append((get_path, [{"path": str(path)}]))
+                    store_functions.append((get_path, [{"path": path}]))
 
         # Calculate and store statistics
         for _, ens_df in self.ens_df.groupby("ENSEMBLE"):
             runpaths = list(ens_df["RUNPATH"].unique())
             for filename in filenames:
                 paths = [
-                    str(Path(runpath) / "share" / "results" / "maps" / filename)
+                    Path(runpath) / "share" / "results" / "maps" / filename
                     for runpath in runpaths
                 ]
                 for statistic in ["Mean", "StdDev", "Min", "Max"]:

--- a/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
@@ -334,7 +334,7 @@ The performance is currently slow for large grids.
             surfacepath, surface_type, gridparameter, color_values, colorscale
         ):
 
-            surface = xtgeo.RegularSurface(str(get_path(surfacepath)))
+            surface = xtgeo.RegularSurface(get_path(surfacepath))
             hillshading = True
             min_val = None
             max_val = None
@@ -345,8 +345,8 @@ The performance is currently slow for large grids.
                 min_val = color_values[0] if color_values else None
                 max_val = color_values[1] if color_values else None
                 color = ListedColormap(colorscale) if colorscale else "viridis"
-                grid = load_grid(str(get_path(self.gridfile)))
-                gridparameter = load_grid_parameter(grid, str(get_path(gridparameter)))
+                grid = load_grid(get_path(self.gridfile))
+                gridparameter = load_grid_parameter(grid, get_path(gridparameter))
                 surface.slice_grid3d(grid, gridparameter)
                 surface.values = surface.values.filled(0)
                 if min_val is not None:
@@ -377,14 +377,14 @@ The performance is currently slow for large grids.
         def _render_fence(coords, gridparameter, surfacepath, color_values, colorscale):
             if not coords:
                 raise PreventUpdate
-            grid = load_grid(str(get_path(self.gridfile)))
-            gridparameter = load_grid_parameter(grid, str(get_path(gridparameter)))
+            grid = load_grid(get_path(self.gridfile))
+            gridparameter = load_grid_parameter(grid, get_path(gridparameter))
             fence = get_fencespec(coords)
             hmin, hmax, vmin, vmax, values = grid.get_randomline(
                 fence, gridparameter, zincrement=0.5
             )
 
-            surface = xtgeo.RegularSurface(str(get_path(surfacepath)))
+            surface = xtgeo.RegularSurface(get_path(surfacepath))
             s_arr = get_surface_fence(fence, surface)
             return make_heatmap(
                 values,
@@ -413,8 +413,8 @@ The performance is currently slow for large grids.
             [State(self.ids("gridparameter"), "value")],
         )
         def _update_color_slider(_clicks, gridparameter):
-            grid = load_grid(str(get_path(self.gridfile)))
-            gridparameter = load_grid_parameter(grid, str(get_path(gridparameter)))
+            grid = load_grid(get_path(self.gridfile))
+            gridparameter = load_grid_parameter(grid, get_path(gridparameter))
 
             minv = float(f"{gridparameter.values.min():2f}")
             maxv = float(f"{gridparameter.values.max():2f}")

--- a/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
@@ -322,7 +322,7 @@ The cross section is defined by a polyline interactively edited in the map view.
             surfacepath, surface_type, cubepath, color_values, colorscale
         ):
 
-            surface = xtgeo.RegularSurface(str(get_path(surfacepath)))
+            surface = xtgeo.RegularSurface(get_path(surfacepath))
             hillshading = True
             min_val = None
             max_val = None
@@ -366,7 +366,7 @@ The cross section is defined by a polyline interactively edited in the map view.
             fence = get_fencespec(coords)
             hmin, hmax, vmin, vmax, values = cube.get_randomline(fence)
 
-            surface = xtgeo.RegularSurface(str(get_path(surfacepath)))
+            surface = xtgeo.RegularSurface(get_path(surfacepath))
             s_arr = get_surface_fence(fence, surface)
             return make_heatmap(
                 values,

--- a/webviz_subsurface/plugins/_well_cross_section.py
+++ b/webviz_subsurface/plugins/_well_cross_section.py
@@ -223,7 +223,7 @@ class WellCrossSection(WebvizPluginABC):
         )
         def _render_section(well, cube, options, sampling, nextend):
             """Update cross section"""
-            well = load_well(str(get_path(well)))
+            well = load_well(get_path(well))
             xsect = XSectionFigure(
                 well=well,
                 zmin=self.zmin,
@@ -232,7 +232,7 @@ class WellCrossSection(WebvizPluginABC):
                 sampling=int(sampling),
             )
 
-            surfaces = [load_surface(str(get_path(surf))) for surf in self.surfacefiles]
+            surfaces = [load_surface(get_path(surf)) for surf in self.surfacefiles]
 
             xsect.plot_surfaces(
                 surfaces=surfaces,
@@ -241,7 +241,7 @@ class WellCrossSection(WebvizPluginABC):
             )
 
             if "show_seismic" in options:
-                cube = load_cube_data(str(get_path(cube)))
+                cube = load_cube_data(get_path(cube))
                 xsect.plot_cube(cube)
 
             xsect.plot_well(
@@ -279,8 +279,8 @@ class WellCrossSection(WebvizPluginABC):
             """Update map"""
             wellname = Path(wellfile).stem
             wellfile = get_path(wellfile)
-            surface = load_surface(str(get_path(self.surfacefiles[0])))
-            well = load_well(str(wellfile))
+            surface = load_surface(get_path(self.surfacefiles[0]))
+            well = load_well(wellfile)
             s_layer = make_surface_layer(
                 surface, name=self.surfacenames[0], hillshading=True,
             )

--- a/webviz_subsurface/plugins/_well_cross_section_fmu.py
+++ b/webviz_subsurface/plugins/_well_cross_section_fmu.py
@@ -1,8 +1,9 @@
+import io
+import os
+import json
 from uuid import uuid4
 from pathlib import Path
 from typing import List
-import io
-import json
 
 import numpy as np
 import xtgeo
@@ -422,7 +423,7 @@ per realization.
                 self.surfacefiles[self.surfacenames.index(name)]
                 for name in surfacenames
             ]
-            well = load_well(str(get_path(well)))
+            well = load_well(get_path(well))
             xsect = XSectionFigure(
                 well=well,
                 zmin=self.zmin,
@@ -444,7 +445,7 @@ per realization.
                 )
 
             if "show_seismic" in options:
-                cube = load_cube_data(str(get_path(cube)))
+                cube = load_cube_data(get_path(cube))
                 xsect.plot_cube(cube)
 
             xsect.plot_well(
@@ -550,10 +551,9 @@ per realization.
 def calculate_surface_statistics(
     realdf, ensemble, surfacefile, surfacefolder
 ) -> io.BytesIO:
-    real_paths = list(realdf[realdf["ENSEMBLE"] == ensemble]["RUNPATH"])
     fns = [
-        str(Path(Path(real_path) / Path(surfacefolder) / Path(surfacefile)))
-        for real_path in real_paths
+        os.path.join(real_path, surfacefolder, surfacefile)
+        for real_path in list(realdf[realdf["ENSEMBLE"] == ensemble]["RUNPATH"])
     ]
     surfaces = get_surfaces(fns)
     return io.BytesIO(


### PR DESCRIPTION
Closes #281.

- [X] Change all file path inputs to `xtgeo` to `pathlib.Path` (i.e. remove explicit conversion to `str`).
- [x] Waiting for https://github.com/equinor/xtgeo/issues/332.
- [x] Waiting on new `xtgeo` release.