### PR TITLE
Use new WebvizSettings instead of dictionary piggybacked onto app object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED] - YYYY-MM-DD
+### Changed
+- [#544](https://github.com/equinor/webviz-subsurface/pull/544) - All plugins now use new special `webviz_settings` argument to plugin's `__init__` method for common settings in favor of piggybacking dictionary onto the to the Dash applicaton object.
+
 ### Fixed
 - [#536](https://github.com/equinor/webviz-subsurface/pull/536) - Fixed issue and bumped dependencies related to Pandas version 1.2.0. Bumped dependency to webviz-config to support mypy typechecks.
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "pyscal>=0.7.2",
         "scipy>=1.2",
         "statsmodels>=0.12.1",  # indirect dependency through https://plotly.com/python/linear-fits/
-        "webviz-config>=0.2.6",
+        "webviz-config>=0.2.7",
         "webviz-subsurface-components>=0.2.0",
         "xtgeo>=2.8",
     ],

--- a/tests/integration_tests/test_parameter_corr.py
+++ b/tests/integration_tests/test_parameter_corr.py
@@ -3,6 +3,7 @@ import dash
 import pandas as pd
 from webviz_config.common_cache import CACHE
 from webviz_config.themes import default_theme
+from webviz_config import WebvizSettings
 
 # pylint: disable=no-name-in-module
 from webviz_config.plugins import (
@@ -22,16 +23,15 @@ def test_parameter_corr(dash_duo: dash.testing.composite.DashComposite) -> None:
     app.scripts.config.serve_locally = True
     app.config.suppress_callback_exceptions = True
     CACHE.init_app(app.server)
-    app.webviz_settings = {
-        "shared_settings": {"scratch_ensembles": {"iter-0": ""}},
-        "theme": default_theme,
-    }
+    webviz_settings = WebvizSettings(
+        shared_settings={"scratch_ensembles": {"iter-0": ""}}, theme=default_theme
+    )
     ensembles = ["iter-0"]
 
     with mock.patch(GET_PARAMETERS) as mock_parameters:
         mock_parameters.return_value = pd.read_csv("tests/data/parameters.csv")
 
-        parameter_correlation = ParameterCorrelation(app, ensembles)
+        parameter_correlation = ParameterCorrelation(app, webviz_settings, ensembles)
 
         app.layout = parameter_correlation.layout
         dash_duo.start_server(app)

--- a/webviz_subsurface/_private_plugins/tornado_plot.py
+++ b/webviz_subsurface/_private_plugins/tornado_plot.py
@@ -10,6 +10,7 @@ import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config.common_cache import CACHE
+from webviz_config import WebvizSettings
 
 from .._abbreviations.number_formatting import si_prefixed
 
@@ -52,6 +53,7 @@ class TornadoPlot:
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         realizations: pd.DataFrame,
         reference: str = "rms_seed",
         allow_click: bool = False,
@@ -71,7 +73,7 @@ class TornadoPlot:
         )
         self.allow_click = allow_click
         self.uid = uuid4()
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.set_callbacks(app)
 
     def ids(self, element: str) -> str:

--- a/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
+++ b/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
@@ -11,6 +11,7 @@ import dash_core_components as dcc
 from dash.dependencies import Input, Output
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 import webviz_core_components as wcc
@@ -39,12 +40,12 @@ class AssistedHistoryMatchingAnalysis(WebvizPluginABC):
 
     """
 
-    def __init__(self, app, input_dir: Path):
+    def __init__(self, app, webviz_settings: WebvizSettings, input_dir: Path):
 
         super().__init__()
 
         self.input_dir = input_dir
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
 
         self.set_callbacks(app)
 

--- a/webviz_subsurface/plugins/_bhp_qc.py
+++ b/webviz_subsurface/plugins/_bhp_qc.py
@@ -9,6 +9,7 @@ import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from webviz_subsurface._models import EnsembleSetModel
 from .._utils.unique_theming import unique_colors
@@ -37,6 +38,7 @@ class BhpQc(WebvizPluginABC):
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         ensembles: list,
         wells: Optional[List[str]] = None,
     ):
@@ -48,14 +50,14 @@ class BhpQc(WebvizPluginABC):
 
         self.emodel = EnsembleSetModel(
             ensemble_paths={
-                ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+                ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                 for ens in ensembles
             }
         )
         self.smry = self.emodel.load_smry(
             time_index="raw", column_keys=self.column_keys
         )
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
         self.set_callbacks(app)
 
     @property

--- a/webviz_subsurface/plugins/_disk_usage.py
+++ b/webviz_subsurface/plugins/_disk_usage.py
@@ -5,12 +5,12 @@ import pathlib
 import datetime
 
 import pandas as pd
-import dash
 import dash_html_components as html
 import webviz_core_components as wcc
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 
 class DiskUsage(WebvizPluginABC):
@@ -34,7 +34,10 @@ class DiskUsage(WebvizPluginABC):
     """
 
     def __init__(
-        self, app: dash.Dash, scratch_dir: pathlib.Path, date: Optional["str"] = None
+        self,
+        webviz_settings: WebvizSettings,
+        scratch_dir: pathlib.Path,
+        date: Optional["str"] = None,
     ):
 
         super().__init__()
@@ -45,7 +48,7 @@ class DiskUsage(WebvizPluginABC):
         self.date = str(self.disk_usage["date"].unique()[0])
         self.users = self.disk_usage["userid"]
         self.usage_gib = self.disk_usage["usageKB"] / (1024 ** 2)
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
 
     @property
     def layout(self) -> html.Div:

--- a/webviz_subsurface/plugins/_history_match.py
+++ b/webviz_subsurface/plugins/_history_match.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from scipy.stats import chi2
-import dash
 import dash_html_components as html
 import webviz_subsurface_components as wsc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from .._datainput.history_match import extract_mismatch
 
@@ -33,7 +33,12 @@ be made manually. [An example of the format can be found here]\
 observations/observations.yml).
 """
 
-    def __init__(self, app: dash.Dash, ensembles: List[str], observation_file: Path):
+    def __init__(
+        self,
+        webviz_settings: WebvizSettings,
+        ensembles: List[str],
+        observation_file: Path,
+    ):
 
         super().__init__()
 
@@ -41,7 +46,7 @@ observations/observations.yml).
 
         self.ensembles = ensembles
         self.ens_paths = {
-            ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+            ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
             for ens in ensembles
         }
 

--- a/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
+++ b/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
@@ -19,6 +19,7 @@ import webviz_subsurface_components
 
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.webviz_store import webvizstore
 
 import webviz_subsurface
@@ -45,12 +46,13 @@ class HorizonUncertaintyViewer(WebvizPluginABC):
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         basedir: Path,
         planned_wells_dir: Path = None,
     ):
 
         super().__init__()
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.uid = uuid4()
         WEBVIZ_ASSETS.add(
             Path(webviz_subsurface.__file__).parent / "_assets" / "css" / "modal.css"

--- a/webviz_subsurface/plugins/_inplace_volumes.py
+++ b/webviz_subsurface/plugins/_inplace_volumes.py
@@ -13,6 +13,7 @@ import webviz_core_components as wcc
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from .._datainput.inplace_volumes import extract_volumes
 from .._abbreviations.volume_terminology import volume_description, volume_unit
@@ -86,6 +87,7 @@ but the following responses are given more descriptive names automatically:
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         csvfile: Path = None,
         ensembles: list = None,
         volfiles: dict = None,
@@ -105,7 +107,7 @@ but the following responses are given more descriptive names automatically:
 
         elif ensembles and volfiles:
             self.ens_paths = {
-                ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+                ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                 for ens in ensembles
             }
             self.volfiles = volfiles
@@ -122,7 +124,7 @@ but the following responses are given more descriptive names automatically:
         self.initial_response = response
         self.uid = uuid4()
         self.selectors_id = {x: str(uuid4()) for x in self.selectors}
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.initial_group: Union[str, None] = None
         if len(self.volumes["ENSEMBLE"].unique()) > 1:
             self.initial_plot = "Box plot"

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -13,6 +13,7 @@ import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 
@@ -114,6 +115,7 @@ aggregated_data/parameters.csv)
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         csvfile_vol: Path = None,
         csvfile_parameters: Path = None,
         ensembles: list = None,
@@ -141,7 +143,7 @@ aggregated_data/parameters.csv)
 
         elif ensembles and volfiles:
             self.ens_paths = {
-                ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+                ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                 for ens in ensembles
             }
             self.volfiles = volfiles
@@ -165,10 +167,12 @@ aggregated_data/parameters.csv)
         self.volumes = pd.merge(volumes, parameters, on=["ENSEMBLE", "REAL"])
 
         # Initialize a tornado plot. Data is added in callback
-        self.tornadoplot = TornadoPlot(app, parameters, allow_click=True)
+        self.tornadoplot = TornadoPlot(
+            app, webviz_settings, parameters, allow_click=True
+        )
         self.uid = uuid4()
         self.selectors_id = {x: self.uuid(x) for x in self.selectors}
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
         self.set_callbacks(app)
 
     def add_webvizstore(self) -> List[Tuple[Callable, list]]:

--- a/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import dash_core_components as dcc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 
 import webviz_subsurface
@@ -73,6 +74,7 @@ slow for large models.
     def __init__(
         self,
         app,
+        webviz_settings: WebvizSettings,
         ensembles: Optional[list] = None,
         csvfile_parameters: pathlib.Path = None,
         csvfile_smry: pathlib.Path = None,
@@ -87,7 +89,7 @@ slow for large models.
             / "css"
             / "container.css"
         )
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
         self.time_index = time_index
         self.column_keys = column_keys
         self.ensembles = ensembles
@@ -97,9 +99,7 @@ slow for large models.
         if ensembles is not None:
             self.emodel = EnsembleSetModel(
                 ensemble_paths={
-                    ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][
-                        ens
-                    ]
+                    ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                     for ens in ensembles
                 }
             )

--- a/webviz_subsurface/plugins/_parameter_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_correlation.py
@@ -12,6 +12,7 @@ from dash.dependencies import Input, Output
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from .._datainput.fmu_input import scratch_ensemble
 
@@ -42,16 +43,22 @@ class ParameterCorrelation(WebvizPluginABC):
     Parameter values are extracted automatically from the `parameters.txt` files in the individual
     realizations of your defined `ensembles`, using the `fmu-ensemble` library."""
 
