### PR TITLE
Use wcc.Select instead of dcc.Dropdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pillow>=6.1",
         "pyscal>=0.4.1",
         "scipy>=1.2",
-        "webviz-config>=0.0.48",
+        "webviz-config>=0.0.55",
         "webviz-subsurface-components>=0.0.23",
         "xtgeo>=2.8",
     ],

--- a/webviz_subsurface/plugins/_inplace_volumes.py
+++ b/webviz_subsurface/plugins/_inplace_volumes.py
@@ -230,13 +230,10 @@ but the following responses are given more descriptive names automatically:
         dropdowns = []
         for selector in self.selectors:
             elements = list(self.volumes[selector].unique())
-            multi = True
-
             if selector in ["ENSEMBLE", "SOURCE"]:
                 value = elements[0]
             else:
                 value = elements
-
             dropdowns.append(
                 html.Div(
                     children=[
@@ -244,14 +241,14 @@ but the following responses are given more descriptive names automatically:
                             open=True,
                             children=[
                                 html.Summary(selector.lower().capitalize()),
-                                dcc.Dropdown(
+                                wcc.Select(
                                     id=self.selectors_id[selector],
                                     options=[
                                         {"label": i, "value": i} for i in elements
                                     ],
                                     value=value,
-                                    multi=multi,
-                                    clearable=False,
+                                    multi=True,
+                                    size=min(20, len(elements)),
                                 ),
                             ],
                         )
@@ -343,23 +340,23 @@ but the following responses are given more descriptive names automatically:
                                     style={"height": 400},
                                     children=wcc.Graph(id=self.ids("graph")),
                                 ),
+                                html.Div(
+                                    children=[
+                                        html.Div(
+                                            id=self.ids("table_title"),
+                                            style={"textAlign": "center"},
+                                            children="",
+                                        ),
+                                        DataTable(
+                                            id=self.ids("table"),
+                                            sort_action="native",
+                                            filter_action="native",
+                                            page_action="native",
+                                            page_size=10,
+                                        ),
+                                    ],
+                                ),
                             ],
-                        ),
-                    ],
-                ),
-                html.Div(
-                    children=[
-                        html.Div(
-                            id=self.ids("table_title"),
-                            style={"textAlign": "center"},
-                            children="",
-                        ),
-                        DataTable(
-                            id=self.ids("table"),
-                            sort_action="native",
-                            filter_action="native",
-                            page_action="native",
-                            page_size=10,
                         ),
                     ],
                 ),
@@ -430,6 +427,7 @@ but the following responses are given more descriptive names automatically:
             [
                 Output(self.selectors_id["ENSEMBLE"], "multi"),
                 Output(self.selectors_id["ENSEMBLE"], "value"),
+                Output(self.selectors_id["ENSEMBLE"], "size"),
             ],
             [Input(self.ids("group"), "value")],
         )
@@ -437,10 +435,11 @@ but the following responses are given more descriptive names automatically:
             """If iteration is selected as group by set the iteration
             selector to allow multiple selections, else use single selection
             """
+            selectors = list(self.volumes["ENSEMBLE"].unique())
             if group_by == "ENSEMBLE":
-                return True, list(self.volumes["ENSEMBLE"].unique())
+                return True, selectors, len(selectors)
 
-            return False, list(self.volumes["ENSEMBLE"].unique())[0]
+            return False, selectors[0], 1
 
         if "SOURCE" in self.selectors:
 
@@ -448,6 +447,7 @@ but the following responses are given more descriptive names automatically:
                 [
                     Output(self.selectors_id["SOURCE"], "multi"),
                     Output(self.selectors_id["SOURCE"], "value"),
+                    Output(self.selectors_id["SOURCE"], "size"),
                 ],
                 [Input(self.ids("group"), "value")],
             )
@@ -455,11 +455,11 @@ but the following responses are given more descriptive names automatically:
                 """If iteration is selected as group by set the iteration
                 selector to allow multiple selections, else use single selection
                 """
-
+                selectors = list(self.volumes["SOURCE"].unique())
                 if group_by == "SOURCE" and "SOURCE" in self.selectors:
