### PR TITLE
Added average rates and cumulatives over specific time interval to ReservoirSimulationTimeSeries

### DIFF
--- a/tests/unit_tests/data_input/test_calc_from_cumulatives.py
+++ b/tests/unit_tests/data_input/test_calc_from_cumulatives.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+import pytest
+import pandas as pd
+import webviz_subsurface._datainput.from_timeseries_cumulatives as from_cum
+
+DATA_DF = pd.read_csv(
+    Path().absolute()
+    / "webviz-subsurface-testdata"
+    / "reek_history_match"
+    / "share"
+    / "results"
+    / "tables"
+    / "unsmry--monthly.csv"
+)
+DATA_DF.DATE = DATA_DF.DATE.astype(str)
+
+
+def test_calc_from_cumulatives():
+    # Includes monthly data, 10 reals x 4 ensembles, 3 years and 1 month (2000-01-01 to 2003-02-01)
+
+    ## Test single column key, FOPT as average rate avg_fopr, monthly
+    calc_df = from_cum.calc_from_cumulatives(
+        data=DATA_DF,
+        column_keys="FOPT",
+        time_index="monthly",
+        time_index_input="monthly",
+        as_rate=True,
+    )
+
+    # Test real 0, iter-2
+    real_data = DATA_DF[(DATA_DF["REAL"] == 0) & (DATA_DF["ENSEMBLE"] == "iter-2")]
+    real_calc = calc_df[(calc_df["REAL"] == 0) & (calc_df["ENSEMBLE"] == "iter-2")]
+
+    assert real_calc[real_calc.DATE == "2000-01-01"]["AVG_FOPR"].values == (
+        (
+            real_data[real_data.DATE == "2000-02-01"]["FOPT"].values
+            - real_data[real_data.DATE == "2000-01-01"]["FOPT"].values
+        )
+        / 31
+    )
+
+    assert real_calc[real_calc.DATE == "2002-05-01"]["AVG_FOPR"].values == (
+        (
+            real_data[real_data.DATE == "2002-06-01"]["FOPT"].values
+            - real_data[real_data.DATE == "2002-05-01"]["FOPT"].values
+        )
+        / 31
+    )
+
+    ## Test multiple column keys, WOPT:OP_1 as average rate avg_fopr, monthly
+    calc_df = from_cum.calc_from_cumulatives(
+        data=DATA_DF,
+        column_keys=["WOPT:OP_1", "GOPT:OP"],
+        time_index="yearly",
+        time_index_input="monthly",
+        as_rate=True,
+    )
+    # Test real 4, iter-0
+    real_data = DATA_DF[(DATA_DF["REAL"] == 4) & (DATA_DF["ENSEMBLE"] == "iter-0")]
+    real_calc = calc_df[(calc_df["REAL"] == 4) & (calc_df["ENSEMBLE"] == "iter-0")]
+
+    assert real_calc[real_calc.DATE == "2000-01-01"]["AVG_WOPR:OP_1"].values == (
+        (
+            real_data[real_data.DATE == "2001-01-01"]["WOPT:OP_1"].values
+            - real_data[real_data.DATE == "2000-01-01"]["WOPT:OP_1"].values
+        )
+        / 366
+    )
+
+    assert real_calc[real_calc.DATE == "2002-01-01"]["AVG_GOPR:OP"].values == (
+        (
+            real_data[real_data.DATE == "2003-01-01"]["GOPT:OP"].values
+            - real_data[real_data.DATE == "2002-01-01"]["GOPT:OP"].values
+        )
+        / 365
+    )
+
+    assert real_calc[real_calc.DATE == "2002-01-01"]["AVG_WOPR:OP_1"].values == (
+        (
+            real_data[real_data.DATE == "2003-01-01"]["WOPT:OP_1"].values
+            - real_data[real_data.DATE == "2002-01-01"]["WOPT:OP_1"].values
+        )
+        / 365
+    )
+
+    assert real_calc[real_calc.DATE == "2001-01-01"]["AVG_GOPR:OP"].values == (
+        (
+            real_data[real_data.DATE == "2002-01-01"]["GOPT:OP"].values
+            - real_data[real_data.DATE == "2001-01-01"]["GOPT:OP"].values
+        )
+        / 365
+    )
+
+    ## Test multiple column keys, WOPR_OP as average rate avg_fopr, monthly
+    calc_df = from_cum.calc_from_cumulatives(
+        data=DATA_DF,
+        column_keys=["WGPT:OP_2", "GWPT:OP"],
+        time_index="monthly",
+        time_index_input="monthly",
+        as_rate=False,
+    )
+    # Test real 9, iter-0
+    real_data = DATA_DF[(DATA_DF["REAL"] == 9) & (DATA_DF["ENSEMBLE"] == "iter-0")]
+    real_calc = calc_df[(calc_df["REAL"] == 9) & (calc_df["ENSEMBLE"] == "iter-0")]
+
+    assert real_calc[real_calc.DATE == "2000-01-01"]["INTVL_WGPT:OP_2"].values == (
+        real_data[real_data.DATE == "2000-01-01"]["WGPT:OP_2"].values
+        - real_data[real_data.DATE == "2000-02-01"]["WGPT:OP_2"].values
+    )
+
+    assert real_calc[real_calc.DATE == "2002-05-01"]["INTVL_GWPT:OP"].values == (
+        real_data[real_data.DATE == "2002-06-01"]["GWPT:OP"].values
+        - real_data[real_data.DATE == "2002-05-01"]["GWPT:OP"].values
+    )
+
+    assert real_calc[real_calc.DATE == "2000-12-01"]["INTVL_WGPT:OP_2"].values == (
+        real_data[real_data.DATE == "2001-01-01"]["WGPT:OP_2"].values
+        - real_data[real_data.DATE == "2000-12-01"]["WGPT:OP_2"].values
+    )
+
+    assert real_calc[real_calc.DATE == "2002-02-01"]["INTVL_GWPT:OP"].values == (
+        real_data[real_data.DATE == "2002-03-01"]["GWPT:OP"].values
+        - real_data[real_data.DATE == "2002-02-01"]["GWPT:OP"].values
+    )
+
+
+@pytest.mark.parametrize(
+    "column_keys,time_index,time_index_input,as_rate",
+    [
+        (["WGPT:OP_2", "GWPT:OP"], "monthly", "yearly", False),
+        (["WGPT:OP_2", "GWPT:OP"], "daily", "monthly", True),
+        (["WGPT:OP_2", "GWPT:OP"], "daily", "yearly", True),
+    ],
+)
+def test_calc_from_cumulatives_errors(
+    column_keys, time_index, time_index_input, as_rate
+):
+    with pytest.raises(ValueError):
+        calc_df = from_cum.calc_from_cumulatives(
+            data=DATA_DF,
+            column_keys=column_keys,
+            time_index=time_index,
+            time_index_input=time_index_input,
+            as_rate=as_rate,
+        )

