### PR TITLE
Fixed failing test when running with non-default testdata-folder

### DIFF
--- a/tests/unit_tests/model_tests/test_ensemble_set_model.py
+++ b/tests/unit_tests/model_tests/test_ensemble_set_model.py
@@ -19,7 +19,7 @@ def test_single_ensemble(testdata_folder):
         }
     )
     assert emodel.ens_folders == {
-        "iter-0": Path("webviz-subsurface-testdata") / "reek_history_match"
+        "iter-0": Path(testdata_folder) / "reek_history_match"
     }
     assert len(emodel.ensembles) == 1
     smry = emodel.load_smry()


### PR DESCRIPTION
Use the actual `testdata_folder` argument instead of hard-wired path string in test.
This PR closes #530