### PR TITLE
Support Dash 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         ]
     },
     install_requires=[
-        "dash<=1.10",  # https://github.com/equinor/webviz-subsurface/issues/317
         "fmu-ensemble>=1.2.2",
         "matplotlib>=3.0",
         "pandas>=0.24",

--- a/tests/integration_tests/test_aggregated_data_example.py
+++ b/tests/integration_tests/test_aggregated_data_example.py
@@ -43,4 +43,4 @@ def test_basic_example(dash_duo, tmp_path):
             not in log["message"]
         ]
         if logs != []:
-            raise AssertionError(logs)
+            raise AssertionError(page, logs)

--- a/tests/integration_tests/test_raw_data_example.py
+++ b/tests/integration_tests/test_raw_data_example.py
@@ -41,4 +41,4 @@ def test_full_example(dash_duo, tmp_path):
         ]
 
         if logs != []:
-            raise AssertionError(logs)
+            raise AssertionError(page, logs)

--- a/tests/integration_tests/test_surface_selector.py
+++ b/tests/integration_tests/test_surface_selector.py
@@ -41,7 +41,7 @@ def test_surface_selector(dash_duo):
 
     app.layout = html.Div(children=[s.layout, html.Pre(id="pre", children="ok")])
 
-    @app.callback(Output("pre", "children"), [Input(s.storage_id, "children")])
+    @app.callback(Output("pre", "children"), [Input(s.storage_id, "data")])
     def _test(data):
         return json.dumps(json.loads(data))
 

--- a/webviz_subsurface/_private_plugins/surface_selector.py
+++ b/webviz_subsurface/_private_plugins/surface_selector.py
@@ -201,7 +201,7 @@ another_property:
         )
         def _update_attr(_n_prev, _n_next, current_value):
             ctx = dash.callback_context.triggered
-            if not ctx or not current_value:
+            if ctx is None or not current_value:
                 raise PreventUpdate
             if not ctx[0]["value"]:
                 return current_value
@@ -226,7 +226,7 @@ another_property:
         )
         def _update_name(attr, _n_prev, _n_next, current_value):
             ctx = dash.callback_context.triggered
-            if not ctx:
+            if ctx is None:
                 raise PreventUpdate
             names = self._names_in_attr(attr)
             if not names:
@@ -258,7 +258,7 @@ another_property:
         def _update_date(attr, _n_prev, _n_next, current_value):
             ctx = dash.callback_context.triggered
 
-            if not ctx:
+            if ctx is None:
                 raise PreventUpdate
             dates = self._dates_in_attr(attr)
 