--- a/tests/unit_tests/utils_tests/test_simulation_timeseries.py
+++ b/tests/unit_tests/utils_tests/test_simulation_timeseries.py
@@ -1,0 +1,48 @@
+import pytest
+import webviz_subsurface._utils.simulation_timeseries as simulation_timeseries
+
+
+@pytest.mark.parametrize(
+    "date,vector,interval,as_date,res",
+    [
+        # Testing AVG_ vectors
+        ("2000-01-01", "AVG_FOPR", "monthly", False, "2000-01"),
+        ("2003-05-12", "AVG_WOPR:OP_1", "monthly", False, "2003-05"),
+        ("2002-05-12", "AVG_WOPR:OP_1", "yearly", False, "2002"),
+        ("2002-05-12", "AVG_WOPR:OP_1", "yearly", True, "2002-01-01"),
+        ("2002-05-12", "AVG_WOPR:OP_1", "daily", False, "2002-05-12"),
+        ("2002-05-12", "AVG_WOPR:OP_1", "daily", True, "2002-05-12"),
+        (None, "AVG_WOPR:OP_1", "daily", True, None),
+        # Testing INTVL_ vectors
+        ("2000-01-01", "INTVL_FOPR", "monthly", False, "2000-01"),
+        ("2003-05-12", "INTVL_WGPT:OP_1", "monthly", False, "2003-05"),
+        ("2002-05-12", "INTVL_WGPT:OP_1", "yearly", False, "2002"),
+        ("2002-05-12", "INTVL_WGPT:OP_1", "yearly", True, "2002-01-01"),
+        ("2002-05-12", "INTVL_WGPT:OP_1", "daily", False, "2002-05-12"),
+        ("2002-05-12", "INTVL_WGPT:OP_1", "daily", True, "2002-05-12"),
+        (None, "INTVL_WGPT:OP_1", "daily", True, None),
+        # Testing vectors that are not AVG_ or INTVL_. Dates should return as is.
+        ("2000-01-01", "FOPR", "monthly", False, "2000-01-01"),
+        ("2003-05-12", "FGPT", "monthly", False, "2003-05-12"),
+        ("2002-05-12", "WGPT:OP_1", "yearly", False, "2002-05-12"),
+        ("2002-05-12", "WOPR:OP_1", "yearly", True, "2002-05-12"),
+        ("2002-05-12", "TIMESTEP", "daily", False, "2002-05-12"),
+        ("2002-05-12", "NSUMPROB", "daily", True, "2002-05-12"),
+        (None, "WWCT:OP_2", "daily", True, None),
+    ],
+)
+def test_date_to_interval_conversion(date, vector, interval, as_date, res):
+    if res is None:
+        assert (
+            simulation_timeseries.date_to_interval_conversion(
+                date=date, vector=vector, interval=interval, as_date=as_date
+            )
+            is None
+        )
+    else:
+        assert (
+            simulation_timeseries.date_to_interval_conversion(
+                date=date, vector=vector, interval=interval, as_date=as_date
+            )
+            == res
+        )

