### PR TITLE
Improve depth data defaults for make_surface_layer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- [#450](https://github.com/equinor/webviz-subsurface/pull/450) - Flipped colormap for subsurface maps (such that deeper areas get darker colors). Also fixed hill shading such that input values are treated as depth, not positive elevation.
 - [#459](https://github.com/equinor/webviz-subsurface/pull/459) - Bug fix in ReservoirSimulationTimeSeries. All `History` traces are now toggled when clicking `History` in the legend.
 
 ## [0.1.3] - 2020-09-24

--- a/webviz_subsurface/_datainput/surface.py
+++ b/webviz_subsurface/_datainput/surface.py
@@ -73,16 +73,16 @@ def make_surface_layer(
         scale = np.sqrt(ratio).round(2)
     color = (
         [
-            "#440154",
-            "#482878",
-            "#3e4989",
-            "#31688e",
-            "#26828e",
-            "#1f9e89",
-            "#35b779",
-            "#6ece58",
-            "#b5de2b",
             "#fde725",
+            "#b5de2b",
+            "#6ece58",
+            "#35b779",
+            "#1f9e89",
+            "#26828e",
+            "#31688e",
+            "#3e4989",
+            "#482878",
+            "#440154",
         ]
         if color is None
         else color
@@ -106,7 +106,7 @@ def make_surface_layer(
                     "type": shader_type,
                     "shadows": shadows,
                     "shadowIterations": 128,
-                    "elevationScale": 1.0,
+                    "elevationScale": -1.0,
                     "pixelScale": 11000,
                     "setBlackToAlpha": True,
                 },


### PR DESCRIPTION
As this is a repo for subsurface containers, the default should maybe be to assume depth data, not elevation?

The demo is currently showing dark colors for shallow areas and bright colors for deep areas. The hillshading is also wrong as it is calculated as elevation.

If you want to use hillshading for other surfaces (e.g. isochores) you would have to revert to a positive elevationScale.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
