### PR TITLE
Add project_urls in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,12 @@ setup(
     python_requires="~=3.6",
     use_scm_version=True,
     zip_safe=False,
+    project_urls={
+        "Documentation": "https://equinor.github.io/webviz-subsurface",
+        "Download": "https://pypi.org/project/webviz-subsurface/",
+        "Source": "https://github.com/equinor/webviz-subsurface",
+        "Tracker": "https://github.com/equinor/webviz-subsurface/issues",
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
This is related to changes in `webviz-config` - which going forward will use `Download` URL to automatically include required plugin projects in Docker file.

While first doing this - also adding link to documentation and issue tracker.