### PR TITLE
Download data from ReservoirSimulationTimeseries

### DIFF
--- a/webviz_subsurface/_utils/simulation_timeseries.py
+++ b/webviz_subsurface/_utils/simulation_timeseries.py
@@ -2,6 +2,7 @@ import warnings
 from typing import Optional
 
 import pandas as pd
+import numpy as np
 
 
 def set_simulation_line_shape_fallback(line_shape_fallback: str) -> str:
@@ -36,3 +37,117 @@ def get_simulation_line_shape(
     except (AttributeError, KeyError):
         pass
     return line_shape_fallback
+
+
+def calc_series_statistics(df: pd.DataFrame, vectors: list, refaxis: str = "DATE"):
+    """Calculate statistics for given vectors over the ensembles
+    refaxis is used if another column than DATE should be used to groupby.
+    """
+    # Invert p10 and p90 due to oil industry convention.
+    def p10(x):
+        return np.nanpercentile(x, q=90)
+
+    def p90(x):
+        return np.nanpercentile(x, q=10)
+
+    # Calculate statistics, ignoring NaNs.
+    stat_df = (
+        df[["ENSEMBLE", refaxis] + vectors]
+        .groupby(["ENSEMBLE", refaxis])
+        .agg([np.nanmean, np.nanmin, np.nanmax, p10, p90])
+        .reset_index(level=["ENSEMBLE", refaxis], col_level=1)
+    )
+    # Rename nanmin, nanmax and nanmean to min, max and mean.
+    col_stat_label_map = {
+        "nanmin": "min",
+        "nanmax": "max",
+        "nanmean": "mean",
+        "p10": "high_p10",
+        "p90": "low_p90",
+    }
+    stat_df.rename(columns=col_stat_label_map, level=1, inplace=True)
+
+    return stat_df
+
+
+def add_fanchart_traces(
+    ens_stat_df: pd.DataFrame,
+    vector: str,
+    color: str,
+    legend_group: str,
+    line_shape: str,
+    refaxis: str = "DATE",
+):
+    """Renders a fanchart for an ensemble vector"""
+
+    fill_color = hex_to_rgb(color, 0.3)
+    line_color = hex_to_rgb(color, 1)
+    return [
+        {
+            "name": legend_group,
+            "hovertext": "Maximum",
+            "x": ens_stat_df[("", refaxis)],
+            "y": ens_stat_df[(vector, "max")],
+            "mode": "lines",
+            "line": {"width": 0, "color": line_color, "shape": line_shape},
+            "legendgroup": legend_group,
+            "showlegend": False,
+        },
+        {
+            "name": legend_group,
+            "hovertext": "P90",
+            "x": ens_stat_df[("", refaxis)],
+            "y": ens_stat_df[(vector, "low_p90")],
+            "mode": "lines",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"width": 0, "color": line_color, "shape": line_shape},
+            "legendgroup": legend_group,
+            "showlegend": False,
+        },
+        {
+            "name": legend_group,
+            "hovertext": "P10",
+            "x": ens_stat_df[("", refaxis)],
+            "y": ens_stat_df[(vector, "high_p10")],
+            "mode": "lines",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"width": 0, "color": line_color, "shape": line_shape},
+            "legendgroup": legend_group,
+            "showlegend": False,
+        },
+        {
+            "name": legend_group,
+            "hovertext": "Mean",
+            "x": ens_stat_df[("", refaxis)],
+            "y": ens_stat_df[(vector, "mean")],
+            "mode": "lines",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"color": line_color, "shape": line_shape},
+            "legendgroup": legend_group,
+            "showlegend": True,
+        },
+        {
+            "name": legend_group,
+            "hovertext": "Minimum",
+            "x": ens_stat_df[("", refaxis)],
+            "y": ens_stat_df[(vector, "min")],
+            "mode": "lines",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"width": 0, "color": line_color, "shape": line_shape},
+            "legendgroup": legend_group,
+            "showlegend": False,
+        },
+    ]
+
+
+def hex_to_rgb(hex_string, opacity=1):
+    """Converts a hex color to rgb"""
+    hex_string = hex_string.lstrip("#")
+    hlen = len(hex_string)
+    rgb = [int(hex_string[i : i + hlen // 3], 16) for i in range(0, hlen, hlen // 3)]
+    rgb.append(opacity)
+    return f"rgba{tuple(rgb)}"


### PR DESCRIPTION
Resolves #276 and #326 (though only download, not table).

Adds functionality to download visualized data from the ReservoirSimulationTimeseries plugin. Data is stored in a zipped folder
as a csvfile.

The code has been somewhat refactored to ease the download functionality + to make the code more modular and reusable.
Some simple performance tests indicate that the new solution is at least not slower than the previous (if anything slightly faster).

Supports:
- [x] Regular ensembles
- [x] Delta ensembles
- [x] Multiple ensembles
- [x] Data per realization
- [x] Ensemble statistics
- [x] Multiple vectors

Some data is intentionally currently not supported for download, as they are not part of the basic dataframe which is exported to csv (they would require custom solutions which I haven't prioritized). Think this PR is useful without them. This includes (at least):
- [ ]  Histogram data (bins) for selected date
- [ ]  Historical vector (if existing)
- [ ]  Observations
- [ ]  Vector metadata