--- a/webviz_subsurface/_abbreviations/reservoir_simulation.py
+++ b/webviz_subsurface/_abbreviations/reservoir_simulation.py
@@ -41,6 +41,14 @@ def simulation_vector_description(vector: str) -> str:
     """Returns a more human friendly description of the simulation vector if possible,
      otherwise returns the input as is.
     """
+    if vector.startswith("AVG_"):
+        prefix = "Average "
+        vector = vector[4:]
+    elif vector.startswith("INTVL_"):
+        prefix = "Interval "
+        vector = vector[6:]
+    else:
+        prefix = ""
     [vector_name, node] = vector.split(":", 1) if ":" in vector else [vector, None]
     if len(vector_name) == 8:
         if vector_name[0] == "R":
@@ -54,8 +62,8 @@ def simulation_vector_description(vector: str) -> str:
                 and SIMULATION_VECTOR_TERMINOLOGY[vector_base_name]["type"] == "region"
             ):
                 return (
-                    f"{SIMULATION_VECTOR_TERMINOLOGY[vector_base_name]['description']}"
-                    + f", region {fip} {node}"
+                    f"{prefix}{SIMULATION_VECTOR_TERMINOLOGY[vector_base_name]['description']}"
+                    f", region {fip} {node}"
                 )
         elif vector_name.startswith("W") and vector_name[4] == "L":
             # These are completion vectors, e.g. WWCTL:__1:OP_1 and WOPRL_10:OP_1 for
@@ -68,15 +76,15 @@ def simulation_vector_description(vector: str) -> str:
                 == "completion"
             ):
                 return (
-                    f"{SIMULATION_VECTOR_TERMINOLOGY[vector_base_name]['description']}"
-                    + f", well {node} completion {comp}"
+                    f"{prefix}{SIMULATION_VECTOR_TERMINOLOGY[vector_base_name]['description']}"
+                    f", well {node} completion {comp}"
                 )
 
     if vector_name in SIMULATION_VECTOR_TERMINOLOGY:
         metadata = SIMULATION_VECTOR_TERMINOLOGY[vector_name]
         if node is None:
-            return metadata["description"]
-        return f"{metadata['description']}, {metadata['type'].replace('_', ' ')} {node}"
+            return prefix + metadata["description"]
+        return f"{prefix}{metadata['description']}, {metadata['type'].replace('_', ' ')} {node}"
 
     if not vector.startswith(
         ("AU", "BU", "CU", "FU", "GU", "RU", "SU", "WU", "Recovery Factor of")
@@ -91,7 +99,7 @@ def simulation_vector_description(vector: str) -> str:
             ),
             UserWarning,
         )
