### PR TITLE
Add legendgroup: History to history traces in ReservoirSimulationTime…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED] - YYYY-MM-DD
+### Added
+
+### Fixed
+- [#459](https://github.com/equinor/webviz-subsurface/pull/459) - Bug fix in ReservoirSimulationTimeSeries. All `History` traces are now toggled when clicking `History` in the legend.
+
 ## [0.1.3] - 2020-09-24
 ### Added
 - [#417](https://github.com/equinor/webviz-subsurface/pull/417) - Added an optional argument `--testdata-folder` to `pytest`, can be used when [test data](https://github.com/equinor/webviz-subsurface-testdata) is in non-default location.

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -1105,6 +1105,7 @@ def add_history_trace(dframe, vector, line_shape):
         "name": "History",
         "marker": {"color": "black"},
         "showlegend": True,
+        "legendgroup": "History",
     }
 
 


### PR DESCRIPTION
### Contributor checklist

- [X] :tada: This PR closes #458 
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Add `"legendgroup": "History"` to history traces
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
