### PR TITLE
Obey column_keys when storing unsmry data with frequency raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED] - YYYY-MM-DD
+### Fixed
+- [#531](https://github.com/equinor/webviz-subsurface/pull/531) - The change in [#505](https://github.com/equinor/webviz-subsurface/pull/505) resulted in potentially very large datasets when using `raw` sampling. Some users experienced `MemoryError`. `column_keys` filtering is therefore now used when loading and storing data if `sampling` is `raw` in plugins using `UNSMRY` data, most noticable in `BhpQc` which has `raw` as the default and only option.
+
 ## [0.1.6] - 2020-11-30
 ### Fixed
 - [#505](https://github.com/equinor/webviz-subsurface/pull/505) - Fixed recent performance regression issue for loading of UNSMRY data. Loading times when multiple plugins are using the same data is now significantly reduced. Note that all UNSMRY vectors are now stored in portable apps, independent of choice of column_keys in individual plugins.
@@ -19,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.4] - 2020-10-29
 ### Added
-- [#457](https://github.com/equinor/webviz-subsurface/pull/457) - Raise a descriptive error if a scratch ensemble is empty, i.e. no `OK` target file is found in any realizations. 
-- [#427](https://github.com/equinor/webviz-subsurface/pull/427) - `BhpQc` plugin added: Quality check that simulated bottom hole pressures are realistic. 
+- [#457](https://github.com/equinor/webviz-subsurface/pull/457) - Raise a descriptive error if a scratch ensemble is empty, i.e. no `OK` target file is found in any realizations.
+- [#427](https://github.com/equinor/webviz-subsurface/pull/427) - `BhpQc` plugin added: Quality check that simulated bottom hole pressures are realistic.
 - [#481](https://github.com/equinor/webviz-subsurface/pull/481) - `RFT-plotter`: Added support for MD, and made ECLIPSE RFT data optional.
 - [#467](https://github.com/equinor/webviz-subsurface/pull/467) - `PropertyStatistics` plugin added: QC and analysis of grid property statistics.
 

--- a/webviz_subsurface/_models/ensemble_model.py
+++ b/webviz_subsurface/_models/ensemble_model.py
@@ -62,6 +62,24 @@ class EnsembleModel:
         time_index: Optional[Union[list, str]] = None,
         column_keys: Optional[list] = None,
     ) -> pd.DataFrame:
+        # Limit saved columns if time_index = 'raw' or None, as the data density might
+        # be very high, and increases risk of `MemoryError`
+        if time_index == "raw" or time_index is None:
+            self._webviz_store.append(
+                (
+                    self._load_smry,
+                    [
+                        {
+                            "self": self,
+                            "time_index": time_index,
+                            "column_keys": column_keys,
+                        }
+                    ],
+                )
+            )
+            return self._load_smry(time_index=time_index, column_keys=column_keys)
+
+        # Otherwise store all columns to reduce risk of duplicates
         self._webviz_store.append(
             (
                 self._load_smry,


### PR DESCRIPTION
Obeys selected `column_keys` when using `time_index` / `sampling` of `raw` (or the equivalent `None`) when loading and storing `UNSMRY` data.

Did some test on larger datasets than our test data, and it was a dramatic improvement. Saw peak memory usage reduced by up to **97%!**

Nevertheless, it is clear that we have memory issues: with this edit on my larger data set, peak memory usage during load and portable build was still more than 3 times higher than peaks when running the portable. 

**Could also be that we should do the same for `daily` data frequency, as that is also quite high when it comes to reservoir simulation?**

---

### Contributor checklist

- [X] :tada: This PR closes #528 

- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
