### PR TITLE
Improvements of ReservoirSimulationTimeSeriesOneByOne

### DIFF
--- a/webviz_subsurface/_abbreviations/number_formatting.py
+++ b/webviz_subsurface/_abbreviations/number_formatting.py
@@ -59,7 +59,7 @@ def si_prefixed(
             else f"{number_base:{number_format}}{si_prefix}{unit}"
         )
 
-    if locked_si_prefix:
+    if locked_si_prefix is not None:
         # Make sure locked_si_prefix is a string to avoid == issues
         locked_si_prefix = str(locked_si_prefix)
 


### PR DESCRIPTION
Resolves #327 and resolves #339

Done in the same PR as it felt a bit more efficient.
Also some necessary modifications to `TornadoPlot` and a minor change to `number_formatting.py` (a bug spotted on the way in the case that `locked_si_prefix==0`, could be a separate PR).

- History traces added. Added with black color, but slightly thicker than default. Not ideal, but didn't want to make something that was very specific for a `theme`. Open for suggestions there.
- Legends added to time series
- Time series coloring is now correctly updated both on click and change of vector. To make it possible:
  - In `TornadoPlot`, a storage is now created for realizations for each sensitivity in the whole `TornadoPlot`, and not just the sensitivities that are clicked on. The click storage in `_save_click_data` could therefore be reduced to only the clicked `sens_name`, but I didn't remove `real_low` and `real_high` for now, as it would require changes to other plugins that use `TornadoPlot`. Might also be that someone uses `TornadoPlot` for other plugins than those in `webviz-subsurface`
  - The callback inputs to trigger the time series graph are changed to make sure that the data from the `TornadoPlot` is stored before updating the graph. Updates now on update of or click on the `TornadoPlot`. Clicks on the time series graph might therefore feel slightly less responsive.
- Additional information on hoover of time series, e.g. realization number, value and legend.