### PR TITLE
Delete raw testdata when finished aggregating

### DIFF
--- a/.github/workflows/webviz-subsurface.yml
+++ b/.github/workflows/webviz-subsurface.yml
@@ -93,6 +93,7 @@ jobs:
       run: |
         pip install webviz-config-equinor
         webviz build ./webviz-subsurface-testdata/webviz_examples/full_demo.yaml --portable ./example_subsurface_app --theme equinor
+        rm -rf ./webviz-subsurface-testdata
         pushd example_subsurface_app
         # Related to https://github.com/equinor/webviz-config/issues/150:
         echo "RUN pip install --user git+https://github.com/equinor/webviz-subsurface" >> Dockerfile


### PR DESCRIPTION
When `webviz` has made a portable application, we can delete the raw data source before bulding the Docker image (in order to decrease the chance of running out of space on the GitHub CI runner).