-    def __init__(self, app: dash.Dash, ensembles: list, drop_constants: bool = True):
+    def __init__(
+        self,
+        app: dash.Dash,
+        webviz_settings: WebvizSettings,
+        ensembles: list,
+        drop_constants: bool = True,
+    ):
 
         super().__init__()
 
         self.ensembles = {
-            ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+            ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
             for ens in ensembles
         }
         self.drop_constants = drop_constants
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
 
         self.uid = uuid4()
         self.set_callbacks(app)

--- a/webviz_subsurface/plugins/_parameter_distribution.py
+++ b/webviz_subsurface/plugins/_parameter_distribution.py
@@ -10,6 +10,7 @@ import dash_html_components as html
 import dash_core_components as dcc
 import webviz_subsurface_components as wsc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 
@@ -42,7 +43,13 @@ When using an aggregated `csvfile`, you need to have the columns `REAL`, `ENSEMB
 and the parameter columns.
 """
 
-    def __init__(self, app: dash.Dash, csvfile: Path = None, ensembles: list = None):
+    def __init__(
+        self,
+        app: dash.Dash,
+        webviz_settings: WebvizSettings,
+        csvfile: Path = None,
+        ensembles: list = None,
+    ):
 
         super().__init__()
 
@@ -56,7 +63,7 @@ and the parameter columns.
             self.parameters = read_csv(csvfile)
         elif ensembles:
             self.ensembles = {
-                ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+                ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                 for ens in ensembles
             }
             self.parameters = load_parameters(
@@ -73,7 +80,7 @@ and the parameter columns.
             if col not in ["REAL", "ENSEMBLE"]
         ]
         self.uid = uuid4()
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.set_callbacks(app)
 
     def ids(self, element: str) -> str:

--- a/webviz_subsurface/plugins/_parameter_parallel_coordinates.py
+++ b/webviz_subsurface/plugins/_parameter_parallel_coordinates.py
@@ -7,6 +7,7 @@ import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 
@@ -132,6 +133,7 @@ folder, to avoid risk of not extracting the right data.
     def __init__(
         self,
         app,
+        webviz_settings: WebvizSettings,
         ensembles: list = None,
         parameter_csv: Path = None,
         response_csv: Path = None,
@@ -185,9 +187,7 @@ folder, to avoid risk of not extracting the right data.
                 )
             self.emodel = EnsembleSetModel(
                 ensemble_paths={
-                    ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][
-                        ens
-                    ]
+                    ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                     for ens in ensembles
                 }
             )
@@ -236,7 +236,7 @@ folder, to avoid risk of not extracting the right data.
             lambda row: self.ensembles.index(row["ENSEMBLE"]), axis=1
         )
 
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
         self.set_callbacks(app)
 
     @property

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -11,6 +11,7 @@ import webviz_core_components as wcc
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.utils import calculate_slider_step
 
 from webviz_subsurface._models import EnsembleSetModel
@@ -120,6 +121,7 @@ folder, to avoid risk of not extracting the right data.
     def __init__(
         self,
         app,
+        webviz_settings: WebvizSettings,
         parameter_csv: Path = None,
         response_csv: Path = None,
         ensembles: list = None,
@@ -160,7 +162,7 @@ folder, to avoid risk of not extracting the right data.
 
         elif ensembles:
             self.ens_paths = {
-                ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+                ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                 for ens in ensembles
             }
             self.parameterdf = load_parameters(
@@ -202,7 +204,7 @@ folder, to avoid risk of not extracting the right data.
                 inplace=True,
             )
 
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.uid = uuid4()
         self.set_callbacks(app)
 

--- a/webviz_subsurface/plugins/_property_statistics/property_statistics.py
+++ b/webviz_subsurface/plugins/_property_statistics/property_statistics.py
@@ -4,6 +4,7 @@ import pathlib
 import dash
 import dash_core_components as dcc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config import WebvizConfigTheme
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 
@@ -82,6 +83,7 @@ folder, to avoid risk of not extracting the right data.
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         ensembles: Optional[list] = None,
         statistics_file: str = "share/results/tables/gridpropstatistics.csv",
         csvfile_statistics: pathlib.Path = None,
@@ -97,8 +99,7 @@ folder, to avoid risk of not extracting the right data.
             / "css"
             / "container.css"
         )
-        # TODO(Sigurd) fix this once we get a separate webviz_settings parameter
-        self.theme: WebvizConfigTheme = app.webviz_settings["theme"]
+        self.theme: WebvizConfigTheme = webviz_settings.theme
         self.time_index = time_index
         self.column_keys = column_keys
         self.statistics_file = statistics_file
@@ -110,9 +111,7 @@ folder, to avoid risk of not extracting the right data.
         if ensembles is not None:
             self.emodel = EnsembleSetModel(
                 ensemble_paths={
-                    ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][
-                        ens
-                    ]
+                    ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                     for ens in ensembles
                 }
             )

--- a/webviz_subsurface/plugins/_pvt_plot.py
+++ b/webviz_subsurface/plugins/_pvt_plot.py
@@ -15,6 +15,7 @@ import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from .._datainput.pvt_data import load_pvt_dataframe, load_pvt_csv
 
@@ -69,6 +70,7 @@ class PvtPlot(WebvizPluginABC):
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         ensembles: List[str],
         pvt_relative_file_path: str = None,
         read_from_init_file: bool = False,
@@ -78,13 +80,11 @@ class PvtPlot(WebvizPluginABC):
         super().__init__()
 
         self.ensemble_paths = {
-            ensemble: app.webviz_settings["shared_settings"]["scratch_ensembles"][
-                ensemble
-            ]
+            ensemble: webviz_settings.shared_settings["scratch_ensembles"][ensemble]
             for ensemble in ensembles
         }
 
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
 
         self.pvt_relative_file_path = pvt_relative_file_path
 

--- a/webviz_subsurface/plugins/_relative_permeability.py
+++ b/webviz_subsurface/plugins/_relative_permeability.py
@@ -11,6 +11,7 @@ from dash.exceptions import PreventUpdate
 import webviz_core_components as wcc
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from .._datainput.relative_permeability import load_satfunc, load_scal_recommendation
 from .._datainput.fmu_input import load_csv
@@ -86,6 +87,7 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
     def __init__(
         self,
         app,
+        webviz_settings: WebvizSettings,
         ensembles: list,
         relpermfile: str = None,
         scalfile: Path = None,
@@ -94,10 +96,10 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
 
         super().__init__()
         self.ens_paths = {
-            ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+            ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
             for ens in ensembles
         }
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.relpermfile = relpermfile
         if self.relpermfile is not None:
             self.satfunc = load_csv(ensemble_paths=self.ens_paths, csv_file=relpermfile)

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -13,6 +13,7 @@ import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC, EncodedFile
+from webviz_config import WebvizSettings
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 
@@ -126,6 +127,7 @@ folder, to avoid risk of not extracting the right data.
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         csvfile: Path = None,
         ensembles: list = None,
         obsfile: Path = None,
@@ -166,9 +168,7 @@ folder, to avoid risk of not extracting the right data.
         elif ensembles:
             self.emodel = EnsembleSetModel(
                 ensemble_paths={
-                    ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][
-                        ens
-                    ]
+                    ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                     for ens in ensembles
                 }
             )
@@ -224,7 +224,7 @@ folder, to avoid risk of not extracting the right data.
                 )
 
         self.ensembles = list(self.smry["ENSEMBLE"].unique())
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
         self.plot_options = options if options else {}
         self.plot_options["date"] = (
             str(self.plot_options.get("date"))

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -14,6 +14,7 @@ import dash_core_components as dcc
 from dash_table import DataTable
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 
@@ -123,6 +124,7 @@ folder, to avoid risk of not extracting the right data.
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         csvfile_smry: Path = None,
         csvfile_parameters: Path = None,
         ensembles: list = None,
@@ -154,9 +156,7 @@ folder, to avoid risk of not extracting the right data.
 
         elif ensembles:
             self.ens_paths = {
-                ensemble: app.webviz_settings["shared_settings"]["scratch_ensembles"][
-                    ensemble
-                ]
+                ensemble: webviz_settings.shared_settings["scratch_ensembles"][ensemble]
                 for ensemble in ensembles
             }
             self.emodel = EnsembleSetModel(ensemble_paths=self.ens_paths)
@@ -191,9 +191,11 @@ folder, to avoid risk of not extracting the right data.
         self.line_shape_fallback = set_simulation_line_shape_fallback(
             line_shape_fallback
         )
-        self.tornadoplot = TornadoPlot(app, parameters, allow_click=True)
+        self.tornadoplot = TornadoPlot(
+            app, webviz_settings, parameters, allow_click=True
+        )
         self.uid = uuid4()
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
         self.set_callbacks(app)
 
     def ids(self, element: str) -> str:

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -19,6 +19,8 @@ from dash.exceptions import PreventUpdate
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizConfigTheme
+from webviz_config import WebvizSettings
 
 from webviz_subsurface._models import EnsembleSetModel
 from .._abbreviations.reservoir_simulation import (
@@ -113,10 +115,11 @@ folder, to avoid risk of not extracting the right data.
     TABLE_STATISTICS: List[Tuple[str, dict]] = [("Group", {})] + table_statistics_base()
     ENSEMBLE_COLUMNS = ["REAL", "ENSEMBLE", "DATE"]
 
-    # pylint: disable=dangerous-default-value
+    # pylint: disable=dangerous-default-value, too-many-arguments
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         ensembles: list,
         fipfile: Path = None,
         initial_vector: str = "ROIP",
@@ -136,7 +139,7 @@ folder, to avoid risk of not extracting the right data.
             )
         self.emodel = EnsembleSetModel(
             ensemble_paths={
-                ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+                ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                 for ens in ensembles
             }
         )
@@ -219,7 +222,7 @@ folder, to avoid risk of not extracting the right data.
         self.fipdesc = (
             None if self.fipfile is None else get_fipdesc(self.fipfile, self.smry_cols)
         )
-        self.theme = app.webviz_settings["theme"]
+        self.theme = webviz_settings.theme
         self.line_shape_fallback = set_simulation_line_shape_fallback(
             line_shape_fallback
         )
@@ -885,7 +888,7 @@ def render_single_date_graph(
     mode: str,
     groupby: str,
     date: str,
-    theme: dict,
+    theme: WebvizConfigTheme,
     title: str,
     colors: dict,
 ) -> wcc.Graph:
@@ -1000,9 +1003,6 @@ def render_single_date_graph(
                 }
             )
 
-    # TODO(Sigurd) What is the type for theme variable here?
-    # Probably the assumption is that theme is of type WebvizConfigTheme but how should this
-    # type be propagated to the plugins?
     return wcc.Graph(
         figure={"data": traces, "layout": theme.create_themed_layout(layout)}  # type: ignore
     )

--- a/webviz_subsurface/plugins/_rft_plotter/rft_plotter.py
+++ b/webviz_subsurface/plugins/_rft_plotter/rft_plotter.py
@@ -10,6 +10,7 @@ from dash.dependencies import Input, Output, State
 import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 
@@ -100,9 +101,11 @@ forward_models.html?highlight=gendata_rft#MERGE_RFT_ERTOBS).
 
 """
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         csvfile_rft: Path = None,
         csvfile_rft_ert: Path = None,
         ensembles: Optional[List[str]] = None,
@@ -133,9 +136,7 @@ forward_models.html?highlight=gendata_rft#MERGE_RFT_ERTOBS).
         if ensembles:
             self.ens_paths = (
                 {
-                    ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][
-                        ens
-                    ]
+                    ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                     for ens in ensembles
                 }
                 if ensembles is not None

--- a/webviz_subsurface/plugins/_running_time_analysis_fmu.py
+++ b/webviz_subsurface/plugins/_running_time_analysis_fmu.py
@@ -11,6 +11,7 @@ from dash.dependencies import Input, Output
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from .._datainput.fmu_input import load_ensemble_set, load_parameters
 
@@ -64,6 +65,7 @@ blob/master/reek_history_match/realization-0/iter-0/status.json).
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         ensembles: list,
         filter_shorter: Union[int, float] = 10,
         status_file: str = "status.json",
@@ -72,10 +74,10 @@ blob/master/reek_history_match/realization-0/iter-0/status.json).
         super().__init__()
         self.filter_shorter = filter_shorter
         self.ens_paths = {
-            ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+            ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
             for ens in ensembles
         }
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.ensembles = ensembles
         self.status_file = status_file
         self.parameter_df = load_parameters(

--- a/webviz_subsurface/plugins/_segy_viewer.py
+++ b/webviz_subsurface/plugins/_segy_viewer.py
@@ -10,6 +10,7 @@ import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.webviz_store import webvizstore
 from webviz_config.utils import calculate_slider_step
 import numpy as np
@@ -43,6 +44,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         segyfiles: List[Path],
         zunit: str = "depth (m)",
         colors: list = None,
@@ -74,7 +76,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
         self.init_state.get("colorscale", self.initial_colors)
         self.init_state.get("uirevision", str(uuid4()))
         self.uid = uuid4()
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.set_callbacks(app)
 
     def ids(self, element: str) -> str:

--- a/webviz_subsurface/plugins/_subsurface_map.py
+++ b/webviz_subsurface/plugins/_subsurface_map.py
@@ -4,12 +4,12 @@ from uuid import uuid4
 from pathlib import Path
 
 import pandas as pd
-import dash
 import dash_html_components as html
 from webviz_subsurface_components import Map
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from .._datainput.fmu_input import scratch_ensemble
 
@@ -56,7 +56,7 @@ that you are reading the correct data.
 
     def __init__(
         self,
-        app: dash.Dash,
+        webviz_settings: WebvizSettings,
         jsonfile: Path = None,
         ensemble: str = None,
         map_value: str = None,
@@ -81,9 +81,9 @@ that you are reading the correct data.
             self.map_value = map_value
             self.flow_value = flow_value
             self.time_step = time_step
-            self.ensemble_path = app.webviz_settings["shared_settings"][
-                "scratch_ensembles"
-            ][ensemble]
+            self.ensemble_path = webviz_settings.shared_settings["scratch_ensembles"][
+                ensemble
+            ]
             self.map_data = get_map_data(
                 self.ensemble_path, self.map_value, self.flow_value, self.time_step
             )

--- a/webviz_subsurface/plugins/_surface_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_surface_viewer_fmu.py
@@ -17,6 +17,7 @@ import webviz_core_components as wcc
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 
 from webviz_subsurface._datainput.fmu_input import get_realizations, find_surfaces
 from webviz_subsurface._datainput.surface import make_surface_layer, load_surface
@@ -86,9 +87,11 @@ attribute_settings:
 
 """
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         ensembles: list,
         attributes: list = None,
         attribute_settings: dict = None,
@@ -99,7 +102,7 @@ attribute_settings:
 
         super().__init__()
         self.ens_paths = {
-            ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+            ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
             for ens in ensembles
         }
 

--- a/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
@@ -11,6 +11,7 @@ import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_subsurface_components import LeafletMap
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.webviz_store import webvizstore
 from webviz_config.utils import calculate_slider_step
 
@@ -58,6 +59,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
     def __init__(
         self,
         app,
+        webviz_settings: WebvizSettings,
         gridfile: Path,
         gridparameterfiles: List[Path],
         surfacefiles: List[Path],
@@ -91,7 +93,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             self.gridparanames = [
                 Path(gridfile).stem for gridfile in gridparameterfiles
             ]
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.initial_colors = (
             colors
             if colors is not None

--- a/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
@@ -11,6 +11,7 @@ import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_subsurface_components import LeafletMap
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.webviz_store import webvizstore
 from webviz_config.utils import calculate_slider_step
 
@@ -52,9 +53,11 @@ The surfacefiles are on a `ROFF binary` format and can be investigated outside `
 e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
 """
 
+    # pylint: disable=too-many-arguments
     def __init__(
         self,
         app,
+        webviz_settings: WebvizSettings,
         segyfiles: List[Path],
         surfacefiles: List[Path],
         surfacenames: list = None,
@@ -83,7 +86,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             self.segynames = segynames
         else:
             self.segynames = [Path(segyfile).stem for segyfile in segyfiles]
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.initial_colors = (
             colors
             if colors is not None

--- a/webviz_subsurface/plugins/_well_cross_section_fmu.py
+++ b/webviz_subsurface/plugins/_well_cross_section_fmu.py
@@ -16,6 +16,7 @@ import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_subsurface_components import LeafletMap
 from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 
@@ -80,6 +81,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
     def __init__(
         self,
         app: dash.Dash,
+        webviz_settings: WebvizSettings,
         ensembles: list,
         surfacefiles: list,
         surfacenames: list = None,
@@ -126,7 +128,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             self.surfacenames = surfacefiles
 
         self.ensembles = {
-            ens: app.webviz_settings["shared_settings"]["scratch_ensembles"][ens]
+            ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
             for ens in ensembles
         }
 
@@ -159,7 +161,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 "#17becf",  # blue-teal
             ]
         )
-        self.plotly_theme = app.webviz_settings["theme"].plotly_theme
+        self.plotly_theme = webviz_settings.theme.plotly_theme
         self.colors = self.plotly_theme["layout"]["colorway"]
         self.uid = uuid4()
         self.set_callbacks(app)


### PR DESCRIPTION
Refactor to use new new special `webviz_settings` argument for common settings in favor of the existing solution which piggybacks a dictionary onto the to the Dash applicaton object.

This PR is related to https://github.com/equinor/webviz-config/pull/368 which actually implements the new setting scheme in `webviz-config`.

Bumped the required `webviz-config` version to 0.2.7

---

### Contributor checklist

- [x] :tada: This PR closes #535
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
