### PR TITLE
Work-around xtgeo.RegularSurface values initialization

### DIFF
--- a/webviz_subsurface/plugins/_surface_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_surface_viewer_fmu.py
@@ -659,7 +659,10 @@ def surface_to_json(surface):
 
 
 def surface_from_json(surfaceobj):
-    return xtgeo.RegularSurface(**surfaceobj)
+    # See https://github.com/equinor/xtgeo/issues/405
+    surface = xtgeo.RegularSurface(**surfaceobj)
+    surface.values = np.array(surfaceobj["values"])
+    return surface
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)

--- a/webviz_subsurface/plugins/_well_cross_section_fmu.py
+++ b/webviz_subsurface/plugins/_well_cross_section_fmu.py
@@ -607,7 +607,11 @@ def surface_to_json(surface):
 
 
 def surface_from_json(surfaceobj):
-    return xtgeo.RegularSurface(**json.loads(surfaceobj))
+    # See https://github.com/equinor/xtgeo/issues/405
+    data = json.loads(surfaceobj)
+    surface = xtgeo.RegularSurface(**data)
+    surface.values = np.array(data["values"])
+    return surface
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)


### PR DESCRIPTION
Closes #384 (hopefully).

After [this `xtgeo` commit](https://github.com/equinor/xtgeo/pull/369/files#diff-c8c9bc2052a264d274e4099549de0e0fR2555-R2629), `surface_instance.values = some_value` does not set the `values` property if `some_value` is not of one of the expected types (and is ignored silently).

Explicitly cast to `np.array` to support `xtgeo >= 2.9.0`.