@@ -276,7 +276,7 @@ another_property:
             return options, value, {}
 
         @app.callback(
-            Output(self.storage_id, "children"),
+            Output(self.storage_id, "data"),
             [
                 Input(self.attr_id, "value"),
                 Input(self.name_id, "value"),

--- a/webviz_subsurface/_private_plugins/tornado_plot.py
+++ b/webviz_subsurface/_private_plugins/tornado_plot.py
@@ -126,7 +126,7 @@ that reads from  `tornadoplot.click_id` if `allow_click` has been specified at i
         return html.Div(
             [
                 html.Div(
-                    style={"marginLeft": "10px"},
+                    style={"marginLeft": "20%"},
                     children=[
                         html.Label(
                             "Tornado Plot",
@@ -208,7 +208,7 @@ that reads from  `tornadoplot.click_id` if `allow_click` has been specified at i
                 Input(self.ids("reference"), "value"),
                 Input(self.ids("scale"), "value"),
                 Input(self.ids("cut-by-ref"), "value"),
-                Input(self.ids("storage"), "children"),
+                Input(self.ids("storage"), "data"),
             ],
         )
         def _calc_tornado(reference, scale, cutbyref, data):
@@ -240,14 +240,14 @@ that reads from  `tornadoplot.click_id` if `allow_click` has been specified at i
         if self.allow_click:
 
             @app.callback(
-                Output(self.ids("click-store"), "children"),
+                Output(self.ids("click-store"), "data"),
                 [
                     Input(self.ids("tornado-graph"), "clickData"),
                     Input(self.ids("reset"), "n_clicks"),
                 ],
             )
             def _save_click_data(data, nclicks):
-                if not dash.callback_context.triggered:
+                if dash.callback_context.triggered is None:
                     raise PreventUpdate
 
                 ctx = dash.callback_context.triggered[0]["prop_id"].split(".")[0]

--- a/webviz_subsurface/_private_plugins/tornado_plot.py
+++ b/webviz_subsurface/_private_plugins/tornado_plot.py
@@ -126,7 +126,7 @@ that reads from  `tornadoplot.click_id` if `allow_click` has been specified at i
         return html.Div(
             [
                 html.Div(
-                    style={"marginLeft": "20%"},
+                    style={"marginLeft": "10px"},
                     children=[
                         html.Label(
                             "Tornado Plot",

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -404,7 +404,7 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
         @app.callback(
             [
                 Output(self.ids("graph-wrapper"), "children"),
-                Output(self.tornadoplot.storage_id, "children"),
+                Output(self.tornadoplot.storage_id, "data"),
                 Output(self.ids("table"), "data"),
                 Output(self.ids("table"), "columns"),
             ],
@@ -517,7 +517,7 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
 
         @app.callback(
             Output(self.ids("graph"), "figure"),
-            [Input(self.tornadoplot.click_id, "children")],
+            [Input(self.tornadoplot.click_id, "data")],
             [State(self.ids("plot-type"), "value"), State(self.ids("graph"), "figure")],
         )
         def _color_chart(hoverdata, plot_type, figure):

--- a/webviz_subsurface/plugins/_parameter_distribution.py
+++ b/webviz_subsurface/plugins/_parameter_distribution.py
@@ -159,13 +159,15 @@ or as an ensemble name defined in `shared_settings`.
         def _set_parameter_from_btn(_prev_click, _next_click, column):
 
             ctx = dash.callback_context.triggered
-            if not ctx:
+            if ctx is None:
                 raise PreventUpdate
             callback = ctx[0]["prop_id"]
             if callback == f"{self.ids('prev-btn')}.n_clicks":
                 column = prev_value(column, self.parameter_columns)
             elif callback == f"{self.ids('next-btn')}.n_clicks":
                 column = next_value(column, self.parameter_columns)
+            else:
+                column = self.parameter_columns[0]
             return column
 
         @app.callback(

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -314,7 +314,7 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
                 # Output(self.ids("date-store"), "children"),
                 Output(self.ids("table"), "data"),
                 Output(self.ids("table"), "columns"),
-                Output(self.tornadoplot.storage_id, "children"),
+                Output(self.tornadoplot.storage_id, "data"),
             ],
             [
                 Input(self.ids("ensemble"), "value"),
@@ -350,7 +350,7 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
         @app.callback(
             Output(self.ids("graph"), "figure"),
             [
-                Input(self.tornadoplot.click_id, "children"),
+                Input(self.tornadoplot.click_id, "data"),
                 # Input(self.ids("date-store"), "children"),
                 Input(self.ids("ensemble"), "value"),
                 Input(self.ids("vector"), "value"),
@@ -360,12 +360,12 @@ https://github.com/equinor/webviz-subsurface-testdata/blob/master/aggregated_dat
         )
         def _render_tornado(tornado_click, ensemble, vector, date_click, figure):
             """Update graph with line coloring, vertical line and title"""
-            if not dash.callback_context.triggered:
+            if dash.callback_context.triggered is None:
                 raise PreventUpdate
             ctx = dash.callback_context.triggered[0]["prop_id"].split(".")[0]
 
-            # Redraw figure if ensemble/vector hanges
-            if ctx == self.ids("ensemble") or ctx == self.ids("vector"):
+            # Draw initial figure and redraw if ensemble/vector changes
+            if ctx in ["", self.ids("ensemble"), self.ids("vector")]:
                 layout = {}
                 layout.update(self.plotly_theme["layout"])
                 data = filter_ensemble(self.data, ensemble, vector)

--- a/webviz_subsurface/plugins/_running_time_analysis_fmu.py
+++ b/webviz_subsurface/plugins/_running_time_analysis_fmu.py
@@ -337,8 +337,6 @@ Default: all parameters.
             [
                 Output(self.uuid("matrix_color"), "style"),
                 Output(self.uuid("parcoords_color"), "style"),
-                Output(self.uuid("matrix_heatmap"), "style"),
-                Output(self.uuid("parcoords"), "style"),
                 Output(self.uuid("parameter_dropdown"), "style"),
                 Output(self.uuid("filter_short_checkbox"), "style"),
             ],
@@ -350,15 +348,11 @@ Default: all parameters.
                 style = (
                     {"display": "block"},
                     {"display": "none"},
-                    {"display": "block", "overflowX": "auto"},
-                    {"display": "none"},
                     {"display": "none"},
                     {"display": "block"},
                 )
             else:
                 style = (
-                    {"display": "none"},
-                    {"display": "block"},
                     {"display": "none"},
                     {"display": "block"},
                     {"display": "block"},

--- a/webviz_subsurface/plugins/_surface_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_surface_viewer_fmu.py
@@ -392,10 +392,10 @@ and available for instant viewing.
                 Output(self.uuid("map3-label"), "children"),
             ],
             [
-                Input(self.selector.storage_id, "children"),
+                Input(self.selector.storage_id, "data"),
                 Input(self.uuid("ensemble"), "value"),
                 Input(self.uuid("realization"), "value"),
-                Input(self.selector2.storage_id, "children"),
+                Input(self.selector2.storage_id, "data"),
                 Input(self.uuid("ensemble2"), "value"),
                 Input(self.uuid("realization2"), "value"),
                 Input(self.uuid("calculation"), "value"),

--- a/webviz_subsurface/plugins/_well_cross_section_fmu.py
+++ b/webviz_subsurface/plugins/_well_cross_section_fmu.py
@@ -226,7 +226,9 @@ per realization.
                     ]
                 ),
             )
-        return html.Div(id=self.ids("cube"))
+        return html.Div(
+            style={"visibility": "hidden"}, children=dcc.Dropdown(id=self.ids("cube"))
+        )
 
     @property
     def marginal_log_layout(self):
@@ -247,7 +249,10 @@ per realization.
                     ]
                 ),
             )
-        return html.Div(id=self.ids("marginal-log"))
+        return html.Div(
+            style={"visibility": "hidden"},
+            children=dcc.Dropdown(id=self.ids("marginal-log")),
+        )
 
     @property
     def intersection_option(self):


### PR DESCRIPTION
Closes #317 

Fixes related to Dash 1.11.
- We used some wrong component props in callbacks that are no longer allowed in Dash 1.11. E.g. `dcc.Store(children)` should be `dcc.Store(data)`.
- There is a breaking change in Dash 1.11 when using `callback_context.triggered`. It is no longer possible to identify which input parameters triggers the first time a callback is executed. A check for this has been added to the necessary callbacks.