### PR TITLE
Filter on ERT OK file in HistoryMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - YYYY-MM-DD
 ### Added
 - [#417](https://github.com/equinor/webviz-subsurface/pull/417) - Added an optional argument `--testdata-folder` to `pytest`, can be used when [test data](https://github.com/equinor/webviz-subsurface-testdata) is in non-default location.
+- [#422](https://github.com/equinor/webviz-subsurface/pull/422) - `HistoryMatch` plugin now
+quietly excludes all realizations lacking an `OK` file written by `ERT` on completion of realization workflow, similar to behavior of other plugins that read from individual realizations. Previously wrote warnings for missing data.
 
 ## [0.1.2] - 2020-09-24
 ### Changed

--- a/webviz_subsurface/_datainput/history_match.py
+++ b/webviz_subsurface/_datainput/history_match.py
@@ -5,7 +5,7 @@ import fmu.ensemble
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 
-from .fmu_input import scratch_ensemble
+from .fmu_input import load_ensemble_set
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
@@ -15,12 +15,7 @@ def extract_mismatch(ens_paths, observation_file: Path) -> pd.DataFrame:
     suitable for the interactive history match visualization.
     """
 
-    list_ens = [
-        scratch_ensemble(ensemble_name, path)
-        for (ensemble_name, path) in ens_paths.items()
-    ]
-
-    ens_data = fmu.ensemble.EnsembleSet("HistoryMatch", list_ens)
+    ens_data = load_ensemble_set(ens_paths)
 
     df_mismatch = fmu.ensemble.Observations(str(observation_file)).mismatch(ens_data)
 


### PR DESCRIPTION
---

### Contributor checklist

- [X] :tada: This PR closes #421. 
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Use `load_ensemble_set` from `_datainput.fmu_input` to initialize the `EnsembleSet`, as it already includes the filtering.
- [X] :robot: ~~I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.~~ **I have NOT added/extended tests.**
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