-                    return True, list(self.volumes["SOURCE"].unique())
+                    return True, selectors, len(selectors)
 
-                return False, list(self.volumes["SOURCE"].unique())[0]
+                return False, selectors[0], 1
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -186,7 +186,6 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
 
     def selector(self, label, id_name, column):
         return html.Div(
-            style={"paddingBottom": "30px"},
             children=html.Label(
                 children=[
                     html.Span(f"{label}:", style={"font-weight": "bold"}),
@@ -340,7 +339,7 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
                         open=True,
                         children=[
                             html.Summary(selector.lower().capitalize()),
-                            dcc.Dropdown(
+                            wcc.Select(
                                 id=self.selectors_id[selector],
                                 options=[
                                     {"label": i, "value": i}
@@ -348,7 +347,7 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
                                 ],
                                 value=list(self.volumes[selector].unique()),
                                 multi=True,
-                                clearable=False,
+                                size=min(20, len(self.volumes[selector].unique())),
                             ),
                         ],
                     )
@@ -391,28 +390,35 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
                                             ],
                                         ),
                                         html.Div(
-                                            style={"flex": 3, "height": "600px"},
-                                            id=self.ids("graph-wrapper"),
+                                            style={"flex": 3},
+                                            children=[
+                                                html.Div(
+                                                    style={"height": "600px"},
+                                                    id=self.ids("graph-wrapper"),
+                                                ),
+                                                html.Div(
+                                                    children=[
+                                                        html.Div(
+                                                            id=self.ids("volume_title"),
+                                                            style={
+                                                                "textAlign": "center"
+                                                            },
+                                                            children="",
+                                                        ),
+                                                        DataTable(
+                                                            id=self.ids("table"),
+                                                            sort_action="native",
+                                                            filter_action="native",
+                                                            page_action="native",
+                                                            page_size=10,
+                                                        ),
+                                                    ],
+                                                ),
+                                            ],
                                         ),
                                     ],