-    return vector
+    return prefix + vector
 
 
 def historical_vector(

--- a/webviz_subsurface/_datainput/from_timeseries_cumulatives.py
+++ b/webviz_subsurface/_datainput/from_timeseries_cumulatives.py
@@ -1,0 +1,164 @@
+from typing import List, Union
+
+import pandas as pd
+import numpy as np
+
+# pylint: disable=dangerous-default-value
+def calc_from_cumulatives(
+    data: pd.DataFrame,
+    column_keys: Union[List[str], str],
+    time_index: str,
+    time_index_input: str,
+    as_rate: bool,
+) -> pd.DataFrame:
+    """Calculates interval delta and average rate at given time interval `time_index`.
+    `data` is a dataframe which has the columns "DATE", "ENSEMBLE", "REAL" and the columns
+    that you want to make the calculation for
+
+    Assumes that the data is already sampled to a time interval `time_index_input`.
+    `time_index` can currently be `daily`, `monthly` or `yearly`.
+
+    Interpolation is not performed, and the time interval `time_index` therefore has to be shorter
+    or equal to `time_index_input` (e.g. `time_index` = `yearly` is compatible with
+    `time_index_input` = `monthly`, but the opposite is invalid).
+
+    `column_keys` define vectors to take calculate for of.
+
+    If `as_rate` == True, the calculated cumulative for an interval is divided by the number of
+    days in the interval to give a rate per day.
+
+    Assumes that the data for each realization comes in consecutive lines, and that it is sorted as
+    increasing in time.
+
+    The average rate and interval production is stored at the beginning date of the interval,
+    opposite to rates in e.g. the Eclipse simulator's summary format, but similar to fmu-ensemble's
+    get_volumetric_rates(). E.g. for a monthly interval, the values stored at 2010-01-01 would be
+    the average rate and production for January 2010.
+    """
+    data = data.copy()
+    if isinstance(column_keys, str):
+        column_keys = [column_keys]
+
+    # Converting the DATE axis to datetime to allow for timedeltas
+    data.loc[:, ["DATE"]] = pd.to_datetime(data["DATE"])
+    _verify_time_index(data, time_index, time_index_input)
+    # Creating a column of unique values per ensemble-realization combination. A non-zero
+    # diff of this column will then mean that it is a diff between different realizations.
+    # Could alternatively loop over ensembles and realizations, but this is quicker for
+    # larger datasets.
+    data["ensrealuid"] = (
+        data["ENSEMBLE"].astype("category").cat.codes * data["REAL"].nunique()
+        + data["REAL"]
+    )
+
+    # Allows us to resample on DATE without merging ensembles and realizations.
+    data.set_index(["ENSEMBLE", "REAL", "DATE"], inplace=True)
+
+    # Resample on DATE frequency
+    data = _resample_time_index(
+        df=data, time_index=time_index, time_index_input=time_index_input
+    )
+
+    data.reset_index(level=["ENSEMBLE", "REAL"], inplace=True)
+
+    calc_cols = {vec: rename_vec_from_cum(vec, as_rate) for vec in column_keys}
+    listed_calc_cols = [calc_cols[col] for col in column_keys]
+
+    # Take diff of given column_keys + the ensemble-realization identifier.
+    # Preserve ENSEMBLE and REAL
+    diff_cum = pd.concat(
+        [
+            data[["ENSEMBLE", "REAL"]],
+            data[["ensrealuid"] + column_keys]
+            .diff()
+            .shift(-1)
+            .rename(mapper=calc_cols, axis=1,),
+        ],
+        axis=1,
+    )
+    diff_cum[listed_calc_cols] = diff_cum[listed_calc_cols].fillna(value=0)
+
+    # Reset index (DATE becomes regular column)
+    diff_cum.reset_index(inplace=True)
+
+    # Convert interval cumulative to daily average rate if requested
+    if as_rate:
+        days = diff_cum["DATE"].diff().shift(-1).dt.days.fillna(value=0)
+        for vec in column_keys:
+            with np.errstate(invalid="ignore"):
+                diff_cum.loc[:, calc_cols[vec]] = (
+                    diff_cum[calc_cols[vec]].values / days.values
+                )
+
+    # Set last value of each real to 0 (as we don't loop over the realizations)
+    diff_cum.loc[diff_cum["ensrealuid"] != 0, listed_calc_cols] = 0
+    diff_cum.drop("ensrealuid", axis=1, inplace=True)
+
+    return diff_cum
+
+
+def _verify_time_index(df: pd.DataFrame, time_index: str, time_index_input: str):
+    freqs = {"D": "daily", "MS": "monthly", "YS": "yearly"}
+    valid_time_indices = {
+        "daily": ["daily", "monthly", "yearly"],
+        "monthly": ["monthly", "yearly"],
+        "yearly": ["yearly"],
+    }
+    inferred_frequency = pd.infer_freq(sorted(df["DATE"].unique()))
+    if not freqs.get(inferred_frequency) == time_index_input:
+        raise ValueError(
+            "The DataFrame most likely contains data points which are not sampled on "
+            f"frequency time_index_input={time_index_input}. The inferred frequency from the "
+            f"unique DATE values was {inferred_frequency}."
+        )
+    if not time_index in valid_time_indices[time_index_input]:
+        raise ValueError(
+            f"The time_index {time_index} has higher frequency than time_index_input "
+            f"{time_index_input}. Valid time_index options are "
+            f"{valid_time_indices[time_index_input]}."
+        )
+
+
+def _resample_time_index(
+    df: pd.DataFrame, time_index: str, time_index_input: str
+) -> pd.DataFrame:
+    if time_index == time_index_input:
+        return df
+    if time_index == "yearly" and time_index_input in ["daily", "monthly"]:
+        return df.groupby(
+            [
+                pd.Grouper(level="ENSEMBLE"),
+                pd.Grouper(level="REAL"),
+                pd.Grouper(level="DATE", freq="YS"),
+            ]
+        ).first()
+    if time_index == "monthly" and time_index_input == "daily":
+        return df.groupby(
+            [
+                pd.Grouper(level="ENSEMBLE"),
+                pd.Grouper(level="REAL"),
+                pd.Grouper(level="DATE", freq="MS"),
+            ]
+        ).first()
+    raise ValueError(
+        f"Cannot combine `time_index`={time_index} and `time_index_input`={time_index_input}. "
+        "Ensure that `time_index_input` has a higher than or equal frequency to `time_index`. "
+        "Valid options are `daily`, `monthly` and `yearly` (dependent on input data)."
+    )
+
+
+def rename_vec_from_cum(vector: str, as_rate: bool):
+    """This function assumes that it is a cumulative/total vector named in the Eclipse standard
+    and is fairly naive when converting to rate. Based in the list in libecl
+    https://github.com/equinor/libecl/blob/69f1ee0ddf696c87b6d85eca37eed7e8b66ac2db/\
+        lib/ecl/smspec_node.cpp#L531-L586
+    the T identifying total/cumulative should not occur before letter 4,
+    as all the listed strings are prefixed with one or two letters in the vectors.
+    Therefore starting the replace at the position 3 (4th letter) to reduce risk of errors
+    in the conversion to rate naming, but hard to be completely safe.
+    """
+    return (
+        f"AVG_{vector[0:3] + vector[3:].replace('T', 'R', 1)}"
+        if as_rate
+        else f"INTVL_{vector}"
+    )

--- a/webviz_subsurface/_utils/simulation_timeseries.py
+++ b/webviz_subsurface/_utils/simulation_timeseries.py
@@ -26,11 +26,15 @@ def get_simulation_line_shape(
     """Get simulation time series line shape, smry_meta is a pd.DataFrame on the format given
     by `load_smry_meta` in `../_datainput/fmu_input.py`.
     """
+    if vector.startswith("AVG_") or vector.startswith("INTVL_"):
+        # These custom calculated vectors are valid forwards in time.
+        return "hv"
 
     if smry_meta is None:
         return line_shape_fallback
     try:
         if smry_meta.is_rate[vector]:
+            # Eclipse rate vectors are valid backwards in time.
             return "vh"
         if smry_meta.is_total[vector]:
             return "linear"
@@ -77,15 +81,15 @@ def add_fanchart_traces(
     legend_group: str,
     line_shape: str,
     refaxis: str = "DATE",
+    hovertemplate: str = "(%{x}, %{y})<br>",
 ):
     """Renders a fanchart for an ensemble vector"""
-
     fill_color = hex_to_rgb(color, 0.3)
     line_color = hex_to_rgb(color, 1)
     return [
         {
             "name": legend_group,
-            "hovertext": "Maximum",
+            "hovertemplate": hovertemplate + "Maximum",
             "x": ens_stat_df[("", refaxis)],
             "y": ens_stat_df[(vector, "max")],
             "mode": "lines",
@@ -95,7 +99,7 @@ def add_fanchart_traces(
         },
         {
             "name": legend_group,
-            "hovertext": "P90",
+            "hovertemplate": hovertemplate + "P90",
             "x": ens_stat_df[("", refaxis)],
             "y": ens_stat_df[(vector, "low_p90")],
             "mode": "lines",
@@ -107,7 +111,7 @@ def add_fanchart_traces(
         },
         {
             "name": legend_group,
-            "hovertext": "P10",
+            "hovertemplate": hovertemplate + "P10",
             "x": ens_stat_df[("", refaxis)],
             "y": ens_stat_df[(vector, "high_p10")],
             "mode": "lines",
@@ -119,7 +123,7 @@ def add_fanchart_traces(
         },
         {
             "name": legend_group,
-            "hovertext": "Mean",
+            "hovertemplate": hovertemplate + "Mean",
             "x": ens_stat_df[("", refaxis)],
             "y": ens_stat_df[(vector, "mean")],
             "mode": "lines",
@@ -131,7 +135,7 @@ def add_fanchart_traces(
         },
         {
             "name": legend_group,
-            "hovertext": "Minimum",
+            "hovertemplate": hovertemplate + "Minimum",
             "x": ens_stat_df[("", refaxis)],
             "y": ens_stat_df[(vector, "min")],
             "mode": "lines",
@@ -151,3 +155,39 @@ def hex_to_rgb(hex_string, opacity=1):
     rgb = [int(hex_string[i : i + hlen // 3], 16) for i in range(0, hlen, hlen // 3)]
     rgb.append(opacity)
     return f"rgba{tuple(rgb)}"
+
+
+def render_hovertemplate(vector: str, interval: Optional[str]):
+    if vector.startswith(("AVG_", "INTVL_")) and interval is not None:
+        if interval == "daily":
+            return "(%{x|%b} %{x|%-d}, %{x|%Y}, %{y})<br>"
+        if interval == "monthly":
+            return "(%{x|%b} %{x|%Y}, %{y})<br>"
+        if interval == "yearly":
+            return "(%{x|%Y}, %{y})<br>"
+        raise ValueError(f"Interval {interval} is not supported.")
+    return "(%{x}, %{y})<br>"  # Plotly's default behavior
+
+
+def date_to_interval_conversion(
+    date: Optional[str], vector: str, interval: str, as_date: bool = False
+) -> Optional[str]:
+    """Converts a date on form YYYY-MM-DD to an interval 'date' if the
+    vector is a vector that is calculated from cumulatives (AVG_ or INTVL_).
+    If as_date=True, the date returned will be the the first date of the interval
+    (independent of which date in the interval the input is),
+    if not, the 'date' returned will be the common basis for the interval,
+    e.g. YYYY-MM-DD for daily, YYYY-MM for monthly and YYYY for yearly.
+
+    The input date must be a date that can be reduced to the interval date by simply
+    removing terms, e.g. is both 2001-05-16 and 2001-05-01 ok for monthly and will return
+    2001-05.
+    """
+    if date is None:
+        return date
+    if vector.startswith(("AVG_", "INTVL_")):
+        if interval == "monthly":
+            date = "-".join(date.split("-")[0:2]) + ("-01" if as_date else "")
+        if interval == "yearly":
+            date = date.split("-")[0] + ("-01-01" if as_date else "")
+    return date


### PR DESCRIPTION
Closes #292 

The PR covers statistically averaged rates (per day) for a time period calculated from cumulative (total) vectors (In the petroleum industry commonly known as `calendar day rates`). 
In addition the delta production per time interval can be shown, which of course is the equivalent of a rate with the interval length as time unit.

To make it performant on-the-fly, only resampling is supported, not interpolation/extrapolation, meaning that the intervals have to be the same or a coarser interval than the dataset, and that the dataset has to be on a recurring frequency. Some modifications to verification of the frequency option part remains, but the plan is to support input frequencies:

- `daily`: with available intervals `daily`, `monthly` and `yearly` (note that `daily` quickly grows to large amounts of data, so might be slow).

- `monthly` (first day of month, pandas MS): with available intervals  `monthly` and `yearly`

- `yearly` (first day of year, pandas YS): with available intervals  `yearly`

Currently the delta per interval and average rates are calculated back to the first day of the interval. E.g. the values 01.01.2000 for monthly frequency is in fact the value for January 2000. This is opposite to the convention for Eclipse rates, but the same as what is used for `get_volumetric_rates` in `fmu-ensemble`. Visualization wise this is not a big issue, as we can control which way we fill, but for a data dump to e.g. csv, this could be confusing for users (e.g. if you dump together with other vectors, and values on the same line/date don't add up). But also confusing if results are not comparable with fmu-ensemble which many users are already used too 🤯...

When it comes to the inclusion in plugins, this PR shows a prototype for the ReservoirSimulationTimeSeries plugin. Attempted a few different solutions, but think including the new options in the regular vector selectors was the cleanest way I could find.
Has been proposed to force delta production over intervals (those starting with INTVL_) to be bar charts, but that turned out to not work well when plotting as realizations, and it was also not ideal to handle statistics due to overlaying bars.