### PR TITLE
Facilitating deployment of "review images"

### DIFF
--- a/.github/workflows/webviz-subsurface.yml
+++ b/.github/workflows/webviz-subsurface.yml
@@ -2,8 +2,6 @@ name: webviz-subsurface
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -15,8 +13,9 @@ on:
     - cron:  '0 0 * * *'
 
 jobs:
-
   webviz-subsurface:
+    # Run on all events defined above, except pushes which are neither to master nor with a substring [deploy test] in commit message
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || contains(github.event.head_commit.message, '[deploy test]')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -106,6 +105,14 @@ jobs:
       run: |
         echo ${{ secrets.dockerhub_webviz_token }} | docker login --username webviz --password-stdin
         docker push webviz/example_subsurface_image:equinor-theme
+
+    - name: 🐳 Update review/test Docker example image
+      if: github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[deploy test]') && matrix.python-version == '3.6' && matrix.pandas-version == '1.*'
+      run: |
+        docker tag webviz/example_subsurface_image:equinor-theme ${{ secrets.review_docker_registry_url }}/${{ secrets.review_container_name }}
+
+        echo ${{ secrets.review_docker_registry_token }} | docker login ${{ secrets.review_docker_registry_url }} --username ${{ secrets.review_docker_registry_username }} --password-stdin
+        docker push ${{ secrets.review_docker_registry_url }}/${{ secrets.review_container_name }}
 
     - name: 🚢 Build and deploy Python package
       if: github.event_name == 'release' && matrix.python-version == '3.6' && matrix.pandas-version == '1.*'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ plugins in [webviz-config](https://github.com/equinor/webviz-config).
 
 ### Installation
 
-
 The easiest way of installing this package is to run
 ```bash
 pip install webviz-subsurface
@@ -57,6 +56,22 @@ black --check webviz_subsurface tests # Check code style
 pylint webviz_subsurface tests # Check code quality
 bandit -r -c ./bandit.yml webviz_subsurface tests  # Check Python security best practice
 ```
+
+### Review of contributions
+
+When doing review of contributions, it is usually useful to also see the resulting application live, and
+not only the code changes. In order to facilitate this, this repository is using GitHub actions.
+
+When on a feature branch, and a commit message including the substring `[deploy test]` arrives, the GitHub 
+action workflow will try to build and deploy a test Docker image for you (which you then can link to a web app with
+e.g. automatic reload on new images). All you need to do in your own fork is to add
+GitHub secrets with the following names:
+  - `review_docker_registry_url`: The registry to push to (e.g. `myregistry.azurecr.io`)
+  - `review_docker_registry_username`: Registry login username.
+  - `review_docker_registry_token`: Registry login token (or password).
+  - `review_container_name`: What you want to call the container pushed to the registry.
+
+You are encouraged to rebase and squash/fixup unnecessary commits before pull request is merged to `master`.
 
 ### Disclaimer
 


### PR DESCRIPTION
A review of `webviz-subsruface` PRs currently typically consists of two steps:
- Review the actual code changes
- Fetch the PR locally, install the changes, and run an example application to see front-end changes.

The second step is unnecessary time-consuming. In this pull request, we try to facilitate automatic deployment of an example docker image, whenever the PR gets a commit with commit message including the substring `[deploy test`].