-                                ),
-                                html.Div(
-                                    children=[
-                                        html.Div(
-                                            id=self.ids("volume_title"),
-                                            style={"textAlign": "center"},
-                                            children="",
-                                        ),
-                                        DataTable(
-                                            id=self.ids("table"),
-                                            sort_action="native",
-                                            filter_action="native",
-                                            page_action="native",
-                                            page_size=10,
-                                        ),
-                                    ],
-                                ),
-                            ],
+                                )
+                            ]
                         ),
                         html.Div(
                             id=self.ids("tornado-wrapper"),
@@ -463,7 +469,7 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
 
             # Make Plotly figure
             layout = {}
-            layout.update({"margin": {"l": 100, "b": 100}})
+            layout.update({"height": 600, "margin": {"l": 100, "b": 100}})
             if plot_type == "Per realization":
                 # One bar per realization
                 layout.update(

--- a/webviz_subsurface/plugins/_parameter_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_correlation.py
@@ -76,17 +76,6 @@ and scatter plot for any given pair of parameters.
                 style={"padding": "5px"},
                 children=[
                     html.Label(
-                        "Set ensemble in all plots:", style={"font-weight": "bold"},
-                    ),
-                    Widgets.dropdown_from_dict(
-                        self.ids("ensemble-all"), self.ensembles
-                    ),
-                ],
-            ),
-            html.Div(
-                style={"padding": "5px"},
-                children=[
-                    html.Label(
                         "Parameter horizontal axis:", style={"font-weight": "bold"},
                     ),
                     dcc.Dropdown(
@@ -132,11 +121,35 @@ and scatter plot for any given pair of parameters.
 
     @property
     def layout(self):
-        return html.Div(
+        return wcc.FlexBox(
             children=[
-                wcc.FlexBox(self.control_div),
-                wcc.FlexBox(
-                    children=[self.matrix_plot, wcc.Graph(id=self.ids("scatter"))]
+                html.Div(
+                    style={"flex": 1},
+                    children=[
+                        self.matrix_plot,
+                        html.Div(
+                            style={"padding": "5px"},
+                            children=[
+                                html.Label(
+                                    "Set ensemble in all plots:",
+                                    style={"font-weight": "bold"},
+                                ),
+                                Widgets.dropdown_from_dict(
+                                    self.ids("ensemble-all"), self.ensembles
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                html.Div(
+                    style={"flex": 1},
+                    children=[
+                        html.Div(
+                            style={"height": "400px"},
+                            children=[wcc.Graph(id=self.ids("scatter"))],
+                        )
+                    ]
+                    + self.control_div,
                 ),
             ]
         )
@@ -293,7 +306,7 @@ def render_scatter(ens1, x_col, ens2, y_col, color, density, theme):
     layout = theme_layout(
         theme,
         {
-            "margin": {"t": 20, "b": 50, "l": 200, "r": 200},
+            "margin": {"t": 20, "b": 100, "l": 100, "r": 10},
             "bargap": 0.05,
             "xaxis": {
                 "title": x_col,

--- a/webviz_subsurface/plugins/_parameter_parallel_coordinates.py
+++ b/webviz_subsurface/plugins/_parameter_parallel_coordinates.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from dash.dependencies import Input, Output
 import dash_html_components as html
-import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC
 from webviz_config.common_cache import CACHE
@@ -80,14 +79,14 @@ If undefined: all parameters visualized.
                 html.Div(
                     [
                         html.Span("Selected ensembles:", style={"font-weight": "bold"}),
-                        dcc.Dropdown(
+                        wcc.Select(
                             id=self.uuid("ensembles"),
                             options=[
                                 {"label": ens, "value": ens} for ens in self.ensembles
                             ],
-                            clearable=False,
                             multi=True,
                             value=self.ensembles,
+                            size=len(self.ensembles),
                         ),
                     ]
                 ),
@@ -96,15 +95,16 @@ If undefined: all parameters visualized.
                         html.Span(
                             "Selected parameters:", style={"font-weight": "bold"}
                         ),
-                        dcc.Dropdown(
+                        wcc.Select(
                             id=self.uuid("parameters"),
+                            style={"overflowX": "auto", "fontSize": "0.97rem"},
                             options=[
                                 {"label": param, "value": param}
                                 for param in self.parameters
                             ],
-                            clearable=False,
                             multi=True,
                             value=self.visual_parameters,
+                            size=min(50, len(self.visual_parameters)),
                         ),
                     ]
                 ),
@@ -114,12 +114,13 @@ If undefined: all parameters visualized.
     @property
     def layout(self):
         """Main layout"""
-        return html.Div(
+        return wcc.FlexBox(
             id=self.uuid("layout"),
-            style=self.set_grid_layout("1fr 4fr"),
             children=[
-                self.control_layout,
-                html.Div(wcc.Graph(id=self.uuid("parcoords"),),),
+                html.Div(style={"flex": 1}, children=self.control_layout),
+                html.Div(
+                    style={"flex": 3}, children=wcc.Graph(id=self.uuid("parcoords"),),
+                ),
             ],
         )
 

--- a/webviz_subsurface/plugins/_running_time_analysis_fmu.py
+++ b/webviz_subsurface/plugins/_running_time_analysis_fmu.py
@@ -228,15 +228,16 @@ Default: all parameters.
                         html.Span(
                             "Selected parameters:", style={"font-weight": "bold"},
                         ),
-                        dcc.Dropdown(
+                        wcc.Select(
                             id=self.uuid("parameters"),
+                            style={"overflowX": "auto", "fontSize": "0.97rem"},
                             options=[
                                 {"label": param, "value": param}
                                 for param in self.parameters
                             ],
-                            clearable=False,
                             multi=True,
                             value=self.visual_parameters,
+                            size=min(50, len(self.visual_parameters)),
                         ),
                     ],
                 ),
@@ -267,7 +268,7 @@ Default: all parameters.
             style={"padding-top": 10,},
             children=[
                 html.Div(style={"flex": "1"}, children=self.control_div),
-                html.Div(style={"flex": "4"}, children=self.plot_fig),
+                html.Div(style={"flex": "3"}, children=self.plot_fig),
             ],
         )
 


### PR DESCRIPTION
- For selectors with multiple options it is more user friendly to use wcc.Select instead of dcc.Dropdown in some cases.
- Fix layout after flexbox

Closes #320 

