### PR TITLE
Drop NaN in delta profiles instead of replacing with zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#459](https://github.com/equinor/webviz-subsurface/pull/459) - Bug fix in ReservoirSimulationTimeSeries. All `History` traces are now toggled when clicking `History` in the legend.
 - [#474](https://github.com/equinor/webviz-subsurface/pull/474) - Bug fix in ParameterCorrelation. Constant parameters are now removed if `drop_constants` is set to `True`
 - [#480](https://github.com/equinor/webviz-subsurface/pull/480) - Bug fix in SubsurfaceMap, InplaceVolumes and InplaceVolumesOneByOne: Filter on `OK` file is now applied when loading data from ensembles through fmu-ensemble.
+- [#482](https://github.com/equinor/webviz-subsurface/pull/482) - Bug fix in ReservoirSimulationTimeSeries: NaN values are now dropped instead of being replaced by zeros, e.g. if some realizations are missing in one of the ensembles, if the dates don't match, or if a vector is missing in one of the ensembles.
 
 ## [0.1.3] - 2020-09-24
 ### Added

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -1023,7 +1023,7 @@ def calculate_delta(df, base_ens, delta_ens):
     )
     dframe = base_df.sub(delta_df).reset_index()
     dframe["ENSEMBLE"] = f"({base_ens}) - ({delta_ens})"
-    return dframe.fillna(0)
+    return dframe.dropna(axis=0, how="any")
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -679,6 +679,8 @@ folder, to avoid risk of not extracting the right data.
                 cum_interval=cum_interval,
             )
             for i, vector in enumerate(vectors):
+                if dfs[vector]["data"].empty:
+                    continue
                 line_shape = get_simulation_line_shape(
                     line_shape_fallback=self.line_shape_fallback,
                     vector=vector,


### PR DESCRIPTION
Note that in the case of different ensemble sizes, only matching realization indices will be kept (no other logical way to handle it as far as I know).
- [X] :tada: This PR closes #472 
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Switch fillna(0) with dropna(axis=0, how="any") (these are also default options, but in case default behavior changes...)
   - [X] Handle case of empty delta (just skipping, no message, error or warning, but user should know this). Result is empty plot.
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
