### PR TITLE
Avoid mutating and duplicating smry data in SimulationTimeSeriesModels

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         # https://github.com/actions/virtual-environments/issues/751
         # https://github.com/actions/virtual-environments/issues/709
-        sudo apt-get purge p7zip* yarn ruby-full adoptopenjdk* ghc* php7*
+        sudo apt-get purge p7zip* yarn ruby-full ghc* php7*
         sudo apt-get autoremove
         sudo apt-get clean
         df -h

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         # "ecl2df>=0.6.1; sys_platform=='linux'",
         "fmu-ensemble>=1.2.3",
         # "opm>=2020.10.1; sys_platform=='linux'",
-        "pandas>=1.1.5",
+        "pandas==1.2.1",
         "pillow>=6.1",
         "pyscal>=0.7.2",
         "scipy>=1.2",

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,9 @@ setup(
         # "ecl2df>=0.6.1; sys_platform=='linux'",
         "fmu-ensemble>=1.2.3",
         # "opm>=2020.10.1; sys_platform=='linux'",
-        "pandas<= 1.2.1",
+        "pandas>=1.1.5",
         "pillow>=6.1",
-        "pyscal>=0.7.2",
+        "pyscal>=0.7.5",
         "scipy>=1.2",
         "statsmodels>=0.12.1",  # indirect dependency through https://plotly.com/python/linear-fits/
         "webviz-config>=0.2.7",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         # "ecl2df>=0.6.1; sys_platform=='linux'",
         "fmu-ensemble>=1.2.3",
         # "opm>=2020.10.1; sys_platform=='linux'",
-        "pandas==1.2.1",
+        "pandas<= 1.2.1",
         "pillow>=6.1",
         "pyscal>=0.7.2",
         "scipy>=1.2",

--- a/webviz_subsurface/plugins/_parameter_analysis/models/simulation_timeseries_model.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/models/simulation_timeseries_model.py
@@ -1,18 +1,16 @@
-from typing import Optional, Union
+from typing import List, Dict, Optional, Iterable, Tuple
 
 from itertools import chain
 import pandas as pd
 from webviz_config.common_cache import CACHE
 
 from webviz_subsurface._abbreviations.reservoir_simulation import (
-    simulation_vector_description,
     historical_vector,
 )
 from webviz_subsurface._utils.simulation_timeseries import (
     set_simulation_line_shape_fallback,
     get_simulation_line_shape,
 )
-from ..utils.colors import hex_to_rgb
 
 
 class SimulationTimeSeriesModel:
@@ -21,56 +19,81 @@ class SimulationTimeSeriesModel:
     def __init__(
         self,
         dataframe: pd.DataFrame,
-        theme: dict = None,
         metadata: Optional[pd.DataFrame] = None,
         line_shape_fallback: str = "linear",
     ) -> None:
+
+        for column in ["ENSEMBLE", "REAL", "DATE"]:
+            if column not in dataframe.columns:
+                raise KeyError(f"{column} column is missing from UNSMRY data")
+
         self._dataframe = dataframe
-        self._prepare_and_validate_data()
-        self.theme = theme
         self._metadata = metadata
         self.line_shape_fallback = set_simulation_line_shape_fallback(
             line_shape_fallback
         )
-        self._vectors = [
+
+        self._vector_names = SimulationTimeSeriesModel._determine_vector_names(
+            self._dataframe, self._metadata
+        )
+        # Strip out vector names where all data is 0
+        self._vector_names = (
+            SimulationTimeSeriesModel._filter_vector_names_discard_0_columns(
+                self._vector_names, self._dataframe
+            )
+        )
+
+        self._vector_groups = SimulationTimeSeriesModel._split_vectors_by_type(
+            self._vector_names
+        )
+
+        self._dates = sorted(self._dataframe["DATE"].unique().astype(str))
+
+        # Currently we cannot be sure what data type the DATE column has.
+        # Apparently it will have datetime if the source is SMRY files, but
+        # may be of type str if the source is CSV files.
+        # Try and detect if the data type is string by sampling the first entry
+        sample_date = self._dataframe["DATE"].iloc[0]
+        self._date_column_is_str = isinstance(sample_date, str)
+
+    @staticmethod
+    def _determine_vector_names(
+        dataframe: pd.DataFrame, metadata: Optional[pd.DataFrame]
+    ) -> List[str]:
+        """Determine which vectors we should make available"""
+        vecnames = [
             c
-            for c in self.dataframe.columns
+            for c in dataframe.columns
             if c not in ["REAL", "ENSEMBLE", "DATE"]
-            and not historical_vector(c, self.metadata, False) in self.dataframe.columns
+            and not historical_vector(c, metadata, False) in dataframe.columns
         ]
-        self._vector_groups = self._split_vectors_by_type()
-        self._dates = sorted(self._dataframe["DATE"].unique())
+        return vecnames
 
-    def _prepare_and_validate_data(self) -> None:
-        for column in ["ENSEMBLE", "REAL", "DATE"]:
-            if column not in self.dataframe.columns:
-                raise KeyError(f"{column} column is missing from UNSMRY data")
-        self.dataframe["DATE"] = self.dataframe["DATE"].astype(str)
+    @staticmethod
+    def _filter_vector_names_discard_0_columns(
+        vector_names: Iterable[str], dataframe: pd.DataFrame
+    ) -> List[str]:
+        """Filter list of vector names by removing vector names where the data is all zeros"""
+        non_zero_column_mask = (dataframe != 0).any(axis=0)
+        non_zero_column_names = set(dataframe.columns[non_zero_column_mask])
+        filtered_vecnames = [n for n in vector_names if n in non_zero_column_names]
+        return filtered_vecnames
 
-        # drop columns with only 0 values
-        self._dataframe = self._dataframe.loc[:, (self._dataframe != 0).any(axis=0)]
-
-        self._drop_last_date_if_empty()
-
-    def _drop_last_date_if_empty(self):
-        last_date = self.dataframe["DATE"].max()
-        if self.dataframe[self.dataframe["DATE"] == last_date]["FOPR"].mean() == 0:
-            self._dataframe = self.dataframe[~(self.dataframe["DATE"] == last_date)]
-
-    def _split_vectors_by_type(self):
+    @staticmethod
+    def _split_vectors_by_type(vector_names: Iterable[str]) -> Dict[str, dict]:
         vtypes = ["Field", "Well", "Region", "Block", "Group", "Connection"]
         vgroups = {}
         for vtype in vtypes:
-            vectors = [v for v in self.vectors if v.startswith(vtype[0])]
+            vectors = [v for v in vector_names if v.startswith(vtype[0])]
             if vectors:
-                shortnames, items = self._vector_subitems(vectors)
+                shortnames, items = SimulationTimeSeriesModel._vector_subitems(vectors)
                 vgroups[vtype] = dict(
                     vectors=vectors, shortnames=shortnames, items=items
                 )
 
         other_vectors = [
             x
-            for x in self.vectors
+            for x in vector_names
             if x
             not in list(
                 chain.from_iterable([vgroups[vtype]["vectors"] for vtype in vgroups])
@@ -82,7 +105,7 @@ class SimulationTimeSeriesModel:
         return vgroups
 
     @staticmethod
-    def _vector_subitems(vectors):
+    def _vector_subitems(vectors: Iterable[str]) -> Tuple[List[str], List[str]]:
         shortnames = {v.split(":")[0] for v in vectors}
         items = {":".join(v.split(":")[1:]) for v in vectors if len(v.split(":")) > 1}
 
@@ -91,124 +114,44 @@ class SimulationTimeSeriesModel:
         )
 
     @property
-    def colors(self) -> dict:
-        try:
-            return self.theme.plotly_theme["layout"]["colorway"]
-        except KeyError:
-            return self.theme.plotly_theme.get(
-                "colorway",
-                [
-                    "#243746",
-                    "#eb0036",
-                    "#919ba2",
-                    "#7d0023",
-                    "#66737d",
-                    "#4c9ba1",
-                    "#a44c65",
-                    "#80b7bc",
-                    "#ff1243",
-                    "#919ba2",
-                    "#be8091",
-                    "#b2d4d7",
-                    "#ff597b",
-                    "#bdc3c7",
-                    "#d8b2bd",
-                    "#ffe7d6",
-                    "#d5eaf4",
-                    "#ff88a1",
-                ],
-            )
-
-    @property
-    def dataframe(self) -> pd.DataFrame:
-        return self._dataframe
-
-    @property
-    def dates(self) -> pd.DataFrame:
+    def dates(self) -> List[str]:
         return self._dates
 
     @property
-    def metadata(self) -> pd.DataFrame:
-        return self._metadata
+    def vectors(self) -> List[str]:
+        return self._vector_names
 
     @property
-    def vectors(self):
-        return self._vectors
-
-    @property
-    def vector_groups(self):
+    def vector_groups(self) -> Dict[str, dict]:
         return self._vector_groups
 
     @property
-    def ens_colors(self) -> dict:
-        return {ens: self.colors[self.ensembles.index(ens)] for ens in self.ensembles}
-
-    @property
-    def dropdown_options(self) -> list:
-        return [
-            {"label": f"{simulation_vector_description(vec)} ({vec})", "value": vec}
-            for vec in self.vectors
-        ]
-
-    @property
-    def ensembles(self) -> list:
-        return list(self.dataframe["ENSEMBLE"].unique())
+    def ensembles(self) -> List[str]:
+        return list(self._dataframe["ENSEMBLE"].unique())
 
     def get_line_shape(self, vector: str) -> str:
         return get_simulation_line_shape(
             line_shape_fallback=self.line_shape_fallback,
             vector=vector,
-            smry_meta=self.metadata,
+            smry_meta=self._metadata,
         )
 
     def get_ensemble_vectors_for_date(
         self, ensemble: str, date: str, vectors: list = None
     ) -> pd.DataFrame:
-        vectors = vectors if vectors is not None else self.vectors
-        return self.dataframe[vectors + ["REAL"]].loc[
-            (self.dataframe["ENSEMBLE"] == ensemble) & (self.dataframe["DATE"] == date)
+        vectors = vectors if vectors is not None else self._vector_names
+
+        # If the data type of the DATE column is string, use the passed date argument
+        # directly. Otherwise convert to datetime before doing query
+        query_date = date if self._date_column_is_str else pd.to_datetime(date)
+        df = self._dataframe.loc[
+            (self._dataframe["ENSEMBLE"] == ensemble)
+            & (self._dataframe["DATE"] == query_date),
+            vectors + ["REAL"],
         ]
+        return df
 
-    @CACHE.memoize(timeout=CACHE.TIMEOUT)
-    def add_statistic_traces(self, ensembles: list, vector: str) -> list:
-        """Calculate statistics for a given vector for relevant ensembles"""
-        quantiles = [10, 90]
-        traces = []
-        ensembles = ensembles if isinstance(ensembles, list) else [ensembles]
-        dataframe = self.dataframe[self.dataframe["ENSEMBLE"].isin(ensembles)]
-        for ensemble, ens_df in dataframe.groupby("ENSEMBLE"):
-            dframe = ens_df.drop(columns=["ENSEMBLE", "REAL"]).groupby("DATE")
-
-            # Build a dictionary of dataframes to be concatenated
-            dframes = {}
-            dframes["mean"] = dframe.mean()
-            for quantile in quantiles:
-                quantile_str = "p" + str(quantile)
-                dframes[quantile_str] = dframe.quantile(q=quantile / 100.0)
-            dframes["maximum"] = dframe.max()
-            dframes["minimum"] = dframe.min()
-            traces.extend(
-                add_fanchart_traces(
-                    pd.concat(dframes, names=["STATISTIC"], sort=False)[vector],
-                    self.ens_colors.get(
-                        ensemble, self.ens_colors[list(self.ens_colors.keys())[0]]
-                    ),
-                    ensemble,
-                    self.get_line_shape(vector),
-                )
-            )
-        if (
-            historical_vector(vector=vector, smry_meta=self.metadata)
-            in dataframe.columns
-        ):
-            traces.append(
-                self.add_history_trace(
-                    dataframe, historical_vector(vector=vector, smry_meta=self.metadata)
-                )
-            )
-        return traces
-
-    def add_history_trace(self, dframe: pd.DataFrame, vector: str) -> dict:
+    def _add_history_trace(self, dframe: pd.DataFrame, vector: str) -> dict:
         """Renders the history line"""
         df = dframe.loc[
             (dframe["REAL"] == dframe["REAL"].unique()[0])
@@ -216,7 +159,7 @@ class SimulationTimeSeriesModel:
         ]
         return {
             "line": {"shape": self.get_line_shape(vector)},
-            "x": df["DATE"],
+            "x": df["DATE"].astype(str),
             "y": df[vector],
             "hovertext": "History",
             "hoverinfo": "y+x+text",
@@ -226,49 +169,11 @@ class SimulationTimeSeriesModel:
         }
 
     @CACHE.memoize(timeout=CACHE.TIMEOUT)
-    def add_ensset_realization_traces(
-        self, ensembles: Union[str, list], vector: str
-    ) -> list:
-        """Renders line trace for each realization grouped by ensemble,
-        includes history line if present"""
-        ensembles = ensembles if isinstance(ensembles, list) else [ensembles]
-        dataframe = self.dataframe[self.dataframe["ENSEMBLE"].isin(ensembles)]
-        traces = [
-            {
-                "line": {"shape": self.get_line_shape(vector)},
-                "x": list(real_df["DATE"]),
-                "y": list(real_df[vector]),
-                "hovertext": f"Realization: {real}, Ensemble: {ensemble}",
-                "name": ensemble,
-                "legendgroup": ensemble,
-                "marker": {
-                    "color": self.ens_colors.get(
-                        ensemble, self.ens_colors[list(self.ens_colors.keys())[0]]
-                    )
-                },
-                "showlegend": real_idx == 0,
-            }
-            for ens_no, (ensemble, ens_df) in enumerate(dataframe.groupby("ENSEMBLE"))
-            for real_idx, (real, real_df) in enumerate(ens_df.groupby("REAL"))
-        ]
-
-        if (
-            historical_vector(vector=vector, smry_meta=self.metadata)
-            in dataframe.columns
-        ):
-            traces.append(
-                self.add_history_trace(
-                    dataframe, historical_vector(vector=vector, smry_meta=self.metadata)
-                )
-            )
-        return traces
-
-    @CACHE.memoize(timeout=CACHE.TIMEOUT)
     def add_realization_traces(
         self, ensemble: str, vector: str, real_filter: pd.Series = None
     ) -> list:
         """Renders line trace for each realization, includes history line if present"""
-        dataframe = self.dataframe[self.dataframe["ENSEMBLE"] == ensemble]
+        dataframe = self._dataframe[self._dataframe["ENSEMBLE"] == ensemble]
         dataframe = (
             dataframe[dataframe["REAL"].isin(real_filter)]
             if real_filter is not None
@@ -277,7 +182,7 @@ class SimulationTimeSeriesModel:
         traces = [
             {
                 "line": {"shape": self.get_line_shape(vector)},
-                "x": list(real_df["DATE"]),
+                "x": list(real_df["DATE"].astype(str)),
                 "y": list(real_df[vector]),
                 "name": ensemble,
                 "customdata": real,
@@ -288,86 +193,17 @@ class SimulationTimeSeriesModel:
             for real_idx, (real, real_df) in enumerate(dataframe.groupby("REAL"))
         ]
 
-        if (
-            historical_vector(vector=vector, smry_meta=self.metadata)
-            in dataframe.columns
-        ):
+        hist_vecname = historical_vector(vector=vector, smry_meta=self._metadata)
+        if hist_vecname and hist_vecname in dataframe.columns:
             traces.append(
-                self.add_history_trace(
-                    dataframe, historical_vector(vector=vector, smry_meta=self.metadata)
+                self._add_history_trace(
+                    dataframe,
+                    hist_vecname,
                 )
             )
+
         return traces
 
-    def daterange_for_plot(self, vector: str):
-        date = self.dataframe["DATE"][self.dataframe[vector] != 0]
-        return [date.min(), date.max()]
-
-
-def add_fanchart_traces(
-    vector_stats: pd.DataFrame, color: str, legend_group: str, line_shape
-) -> list:
-    """Renders a fanchart for an ensemble vector"""
-
-    fill_color = hex_to_rgb(color, 0.3)
-    line_color = hex_to_rgb(color, 1)
-    return [
-        {
-            "name": legend_group,
-            "hovertext": "Maximum",
-            "x": vector_stats["maximum"].index.tolist(),
-            "y": vector_stats["maximum"].values,
-            "mode": "lines",
-            "line": {"width": 0, "color": line_color, "shape": line_shape},
-            "legendgroup": legend_group,
-            "showlegend": False,
-        },
-        {
-            "name": legend_group,
-            "hovertext": "P10",
-            "x": vector_stats["p10"].index.tolist(),
-            "y": vector_stats["p10"].values,
-            "mode": "lines",
-            "fill": "tonexty",
-            "fillcolor": fill_color,
-            "line": {"width": 0, "color": line_color, "shape": line_shape},
-            "legendgroup": legend_group,
-            "showlegend": False,
-        },
-        {
-            "name": legend_group,
-            "hovertext": "Mean",
-            "x": vector_stats["mean"].index.tolist(),
-            "y": vector_stats["mean"].values,
-            "mode": "lines",
-            "fill": "tonexty",
-            "fillcolor": fill_color,
-            "line": {"color": line_color, "shape": line_shape},
-            "legendgroup": legend_group,
-            "showlegend": True,
-        },
-        {
-            "name": legend_group,
-            "hovertext": "P90",
-            "x": vector_stats["p90"].index.tolist(),
-            "y": vector_stats["p90"].values,
-            "mode": "lines",
-            "fill": "tonexty",
-            "fillcolor": fill_color,
-            "line": {"width": 0, "color": line_color, "shape": line_shape},
-            "legendgroup": legend_group,
-            "showlegend": False,
-        },
-        {
-            "name": legend_group,
-            "hovertext": "Minimum",
-            "x": vector_stats["minimum"].index.tolist(),
-            "y": vector_stats["minimum"].values,
-            "mode": "lines",
-            "fill": "tonexty",
-            "fillcolor": fill_color,
-            "line": {"width": 0, "color": line_color, "shape": line_shape},
-            "legendgroup": legend_group,
-            "showlegend": False,
-        },
-    ]
+    def daterange_for_plot(self, vector: str) -> List[str]:
+        date = self._dataframe["DATE"][self._dataframe[vector] != 0]
+        return [str(date.min()), str(date.max())]

--- a/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
@@ -112,7 +112,6 @@ slow for large models.
                 dataframe=self.emodel.load_smry(
                     time_index=self.time_index, column_keys=self.column_keys
                 ),
-                theme=self.theme,
             )
 
         elif self.csvfile_parameters is None:
@@ -125,7 +124,7 @@ slow for large models.
             )
             if self.csvfile_smry is not None:
                 self.vmodel = SimulationTimeSeriesModel(
-                    dataframe=read_csv(csvfile_smry), theme=self.theme.plotly_theme
+                    dataframe=read_csv(csvfile_smry)
                 )
             else:
                 self.vmodel = None


### PR DESCRIPTION
This PR implements changes to `SimulationTimeSeriesModel` for both the `ParameterAnalysis` and `PropertyStatistics` plugins. Note that these two plugins do not currently share the model. There exists two relatively similar models.

This PR is related to issue https://github.com/equinor/webviz-subsurface/issues/545 as it resolves some of the underlying issues that causes mutation and/or duplication smry dataframes.

**For `SimulationTimeSeriesModel` in `ParameterAnalysis`:**
Refactored the model to avoid mutating the input smry dataframe and to avoid memory duplication. Removed unused code in preparation for a redesign of the public interface and subsequent consolidation with "near copy" of SimulationTimeSeriesModel that resides within PropertyStatistics.
For now, the part of the public interface that is actually in use has been kept unchanged. Note that previously this model dropped the last date if it was empty. This is no longer the case

**For `SimulationTimeSeriesModel` in `PropertyStatistics`:**
Refactored the model to avoid mutating the input smry dataframe (date to str conversion)

Due to unrelated issues also removed uninstall of `adoptopenjdk*` package for github action as well as bumping required version of `pyscal` to 0.7.5

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
