### PR TITLE
Pin ecl2df in Docker CI

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -99,7 +99,7 @@ jobs:
         # Related to https://github.com/equinor/webviz-config/issues/150:
         echo "RUN pip install --user git+https://github.com/${{ github.repository }}.git@${{ github.ref }}" >> Dockerfile
         # There are dependencies which we can't have in setup.py yet due to limitations in internal deployment system ("komodo"):
-        echo "RUN pip install --user libecl ecl2df opm" >> Dockerfile
+        echo "RUN pip install --user libecl ecl2df==0.8.2 opm" >> Dockerfile
         docker build -t webviz/example_subsurface_image:equinor-theme .
         popd
 


### PR DESCRIPTION
...due to recent release of `ecl2df` (today) has a new requirement `equinor-libres` requiring Docker base image to be updated (`gcc` required).