### PR TITLE
Suppress numpy warnings from surface calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#422](https://github.com/equinor/webviz-subsurface/pull/422) - `HistoryMatch` plugin now
 quietly excludes all realizations lacking an `OK` file written by `ERT` on completion of realization workflow, similar to behavior of other plugins that read from individual realizations. Previously wrote warnings for missing data.
 - [#428](https://github.com/equinor/webviz-subsurface/pull/428) - Plugin controls, such as dropdown selections, set by the user is kept on page reload.
+- [#435](https://github.com/equinor/webviz-subsurface/pull/435) - Suppress a warning in SurfaceViewerFMU when calculating statistics from surfaces where one or more surface only has NaN values. [#399](https://github.com/equinor/webviz-subsurface/pull/399)
 
 ### Fixed
 - [#432](https://github.com/equinor/webviz-subsurface/pull/432) - Bug fix in ReservoirSimulationTimeSeries. Vectors starting with A, V, G, I, N, T, V and L resulted in crash due to a bug introduced in [#373](https://github.com/equinor/webviz-subsurface/pull/373) (most notably group and aquifer vectors).


### PR DESCRIPTION


### Contributor checklist

- [x] :tada: Closes #399 
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Suppress numpy warnings resulting from calculating surface statistics
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
