### PR TITLE
Show all Python warnings in CI log

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -17,6 +17,8 @@ jobs:
     # Run on all events defined above, except pushes which are neither to master nor with a substring [deploy test] in commit message
     if: github.event_name != 'push' || github.ref == 'refs/heads/master' || contains(github.event.head_commit.message, '[deploy test]')
     runs-on: ubuntu-latest
+    env:
+      PYTHONWARNINGS: default  # We want to see e.g. DeprecationWarnings
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8']


### PR DESCRIPTION
It is useful to be able to see e.g. `DeprecationWarning`s in the CI log.

This change will make sure we get all warnings (except those filtered away by code using e.g. `filterwarnings`).