### PR TITLE
Add free space and new design to DiskUsage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ quietly excludes all realizations lacking an `OK` file written by `ERT` on compl
 - [#435](https://github.com/equinor/webviz-subsurface/pull/435) - Suppress a warning in SurfaceViewerFMU when calculating statistics from surfaces where one or more surface only has NaN values. [#399](https://github.com/equinor/webviz-subsurface/pull/399)
 - [#438](https://github.com/equinor/webviz-subsurface/pull/438) - Improved documentation of generation of data input for `RelativePermability` plugin.
 - [#434](https://github.com/equinor/webviz-subsurface/pull/434) - Improved hillshading and colors in plugins with map views.
+- [#439](https://github.com/equinor/webviz-subsurface/pull/439) - Pie chart and bar chart are now visualized together in `DiskUsage`. Free space is now visualized as well.
 
 ### Fixed
 - [#432](https://github.com/equinor/webviz-subsurface/pull/432) - Bug fix in ReservoirSimulationTimeSeries. Vectors starting with A, V, G, I, N, T, V and L resulted in crash due to a bug introduced in [#373](https://github.com/equinor/webviz-subsurface/pull/373) (most notably group and aquifer vectors).


### PR DESCRIPTION
Adds free space and puts pie chart and bar chart into the same view for `DiskUsage`.
---

### Contributor checklist

- [X] :tada: This PR closes #398.  
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Add free space using `shutil.disk_usage().free` if the data is from the current date. Even at the current date, the free space will be up-to-date at time of build, whilst the per user data will be when the workflow was run to generate the file.
   - [X] Remove the radio-buttons to switch between pie chart and bar chart, and instead show both at the same time.
- ~~[ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.~~
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
