### PR TITLE
Dash testing fixture does not handle StaleElementReferenceException

### DIFF
--- a/tests/integration_tests/test_aggregated_data_example.py
+++ b/tests/integration_tests/test_aggregated_data_example.py
@@ -1,8 +1,22 @@
 import sys
 import subprocess  # nosec
 
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+)
+
 
 def test_basic_example(testdata_folder, dash_duo, tmp_path):
+
+    # https://github.com/plotly/dash/issues/1164:
+    dash_duo._wd_wait = WebDriverWait(
+        dash_duo.driver,
+        timeout=10,
+        ignored_exceptions=(NoSuchElementException, StaleElementReferenceException),
+    )
+
     # Build a portable webviz from config file
     appdir = tmp_path / "app"
     subprocess.call(  # nosec

--- a/tests/integration_tests/test_raw_data_example.py
+++ b/tests/integration_tests/test_raw_data_example.py
@@ -1,8 +1,22 @@
 import sys
 import subprocess  # nosec
 
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+)
+
 
 def test_full_example(testdata_folder, dash_duo, tmp_path):
+
+    # https://github.com/plotly/dash/issues/1164:
+    dash_duo._wd_wait = WebDriverWait(
+        dash_duo.driver,
+        timeout=10,
+        ignored_exceptions=(NoSuchElementException, StaleElementReferenceException),
+    )
+
     # Build a portable webviz from config file
     appdir = tmp_path / "app"
     subprocess.call(  # nosec
@@ -27,7 +41,7 @@ def test_full_example(testdata_folder, dash_duo, tmp_path):
         "inplacevolumesonebyone",
         "reservoirsimulationtimeseriesonebyone",
         "inplacevolumes",
-        # "parameterdistribution",
+        "parameterdistribution",
         "parametercorrelation",
         "reservoirsimulationtimeseries",
     ]:


### PR DESCRIPTION
See https://github.com/plotly/dash/issues/1164 for details.

`webviz-subsurface` started seeing this recently when we moved from multi-page app using `dcc.Links`/`dcc.Location` combo instead of `dcc.Tabs`.

We instead ignore `NoSucElementException` and `StaleElementException`, and instead use what the user expects to happen: Selenium raises a `selenium.common.exceptions.TimeoutException` if no working element reference found within the timeout.

---

### Contributor checklist

- [X] :tada: This PR closes #471.
- [X] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.