### PR TITLE
Experimental pyarrow backed interface for accessing (smry) time series data

### DIFF
--- a/tests/unit_tests/model_tests/test_ensemble_time_series.py
+++ b/tests/unit_tests/model_tests/test_ensemble_time_series.py
@@ -1,0 +1,113 @@
+from typing import Dict
+from pathlib import Path
+
+from webviz_subsurface._models.ensemble_time_series_factory import (
+    EnsembleTimeSeriesFactory,
+)
+from webviz_subsurface._models.ensemble_time_series_factory import BackingType
+
+BACKING_TYPE: BackingType = BackingType.ARROW
+
+
+# -------------------------------------------------------------------------
+def test_create_from_aggregated_csv(testdata_folder: Path, tmp_path: Path) -> None:
+
+    factory = EnsembleTimeSeriesFactory(tmp_path, BACKING_TYPE)
+
+    csv_filename = testdata_folder / "aggregated_data" / "smry_hm.csv"
+    tsset = factory.create_time_series_set_from_aggregated_csv_file(csv_filename)
+    assert tsset.ensemble_names() == ["iter-0", "iter-3"]
+
+    ts = tsset.ensemble("iter-0")
+    vecnames = ts.vector_names()
+    assert len(vecnames) == 473
+    assert vecnames[0] == "BPR:15,28,1"
+    assert vecnames[472] == "YEARS"
+
+    realizations = ts.realizations()
+    assert len(realizations) == 10
+
+    vecdf = ts.get_vectors_df(["FOPR"])
+    assert vecdf.shape == (380, 3)
+    assert vecdf.columns.tolist() == ["DATE", "REAL", "FOPR"]
+    assert vecdf["REAL"].nunique() == 10
+
+    vecdf = ts.get_vectors_df(["FOPR"], [1])
+    assert vecdf.shape == (38, 3)
+    assert vecdf.columns.tolist() == ["DATE", "REAL", "FOPR"]
+    assert vecdf["REAL"].nunique() == 1
+
+
+# -------------------------------------------------------------------------
+def test_create_from_per_realization_csv_files(
+    testdata_folder: Path, tmp_path: Path
+) -> None:
+
+    factory = EnsembleTimeSeriesFactory(tmp_path, BACKING_TYPE)
+
+    ensembles: Dict[str, str] = {
+        "iter-0": str(testdata_folder / "reek_history_match/realization-*/iter-0"),
+        "iter-1": str(testdata_folder / "reek_history_match/realization-*/iter-1"),
+        "iter-2": str(testdata_folder / "reek_history_match/realization-*/iter-2"),
+        "iter-3": str(testdata_folder / "reek_history_match/realization-*/iter-3"),
+    }
+    csvfile = "share/results/tables/unsmry--monthly.csv"
+
+    tsset = factory.create_time_series_set_from_per_realization_csv_files(
+        ensembles, csvfile
+    )
+    assert tsset.ensemble_names() == ["iter-0", "iter-1", "iter-2", "iter-3"]
+
+    ts = tsset.ensemble("iter-0")
+    vecnames = ts.vector_names()
+    assert len(vecnames) == 473
+    assert vecnames[0] == "BPR:15,28,1"
+    assert vecnames[472] == "YEARS"
+
+    realizations = ts.realizations()
+    assert len(realizations) == 10
+
+    vecdf = ts.get_vectors_df(["FOPR"])
+    assert vecdf.shape == (380, 3)
+    assert vecdf.columns.tolist() == ["DATE", "REAL", "FOPR"]
+    assert vecdf["REAL"].nunique() == 10
+
+    vecdf = ts.get_vectors_df(["FOPR"], [1])
+    assert vecdf.shape == (38, 3)
+    assert vecdf.columns.tolist() == ["DATE", "REAL", "FOPR"]
+    assert vecdf["REAL"].nunique() == 1
+
+
+# -------------------------------------------------------------------------
+def test_create_from_ensemble_smry(testdata_folder: Path, tmp_path: Path) -> None:
+
+    factory = EnsembleTimeSeriesFactory(tmp_path, BACKING_TYPE)
+
+    ensembles: Dict[str, str] = {
+        "iter-0": str(testdata_folder / "reek_history_match/realization-*/iter-0"),
+        "iter-1": str(testdata_folder / "reek_history_match/realization-*/iter-1"),
+        "iter-2": str(testdata_folder / "reek_history_match/realization-*/iter-2"),
+        "iter-3": str(testdata_folder / "reek_history_match/realization-*/iter-3"),
+    }
+
+    tsset = factory.create_time_series_set_from_ensemble_smry(ensembles, "monthly")
+    assert tsset.ensemble_names() == ["iter-0", "iter-1", "iter-2", "iter-3"]
+
+    ts = tsset.ensemble("iter-0")
+    vecnames = ts.vector_names()
+    assert len(vecnames) == 473
+    assert vecnames[0] == "BPR:15,28,1"
+    assert vecnames[472] == "YEARS"
+
+    realizations = ts.realizations()
+    assert len(realizations) == 10
+
+    vecdf = ts.get_vectors_df(["FOPR"])
+    assert vecdf.shape == (380, 3)
+    assert vecdf.columns.tolist() == ["DATE", "REAL", "FOPR"]
+    assert vecdf["REAL"].nunique() == 10
+
+    vecdf = ts.get_vectors_df(["FOPR"], [1])
+    assert vecdf.shape == (38, 3)
+    assert vecdf.columns.tolist() == ["DATE", "REAL", "FOPR"]
+    assert vecdf["REAL"].nunique() == 1

--- a/tests/unit_tests/model_tests/test_ensemble_time_series_impl.py
+++ b/tests/unit_tests/model_tests/test_ensemble_time_series_impl.py
@@ -1,0 +1,128 @@
+from typing import Optional, Literal
+from pathlib import Path
+from datetime import datetime
+
+import pandas as pd
+
+from webviz_subsurface._models.ensemble_time_series import (
+    EnsembleTimeSeries,
+)
+from webviz_subsurface._models.ensemble_time_series_impl_inmem_dataframe import (
+    EnsembleTimeSeriesImplInMemDataFrame,
+)
+from webviz_subsurface._models.ensemble_time_series_impl_arrow import (
+    EnsembleTimeSeriesImplArrow,
+)
+from webviz_subsurface._models.ensemble_time_series_impl_naive_parquet import (
+    EnsembleTimeSeriesImplNaiveParquet,
+)
+
+
+# -------------------------------------------------------------------------
+def _create_synthetic_time_series_obj(storage_dir: Path) -> EnsembleTimeSeries:
+    # fmt: off
+    INPUT_DATA = [
+        ["DATE",                "REAL",  "A",   "B"], 
+        [datetime(2021, 12, 20), 0,      1.0, 11.0 ], 
+        [datetime(2021, 12, 21), 0,      2.0, 12.0 ], 
+        [datetime(2021, 12, 22), 0,      3.0, 13.0 ], 
+        [datetime(2021, 12, 20), 1,      4.0, 14.0 ], 
+        [datetime(2021, 12, 21), 1,      5.0, 15.0 ], 
+        [datetime(2021, 12, 22), 1,      6.0, 16.0 ], 
+        [datetime(2021, 12, 23), 1,      7.0, 17.0 ], 
+    ] 
+    # fmt: on
+
+    impl_to_use: Literal["inmem", "arrow", "parquet"] = "arrow"
+
+    input_df = pd.DataFrame(INPUT_DATA[1:], columns=INPUT_DATA[0])
+    ts: Optional[EnsembleTimeSeries]
+
+    if impl_to_use == "inmem":
+        ts = EnsembleTimeSeriesImplInMemDataFrame(input_df)
+
+    elif impl_to_use == "arrow":
+        EnsembleTimeSeriesImplArrow.write_backing_store_from_ensemble_dataframe(
+            storage_dir, "dummy_key", input_df
+        )
+        ts = EnsembleTimeSeriesImplArrow.from_backing_store(storage_dir, "dummy_key")
+
+    elif impl_to_use == "parquet":
+        EnsembleTimeSeriesImplNaiveParquet.write_backing_store_from_ensemble_dataframe(
+            storage_dir, "dummy_key", input_df
+        )
+        ts = EnsembleTimeSeriesImplNaiveParquet.from_backing_store(
+            storage_dir, "dummy_key"
+        )
+
+    if not ts:
+        raise ValueError("Failed to create EnsembleTimeSeries")
+
+    return ts
+
+
+# -------------------------------------------------------------------------
+def test_get_metadata(tmp_path: Path) -> None:
+
+    ts = _create_synthetic_time_series_obj(tmp_path)
+
+    all_vecnames = ts.vector_names()
+    assert len(all_vecnames) == 2
+    assert all_vecnames == ["A", "B"]
+
+    all_realizations = ts.realizations()
+    assert len(all_realizations) == 2
+
+    all_dates = ts.dates()
+    assert len(all_dates) == 4
+
+    r0_dates = ts.dates([0])
+    r1_dates = ts.dates([1])
+    assert len(r0_dates) == 3
+    assert len(r1_dates) == 4
+
+
+# -------------------------------------------------------------------------
+def test_get_vectors(tmp_path: Path) -> None:
+
+    ts = _create_synthetic_time_series_obj(tmp_path)
+
+    all_vecnames = ts.vector_names()
+    assert len(all_vecnames) == 2
+    assert all_vecnames == ["A", "B"]
+
+    valdf = ts.get_vectors_df(["A"])
+    assert valdf.shape == (7, 3)
+    assert valdf.columns.tolist() == ["DATE", "REAL", "A"]
+
+    valdf = ts.get_vectors_df(["A"], [1])
+    assert valdf.shape == (4, 3)
+    assert valdf.columns.tolist() == ["DATE", "REAL", "A"]
+
+    valdf = ts.get_vectors_df(["B", "A"], [0])
+    assert valdf.shape == (3, 4)
+    assert valdf.columns.tolist() == ["DATE", "REAL", "B", "A"]
+
+
+# -------------------------------------------------------------------------
+def test_synthetic_get_vectors_for_date(tmp_path: Path) -> None:
+
+    ts = _create_synthetic_time_series_obj(tmp_path)
+
+    all_dates = ts.dates()
+    assert len(all_dates) == 4
+
+    date_to_get = all_dates[0]
+    valdf = ts.get_vectors_for_date_df(date_to_get, ["A", "B"])
+    assert valdf.shape == (2, 3)
+    assert valdf.columns.tolist() == ["REAL", "A", "B"]
+
+    date_to_get = all_dates[0]
+    valdf = ts.get_vectors_for_date_df(date_to_get, ["A", "B"], [0])
+    assert valdf.shape == (1, 3)
+    assert valdf.columns.tolist() == ["REAL", "A", "B"]
+
+    date_to_get = all_dates[0]
+    valdf = ts.get_vectors_for_date_df(date_to_get, ["A", "B"], [0])
+    assert valdf.shape == (1, 3)
+    assert valdf.columns.tolist() == ["REAL", "A", "B"]

--- a/tests/unit_tests/model_tests/test_ensemble_time_series_impl.py
+++ b/tests/unit_tests/model_tests/test_ensemble_time_series_impl.py
@@ -22,14 +22,14 @@ from webviz_subsurface._models.ensemble_time_series_impl_naive_parquet import (
 def _create_synthetic_time_series_obj(storage_dir: Path) -> EnsembleTimeSeries:
     # fmt: off
     INPUT_DATA = [
-        ["DATE",                "REAL",  "A",   "B"], 
-        [datetime(2021, 12, 20), 0,      1.0, 11.0 ], 
-        [datetime(2021, 12, 21), 0,      2.0, 12.0 ], 
-        [datetime(2021, 12, 22), 0,      3.0, 13.0 ], 
-        [datetime(2021, 12, 20), 1,      4.0, 14.0 ], 
-        [datetime(2021, 12, 21), 1,      5.0, 15.0 ], 
-        [datetime(2021, 12, 22), 1,      6.0, 16.0 ], 
-        [datetime(2021, 12, 23), 1,      7.0, 17.0 ], 
+        ["DATE",                "REAL",  "A",   "B",  "C",   "Z"], 
+        [datetime(2021, 12, 20), 0,      1.0,  11.0,  1.0,  0.0 ], 
+        [datetime(2021, 12, 21), 0,      2.0,  12.0,  1.0,  0.0 ], 
+        [datetime(2021, 12, 22), 0,      3.0,  13.0,  1.0,  0.0 ], 
+        [datetime(2021, 12, 20), 1,      4.0,  14.0,  1.0,  0.0 ], 
+        [datetime(2021, 12, 21), 1,      5.0,  15.0,  1.0,  0.0 ], 
+        [datetime(2021, 12, 22), 1,      6.0,  16.0,  1.0,  0.0 ], 
+        [datetime(2021, 12, 23), 1,      7.0,  17.0,  1.0,  0.0 ], 
     ] 
     # fmt: on
 
@@ -67,8 +67,18 @@ def test_get_metadata(tmp_path: Path) -> None:
     ts = _create_synthetic_time_series_obj(tmp_path)
 
     all_vecnames = ts.vector_names()
-    assert len(all_vecnames) == 2
-    assert all_vecnames == ["A", "B"]
+    assert len(all_vecnames) == 4
+    assert all_vecnames == ["A", "B", "C", "Z"]
+
+    non_const_vec_names = ts.vector_names_filtered_by_value(
+        exclude_constant_values=True
+    )
+    assert len(non_const_vec_names) == 2
+    assert non_const_vec_names == ["A", "B"]
+
+    non_zero_vec_names = ts.vector_names_filtered_by_value(exclude_all_values_zero=True)
+    assert len(non_zero_vec_names) == 3
+    assert non_zero_vec_names == ["A", "B", "C"]
 
     all_realizations = ts.realizations()
     assert len(all_realizations) == 2
@@ -88,8 +98,7 @@ def test_get_vectors(tmp_path: Path) -> None:
     ts = _create_synthetic_time_series_obj(tmp_path)
 
     all_vecnames = ts.vector_names()
-    assert len(all_vecnames) == 2
-    assert all_vecnames == ["A", "B"]
+    assert len(all_vecnames) == 4
 
     valdf = ts.get_vectors_df(["A"])
     assert valdf.shape == (7, 3)

--- a/webviz_subsurface/_models/ensemble_time_series.py
+++ b/webviz_subsurface/_models/ensemble_time_series.py
@@ -1,0 +1,26 @@
+from typing import List, Dict, Optional, Sequence
+import datetime
+import abc
+
+import pandas as pd
+
+
+# fmt: off
+
+class EnsembleTimeSeries(abc.ABC):
+    @abc.abstractmethod
+    def vector_names(self) -> List[str]: ...
+
+    @abc.abstractmethod
+    def realizations(self) -> List[int]: ...
+
+    @abc.abstractmethod
+    def dates(self, realizations: Optional[Sequence[int]] = None) -> List[datetime.datetime]: ...
+
+    @abc.abstractmethod
+    def get_vectors_df(self, vector_names: Sequence[str], realizations: Optional[Sequence[int]] = None) -> pd.DataFrame: ...
+
+    @abc.abstractmethod
+    def get_vectors_for_date_df(self, date: datetime.datetime, vector_names: Sequence[str], realizations: Optional[Sequence[int]] = None) -> pd.DataFrame: ...
+
+# fmt: on

--- a/webviz_subsurface/_models/ensemble_time_series.py
+++ b/webviz_subsurface/_models/ensemble_time_series.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional, Sequence
+from typing import List, Optional, Sequence
 import datetime
 import abc
 
@@ -10,6 +10,9 @@ import pandas as pd
 class EnsembleTimeSeries(abc.ABC):
     @abc.abstractmethod
     def vector_names(self) -> List[str]: ...
+
+    @abc.abstractmethod
+    def vector_names_filtered_by_value(self, exclude_all_values_zero: bool = False, exclude_constant_values: bool = False) -> List[str]: ...
 
     @abc.abstractmethod
     def realizations(self) -> List[int]: ...

--- a/webviz_subsurface/_models/ensemble_time_series_factory.py
+++ b/webviz_subsurface/_models/ensemble_time_series_factory.py
@@ -1,0 +1,237 @@
+from typing import List, Dict, Optional
+from pathlib import Path
+import time
+import os
+import hashlib
+from enum import Enum
+
+import pandas as pd
+
+from fmu.ensemble import ScratchEnsemble
+from .ensemble_time_series_set import EnsembleTimeSeriesSet
+from .ensemble_time_series import EnsembleTimeSeries
+from .ensemble_time_series_impl_inmem_dataframe import (
+    EnsembleTimeSeriesImplInMemDataFrame,
+)
+from .ensemble_time_series_impl_naive_parquet import (
+    EnsembleTimeSeriesImplNaiveParquet,
+)
+from .ensemble_time_series_impl_arrow import EnsembleTimeSeriesImplArrow
+
+
+class BackingType(Enum):
+    ARROW = 1
+    ARROW_PER_REAL_SMRY_IMPORT = 2
+    PARQUET = 3
+
+
+# =============================================================================
+class EnsembleTimeSeriesFactory:
+
+    # -------------------------------------------------------------------------
+    def __init__(self, root_storage_folder: Path, backing_type: BackingType) -> None:
+        self._storage_dir = Path(root_storage_folder) / __name__
+        self._backing_type: BackingType = backing_type
+
+        print("root_storage_folder:", root_storage_folder)
+        print("self._storage_dir:", self._storage_dir)
+        print("self._backing_type:", self._backing_type)
+
+        # For now, just make sure the storage folder exists
+        os.makedirs(self._storage_dir, exist_ok=True)
+
+    # -------------------------------------------------------------------------
+    def create_time_series_set_from_aggregated_csv_file(
+        self,
+        aggr_csv_file: Path,
+    ) -> EnsembleTimeSeriesSet:
+        aggregated_df = pd.read_csv(aggr_csv_file)
+        ensemble_names = aggregated_df["ENSEMBLE"].unique()
+
+        timeseries_obj_dict: Dict[str, EnsembleTimeSeries] = {}
+
+        for ens_name in ensemble_names:
+            ensemble_df = aggregated_df[aggregated_df["ENSEMBLE"] == ens_name]
+            ens_ts_obj = EnsembleTimeSeriesImplInMemDataFrame(ensemble_df)
+            timeseries_obj_dict[ens_name] = ens_ts_obj
+
+        return EnsembleTimeSeriesSet(timeseries_obj_dict)
+
+    # -------------------------------------------------------------------------
+    def create_time_series_set_from_per_realization_csv_files(
+        self, ensembles: Dict[str, str], csv_file_rel_path: str
+    ) -> EnsembleTimeSeriesSet:
+
+        timeseries_obj_dict: Dict[str, EnsembleTimeSeries] = {}
+        for ens_name, ens_path in ensembles.items():
+
+            hashval = hashlib.md5((ens_path + csv_file_rel_path).encode()).hexdigest()
+            storage_key = f"ens_csv__{hashval}"
+
+            ens_ts_obj = self._create_instance_from_backing_store(storage_key)
+
+            if not ens_ts_obj:
+                scratch_ensemble = ScratchEnsemble(
+                    ens_name, ens_path, autodiscovery=True
+                )
+                ensemble_df = scratch_ensemble.load_csv(csv_file_rel_path)
+                del scratch_ensemble
+
+                self._write_data_to_backing_store(storage_key, ensemble_df)
+                ens_ts_obj = self._create_instance_from_backing_store(storage_key)
+
+            if ens_ts_obj:
+                timeseries_obj_dict[ens_name] = ens_ts_obj
+
+        return EnsembleTimeSeriesSet(timeseries_obj_dict)
+
+    # -------------------------------------------------------------------------
+    def create_time_series_set_from_ensemble_smry(
+        self, ensembles: Dict[str, str], time_index: str
+    ) -> EnsembleTimeSeriesSet:
+
+        storage_keys_to_load: Dict[str, str] = {}
+        for ens_name, ens_path in ensembles.items():
+            hashval = hashlib.md5(ens_path.encode()).hexdigest()
+            storage_keys_to_load[ens_name] = f"ens_smry__{hashval}__{time_index}"
+
+        timeseries_obj_dict: Dict[str, EnsembleTimeSeries] = {}
+
+        # Try and create/load from backing store
+        for ens_name, ens_storage_key in dict(storage_keys_to_load).items():
+            ens_ts_obj = self._create_instance_from_backing_store(ens_storage_key)
+            if ens_ts_obj:
+                timeseries_obj_dict[ens_name] = ens_ts_obj
+                del storage_keys_to_load[ens_name]
+
+        # If there are remaining keys to load, we'll load the smry data, write the
+        # data to storage and then try and load again
+        if storage_keys_to_load:
+            for ens_name, ens_storage_key in dict(storage_keys_to_load).items():
+                ens_path = ensembles[ens_name]
+
+                # Experiment with importing smry data per realization instead of whole
+                # dataframe for entire ensemble (pyarrow only)
+                if self._backing_type is BackingType.ARROW_PER_REAL_SMRY_IMPORT:
+                    per_real_dfs = (
+                        EnsembleTimeSeriesFactory._load_smry_dataframe_per_realization(
+                            ens_path, time_index
+                        )
+                    )
+                    EnsembleTimeSeriesImplArrow.write_backing_store_from_per_realization_dataframes(
+                        self._storage_dir, ens_storage_key, per_real_dfs
+                    )
+                else:
+                    ensemble_df = EnsembleTimeSeriesFactory._load_smry_single_dataframe_for_ensemble(
+                        ens_path, time_index
+                    )
+                    self._write_data_to_backing_store(ens_storage_key, ensemble_df)
+
+                ens_ts_obj = self._create_instance_from_backing_store(ens_storage_key)
+                if ens_ts_obj:
+                    timeseries_obj_dict[ens_name] = ens_ts_obj
+                    del storage_keys_to_load[ens_name]
+
+        return EnsembleTimeSeriesSet(timeseries_obj_dict)
+
+    # -------------------------------------------------------------------------
+    # Crude solution for creating EnsembleTimeSeries instances from backing store
+    # based on the configured backing type. Good enough for testing, but needs a
+    # proper solution if we want such functionality in production.
+    def _create_instance_from_backing_store(
+        self, storage_key: str
+    ) -> Optional[EnsembleTimeSeries]:
+        if (
+            self._backing_type is BackingType.ARROW
+            or self._backing_type is BackingType.ARROW_PER_REAL_SMRY_IMPORT
+        ):
+            return EnsembleTimeSeriesImplArrow.from_backing_store(
+                self._storage_dir, storage_key
+            )
+
+        elif self._backing_type is BackingType.PARQUET:
+            return EnsembleTimeSeriesImplNaiveParquet.from_backing_store(
+                self._storage_dir, storage_key
+            )
+
+        else:
+            raise NotImplementedError()
+
+    # -------------------------------------------------------------------------
+    # Crude solution for writing data to backing store according to the configured
+    # backing type. Good enough for testing, but needs a proper solution if we
+    # want such functionality in production.
+    def _write_data_to_backing_store(
+        self, storage_key: str, ensemble_df: pd.DataFrame
+    ) -> None:
+        if (
+            self._backing_type is BackingType.ARROW
+            or self._backing_type is BackingType.ARROW_PER_REAL_SMRY_IMPORT
+        ):
+            EnsembleTimeSeriesImplArrow.write_backing_store_from_ensemble_dataframe(
+                self._storage_dir, storage_key, ensemble_df
+            )
+
+        elif self._backing_type is BackingType.PARQUET:
+            EnsembleTimeSeriesImplNaiveParquet.write_backing_store_from_ensemble_dataframe(
+                self._storage_dir, storage_key, ensemble_df
+            )
+
+        else:
+            raise NotImplementedError()
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    # @profile
+    def _load_smry_single_dataframe_for_ensemble(
+        ens_path: str, time_index: str
+    ) -> pd.DataFrame:
+
+        print("entering _load_smry_single_dataframe_for_ensemble() ...")
+        start_tim = time.perf_counter()
+
+        lap_tim = start_tim
+        scratch_ensemble = ScratchEnsemble("tempEnsName", paths=ens_path)
+        print(f"  time creating ScratchEnsemble (s): {time.perf_counter() - lap_tim}")
+
+        lap_tim = time.perf_counter()
+        ensemble_df = scratch_ensemble.load_smry(time_index=time_index)
+        print(f"  time executing load_smry() (s): {time.perf_counter() - lap_tim}")
+
+        print(
+            f"total time in _load_smry_single_dataframe_for_ensemble (s): {time.perf_counter() - start_tim}"
+        )
+
+        return ensemble_df
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    # @profile
+    def _load_smry_dataframe_per_realization(
+        ens_path: str, time_index: str
+    ) -> List[pd.DataFrame]:
+
+        print("entering _load_smry_dataframe_per_realization() ...")
+        start_tim = time.perf_counter()
+
+        lap_tim = start_tim
+        scratch_ensemble = ScratchEnsemble("tempEnsName", paths=ens_path)
+        print(f"  time creating ScratchEnsemble (s): {time.perf_counter() - lap_tim}")
+
+        lap_tim = time.perf_counter()
+
+        real_df_list = []
+        for _realidx, realization in scratch_ensemble.realizations.items():
+            # Note that caching seems faster even if we're at realization level, but uses more memory
+            real_df = realization.load_smry(time_index=time_index, cache_eclsum=True)
+            real_df_list.append(real_df)
+
+        print(
+            f"  time loading smry pr realization (s): {time.perf_counter() - lap_tim}"
+        )
+
+        print(
+            f"total time in _load_smry_dataframe_per_realization() (s): {time.perf_counter() - start_tim}"
+        )
+
+        return real_df_list

--- a/webviz_subsurface/_models/ensemble_time_series_impl_arrow.py
+++ b/webviz_subsurface/_models/ensemble_time_series_impl_arrow.py
@@ -1,0 +1,275 @@
+from typing import List, Optional, Sequence
+import datetime
+from pathlib import Path
+import time
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pandas as pd
+import numpy as np
+
+from .ensemble_time_series import EnsembleTimeSeries
+
+
+# =============================================================================
+class EnsembleTimeSeriesImplArrow(EnsembleTimeSeries):
+
+    # -------------------------------------------------------------------------
+    def __init__(self, arrow_file_name: Path) -> None:
+        self._arrow_file_name = str(arrow_file_name)
+
+        print(f"init with arrow file: {self._arrow_file_name}")
+        lap_tim = time.perf_counter()
+
+        # Discover columns and realizations that are present in the arrow file
+        with pa.memory_map(self._arrow_file_name, "r") as source:
+            reader = pa.ipc.RecordBatchFileReader(source)
+            column_names_on_file = reader.schema.names
+            unique_realizations_on_file = reader.read_all().column("REAL").unique()
+
+        self._vector_names: List[str] = [
+            colname
+            for colname in column_names_on_file
+            if colname not in ["DATE", "REAL", "ENSEMBLE"]
+        ]
+        self._realizations: List[int] = unique_realizations_on_file.to_pylist()
+
+        print(f"time to init from arrow (s): {(time.perf_counter() - lap_tim)}")
+
+        if not self._realizations:
+            raise ValueError("Init from backing store failed NO realizations")
+        if not self._vector_names:
+            raise ValueError("Init from backing store failed NO vector_names")
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    # @profile
+    def write_backing_store_from_ensemble_dataframe(
+        storage_dir: Path, storage_key: str, ensemble_df: pd.DataFrame
+    ) -> None:
+
+        print("entering write_backing_store_from_ensemble_dataframe() ...")
+        start_tim = time.perf_counter()
+
+        arrow_file_name = storage_dir / (storage_key + ".arrow")
+
+        # For experimenting with sorting and conversion to float
+        do_convert_to_float32 = False
+        do_sorting = True
+
+        schema_to_use: pa.Schema = None
+        if do_convert_to_float32:
+            lap_tim = time.perf_counter()
+            schema_to_use = EnsembleTimeSeriesImplArrow._create_downcasting_schema(
+                pa.Schema.from_pandas(ensemble_df, preserve_index=None)
+            )
+            print(
+                f"  time figuring out schema for casting (s): {(time.perf_counter() - lap_tim)}"
+            )
+
+        lap_tim = time.perf_counter()
+        table = pa.Table.from_pandas(
+            ensemble_df, schema=schema_to_use, preserve_index=False
+        )
+        del ensemble_df
+        print(f"  time to convert from pandas (s): {(time.perf_counter() - lap_tim)}")
+
+        if do_sorting:
+            lap_tim = time.perf_counter()
+            table = EnsembleTimeSeriesImplArrow._sort_table_on_date_and_real(table)
+            print(f"  time spend sorting table (s): {(time.perf_counter() - lap_tim)}")
+
+        lap_tim = time.perf_counter()
+        with pa.OSFile(str(arrow_file_name), "wb") as sink:
+            with pa.RecordBatchFileWriter(sink, table.schema) as writer:
+                writer.write_table(table)
+        print(
+            f"  time writing arrow (s): {(time.perf_counter() - lap_tim)}   fn: {arrow_file_name}"
+        )
+
+        print(
+            f"Total time in write_backing_store_from_ensemble_dataframe (s): {(time.perf_counter() - start_tim)}"
+        )
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    # @profile
+    def write_backing_store_from_per_realization_dataframes(
+        storage_dir: Path, storage_key: str, per_real_dfs: List[pd.DataFrame]
+    ) -> None:
+
+        print("entering write_backing_store_from_per_realization_dataframes() ...")
+        start_tim = time.perf_counter()
+
+        arrow_file_name = storage_dir / (storage_key + ".arrow")
+
+        # For experimenting with sorting and conversion to float
+        do_convert_to_float32 = False
+        do_sorting = True
+
+        lap_tim = time.perf_counter()
+
+        table_list: List[pa.Table] = []
+        for real_idx, real_df in enumerate(per_real_dfs):
+            if do_convert_to_float32:
+                org_schema = pa.Schema.from_pandas(real_df, preserve_index=False)
+                new_schema = EnsembleTimeSeriesImplArrow._create_downcasting_schema(
+                    org_schema
+                )
+                table = pa.Table.from_pandas(
+                    real_df, schema=new_schema, preserve_index=False
+                )
+            else:
+                table = pa.Table.from_pandas(real_df, preserve_index=False)
+
+            table_list.append(table)
+
+        print(f"  time to convert from pandas (s): {(time.perf_counter() - lap_tim)}")
+
+        lap_tim = time.perf_counter()
+        table = pa.concat_tables(table_list, promote=True)
+        print(f"  time to build table (s): {(time.perf_counter() - lap_tim)}")
+
+        lap_tim = time.perf_counter()
+        real_arr = np.empty(table.num_rows, np.int64)
+        table_start_idx = 0
+        for real_idx, real_table in enumerate(table_list):
+            real_arr[table_start_idx : table_start_idx + real_table.num_rows] = real_idx
+            table_start_idx += real_table.num_rows
+
+        table = table.add_column(0, "REAL", pa.array(real_arr))
+        print(
+            f"  time to build and add real column (s): {(time.perf_counter() - lap_tim)}"
+        )
+
+        if do_sorting:
+            lap_tim = time.perf_counter()
+            table = EnsembleTimeSeriesImplArrow._sort_table_on_date_and_real(table)
+            print(f"  time spend sorting table (s): {(time.perf_counter() - lap_tim)}")
+
+        lap_tim = time.perf_counter()
+        with pa.OSFile(str(arrow_file_name), "wb") as sink:
+            with pa.RecordBatchFileWriter(sink, table.schema) as writer:
+                writer.write_table(table)
+        print(
+            f"  time to write to arrow (s): {(time.perf_counter() - lap_tim)}   fn: {arrow_file_name}"
+        )
+
+        print(
+            f"Total time in write_backing_store_from_per_realization_dataframes (s): {(time.perf_counter() - start_tim)}"
+        )
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def from_backing_store(
+        storage_dir: Path, storage_key: str
+    ) -> Optional["EnsembleTimeSeriesImplArrow"]:
+
+        arrow_file_name = storage_dir / (storage_key + ".arrow")
+        if arrow_file_name.is_file():
+            return EnsembleTimeSeriesImplArrow(arrow_file_name)
+
+        return None
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def _create_downcasting_schema(schema: pa.Schema) -> pa.Schema:
+        dt_float64 = pa.float64()
+        dt_float32 = pa.float32()
+        types = schema.types
+        for i, t in enumerate(types):
+            if t == dt_float64:
+                types[i] = dt_float32
+
+        field_list = zip(schema.names, types)
+        return pa.schema(field_list)
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    # @profile
+    def _sort_table_on_date_and_real(table: pa.Table) -> pa.Table:
+        indices = pc.sort_indices(
+            table, sort_keys=[("DATE", "ascending"), ("REAL", "ascending")]
+        )
+        sorted_table = table.take(indices)
+        return sorted_table
+
+    # -------------------------------------------------------------------------
+    def vector_names(self) -> List[str]:
+        return self._vector_names
+
+    # -------------------------------------------------------------------------
+    def realizations(self) -> List[int]:
+        return self._realizations
+
+    # -------------------------------------------------------------------------
+    def dates(
+        self, realizations: Optional[Sequence[int]] = None
+    ) -> List[datetime.datetime]:
+        source = pa.memory_map(self._arrow_file_name, "r")
+        table: pa.Table = (
+            pa.ipc.RecordBatchFileReader(source).read_all().select(["DATE", "REAL"])
+        )
+
+        if realizations:
+            mask = pc.is_in(table["REAL"], value_set=pa.array(realizations))
+            table = table.filter(mask)
+
+        unique_date_vals = table.column("DATE").unique()
+        return unique_date_vals
+        # return unique_date_vals.to_pylist()
+
+    # -------------------------------------------------------------------------
+    def get_vectors_df(
+        self, vector_names: Sequence[str], realizations: Optional[Sequence[int]] = None
+    ) -> pd.DataFrame:
+
+        # Here we open the file each time we want to read data
+        # We can optimize this by keeping the file open, but should investigate andy downsides
+        source = pa.memory_map(self._arrow_file_name, "r")
+
+        columns_to_get = ["DATE", "REAL"]
+        columns_to_get.extend(vector_names)
+        table: pa.Table = (
+            pa.ipc.RecordBatchFileReader(source).read_all().select(columns_to_get)
+        )
+
+        if realizations:
+            # mask = pc.equal(table["REAL"], pa.scalar(3))
+            mask = pc.is_in(table["REAL"], value_set=pa.array(realizations))
+            df = table.filter(mask).to_pandas()
+        else:
+            df = table.to_pandas()
+            # df = table.to_pandas(split_blocks=True, self_destruct=True)
+
+        # df = table.to_pandas(split_blocks=True, self_destruct=True)
+        # del table  # not necessary, but a good practice
+
+        return df
+
+    # -------------------------------------------------------------------------
+    def get_vectors_for_date_df(
+        self,
+        date: datetime.datetime,
+        vector_names: Sequence[str],
+        realizations: Optional[Sequence[int]] = None,
+    ) -> pd.DataFrame:
+
+        source = pa.memory_map(self._arrow_file_name, "r")
+
+        columns_to_get = ["DATE", "REAL"]
+        columns_to_get.extend(vector_names)
+        table: pa.Table = (
+            pa.ipc.RecordBatchFileReader(source).read_all().select(columns_to_get)
+        )
+
+        mask = pc.equal(table["DATE"], date)
+
+        if realizations:
+            real_mask = pc.is_in(table["REAL"], value_set=pa.array(realizations))
+            mask = pc.and_(mask, real_mask)
+
+        table = table.drop(["DATE"])
+        df = table.filter(mask).to_pandas()
+
+        return df

--- a/webviz_subsurface/_models/ensemble_time_series_impl_inmem_dataframe.py
+++ b/webviz_subsurface/_models/ensemble_time_series_impl_inmem_dataframe.py
@@ -30,6 +30,33 @@ class EnsembleTimeSeriesImplInMemDataFrame(EnsembleTimeSeries):
         return self._vector_names
 
     # -------------------------------------------------------------------------
+    def vector_names_filtered_by_value(
+        self,
+        exclude_all_values_zero: bool = False,
+        exclude_constant_values: bool = False,
+    ) -> List[str]:
+
+        df = self._ensemble_df[self._vector_names]
+        desc_df = df.describe(percentiles=[])
+
+        ret_vec_names: List[str] = []
+
+        for vec_name in desc_df.columns:
+            minval = desc_df[vec_name]["min"]
+            maxval = desc_df[vec_name]["max"]
+
+            if minval == maxval:
+                if exclude_constant_values:
+                    continue
+
+                if exclude_all_values_zero and minval == 0:
+                    continue
+
+            ret_vec_names.append(vec_name)
+
+        return ret_vec_names
+
+    # -------------------------------------------------------------------------
     def realizations(self) -> List[int]:
         return self._realizations
 

--- a/webviz_subsurface/_models/ensemble_time_series_impl_inmem_dataframe.py
+++ b/webviz_subsurface/_models/ensemble_time_series_impl_inmem_dataframe.py
@@ -1,0 +1,94 @@
+from typing import List, Optional, Sequence
+import datetime
+
+import pandas as pd
+
+from .ensemble_time_series import EnsembleTimeSeries
+
+
+# =============================================================================
+class EnsembleTimeSeriesImplInMemDataFrame(EnsembleTimeSeries):
+
+    # -------------------------------------------------------------------------
+    def __init__(self, ensemble_df: pd.DataFrame) -> None:
+        # The input DF may contain an ENSEMBLE column, but it is probably an error if
+        # There is more than one unique value in it
+        if "ENSEMBLE" in ensemble_df:
+            if ensemble_df["ENSEMBLE"].nunique() > 1:
+                raise KeyError("Input data contains more than one unique ensemble name")
+
+        self._ensemble_df = ensemble_df
+        self._realizations = list(self._ensemble_df["REAL"].unique())
+        self._vector_names: List[str] = [
+            vecname
+            for vecname in list(self._ensemble_df.columns)
+            if vecname not in ["DATE", "REAL", "ENSEMBLE"]
+        ]
+
+    # -------------------------------------------------------------------------
+    def vector_names(self) -> List[str]:
+        return self._vector_names
+
+    # -------------------------------------------------------------------------
+    def realizations(self) -> List[int]:
+        return self._realizations
+
+    # -------------------------------------------------------------------------
+    def dates(
+        self, realizations: Optional[Sequence[int]] = None
+    ) -> List[datetime.datetime]:
+
+        if realizations:
+            date_series = self._ensemble_df.loc[
+                self._ensemble_df["REAL"].isin(realizations),
+                "DATE",
+            ]
+        else:
+            date_series = self._ensemble_df["DATE"]
+
+        unique_date_vals = date_series.unique()
+        return unique_date_vals
+
+    # -------------------------------------------------------------------------
+    def get_vectors_df(
+        self, vector_names: Sequence[str], realizations: Optional[Sequence[int]] = None
+    ) -> pd.DataFrame:
+
+        columns_to_get = ["DATE", "REAL"]
+        columns_to_get.extend(vector_names)
+
+        if realizations:
+            df = self._ensemble_df.loc[
+                self._ensemble_df["REAL"].isin(realizations),
+                columns_to_get,
+            ]
+        else:
+            df = self._ensemble_df.loc[:, columns_to_get]
+
+        return df
+
+    # -------------------------------------------------------------------------
+    def get_vectors_for_date_df(
+        self,
+        date: datetime.datetime,
+        vector_names: Sequence[str],
+        realizations: Optional[Sequence[int]] = None,
+    ) -> pd.DataFrame:
+
+        query_date = date
+
+        columns_to_get = ["REAL"]
+        columns_to_get.extend(vector_names)
+
+        if realizations:
+            df = self._ensemble_df.loc[
+                (self._ensemble_df["DATE"] == query_date)
+                & (self._ensemble_df["REAL"].isin(realizations)),
+                columns_to_get,
+            ]
+        else:
+            df = self._ensemble_df.loc[
+                (self._ensemble_df["DATE"] == query_date), columns_to_get
+            ]
+
+        return df

--- a/webviz_subsurface/_models/ensemble_time_series_impl_naive_parquet.py
+++ b/webviz_subsurface/_models/ensemble_time_series_impl_naive_parquet.py
@@ -1,0 +1,125 @@
+from typing import List, Optional, Sequence
+import datetime
+from pathlib import Path
+import time
+
+import pandas as pd
+
+from .ensemble_time_series import EnsembleTimeSeries
+
+
+# =============================================================================
+class EnsembleTimeSeriesImplNaiveParquet(EnsembleTimeSeries):
+
+    # -------------------------------------------------------------------------
+    def __init__(self, parquet_file_name: Path) -> None:
+        self._parquet_file_name = str(parquet_file_name)
+
+        print(f"init with parquet file: {self._parquet_file_name}")
+        lap_tim = time.perf_counter()
+
+        df = pd.read_parquet(path=self._parquet_file_name)
+        self._realizations = list(df["REAL"].unique())
+        self._vector_names: List[str] = [
+            col for col in list(df.columns) if col not in ["DATE", "REAL", "ENSEMBLE"]
+        ]
+
+        print(f"time to init from parquet (s): {(time.perf_counter() - lap_tim)}")
+
+        if not self._realizations:
+            raise ValueError("Init from backing store failed NO realizations")
+        if not self._vector_names:
+            raise ValueError("Init from backing store failed NO vector_names")
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def write_backing_store_from_ensemble_dataframe(
+        storage_dir: Path, storage_key: str, ensemble_df: pd.DataFrame
+    ) -> None:
+
+        print(
+            "entering EnsembleTimeSeriesImplNaiveParquet.write_backing_store_from_ensemble_dataframe() ..."
+        )
+        start_tim = time.perf_counter()
+
+        parquet_file_name = storage_dir / (storage_key + ".parquet")
+        ensemble_df.to_parquet(path=parquet_file_name)
+
+        print(
+            f"Total time in EnsembleTimeSeriesImplNaiveParquet.write_backing_store_from_ensemble_dataframe() (s): {(time.perf_counter() - start_tim)}"
+        )
+
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def from_backing_store(
+        storage_dir: Path, storage_key: str
+    ) -> Optional["EnsembleTimeSeriesImplNaiveParquet"]:
+
+        parquet_file_name = storage_dir / (storage_key + ".parquet")
+        if parquet_file_name.is_file():
+            return EnsembleTimeSeriesImplNaiveParquet(parquet_file_name)
+
+        return None
+
+    # -------------------------------------------------------------------------
+    def vector_names(self) -> List[str]:
+        return self._vector_names
+
+    # -------------------------------------------------------------------------
+    def realizations(self) -> List[int]:
+        return self._realizations
+
+    # -------------------------------------------------------------------------
+    def dates(
+        self, realizations: Optional[Sequence[int]] = None
+    ) -> List[datetime.datetime]:
+
+        if realizations:
+            df = pd.read_parquet(path=self._parquet_file_name, columns=["DATE", "REAL"])
+            date_series = df.loc[df["REAL"].isin(realizations), "DATE"]
+        else:
+            df = pd.read_parquet(path=self._parquet_file_name, columns=["DATE"])
+            date_series = df["DATE"]
+
+        unique_date_vals = date_series.unique()
+        return unique_date_vals
+
+    # -------------------------------------------------------------------------
+    def get_vectors_df(
+        self, vector_names: Sequence[str], realizations: Optional[Sequence[int]] = None
+    ) -> pd.DataFrame:
+
+        columns_to_get = ["DATE", "REAL"]
+        columns_to_get.extend(vector_names)
+        df = pd.read_parquet(path=self._parquet_file_name, columns=columns_to_get)
+
+        if realizations:
+            df = df.loc[df["REAL"].isin(realizations), columns_to_get]
+
+        return df
+
+    # -------------------------------------------------------------------------
+    def get_vectors_for_date_df(
+        self,
+        date: datetime.datetime,
+        vector_names: Sequence[str],
+        realizations: Optional[Sequence[int]] = None,
+    ) -> pd.DataFrame:
+
+        query_date = date
+
+        columns_to_read = ["DATE", "REAL"]
+        columns_to_read.extend(vector_names)
+        tmp_df = pd.read_parquet(path=self._parquet_file_name, columns=columns_to_read)
+
+        columns_to_return = ["REAL"]
+        columns_to_return.extend(vector_names)
+        if realizations:
+            df = tmp_df.loc[
+                (tmp_df["DATE"] == query_date) & (tmp_df["REAL"].isin(realizations)),
+                columns_to_return,
+            ]
+        else:
+            df = tmp_df.loc[(tmp_df["DATE"] == query_date), columns_to_return]
+
+        return df

--- a/webviz_subsurface/_models/ensemble_time_series_perf_testing.py
+++ b/webviz_subsurface/_models/ensemble_time_series_perf_testing.py
@@ -1,0 +1,183 @@
+from typing import Dict
+from pathlib import Path
+import datetime
+import time
+import json
+
+from .ensemble_time_series_factory import EnsembleTimeSeriesFactory
+from .ensemble_time_series_factory import BackingType
+from .ensemble_time_series_set import EnsembleTimeSeriesSet
+from .ensemble_time_series import EnsembleTimeSeries
+
+
+# -------------------------------------------------------------------------
+def _get_n_vectors_one_by_one_all_realizations(
+    ts: EnsembleTimeSeries, num_vectors: int
+) -> None:
+
+    all_vectors = ts.vector_names()
+    num_vectors = min(num_vectors, len(all_vectors))
+    vectors_to_get = all_vectors[0:num_vectors]
+
+    print("## ------------------")
+    print(f"## entering _get_n_vectors_one_by_one_all_realizations({num_vectors}) ...")
+
+    start_tim = time.perf_counter()
+
+    accum_rows = 0
+    accum_cols = 0
+    for vec_name in vectors_to_get:
+        df = ts.get_vectors_df([vec_name])
+        accum_rows += df.shape[0]
+        accum_cols += df.shape[1]
+
+    elapsed_time_ms = 1000 * (time.perf_counter() - start_tim)
+
+    avg_shape = (
+        int(accum_rows / num_vectors),
+        int(accum_cols / num_vectors),
+    )
+    print("## avg shape:", avg_shape)
+    print("## num unique dates:", df["DATE"].nunique())
+    print("## num unique realizations:", df["REAL"].nunique())
+    print("## avg time per vector (ms):", elapsed_time_ms / num_vectors)
+    print(
+        "## finished _get_n_vectors_one_by_one_all_realizations(), total time (ms)",
+        elapsed_time_ms,
+    )
+    print("## ------------------")
+
+
+# -------------------------------------------------------------------------
+def _get_n_vectors_in_batch_all_realizations(
+    ts: EnsembleTimeSeries, num_vectors: int
+) -> None:
+
+    all_vectors = ts.vector_names()
+    num_vectors = min(num_vectors, len(all_vectors))
+    vectors_to_get = all_vectors[0:num_vectors]
+
+    print("## ------------------")
+    print(f"## entering _get_n_vectors_in_batch_all_realizations({num_vectors}) ...")
+
+    start_tim = time.perf_counter()
+
+    df = ts.get_vectors_df(vectors_to_get)
+
+    elapsed_time_ms = 1000 * (time.perf_counter() - start_tim)
+
+    print("## df shape:", df.shape)
+    print("## num unique dates:", df["DATE"].nunique())
+    print("## num unique realizations:", df["REAL"].nunique())
+
+    print("## avg time per vector (ms):", elapsed_time_ms / num_vectors)
+    print(
+        "## finished _get_n_vectors_in_batch_all_realizations(), total time (ms)",
+        elapsed_time_ms,
+    )
+    print("## ------------------")
+
+
+# -------------------------------------------------------------------------
+def _get_n_vectors_for_date_all_realizations(
+    ts: EnsembleTimeSeries, num_vectors: int, date: datetime.datetime
+) -> None:
+
+    all_vectors = ts.vector_names()
+    num_vectors = min(num_vectors, len(all_vectors))
+    vectors_to_get = all_vectors[0:num_vectors]
+
+    print("## ------------------")
+    print(
+        f"## entering _get_n_vectors_for_date_all_realizations({num_vectors}, {date}) ..."
+    )
+
+    start_tim = time.perf_counter()
+
+    df = ts.get_vectors_for_date_df(date, vectors_to_get)
+
+    elapsed_time_ms = 1000 * (time.perf_counter() - start_tim)
+
+    print("## df shape:", df.shape)
+    print("## num unique realizations:", df["REAL"].nunique())
+    print(
+        "## finished _get_n_vectors_for_date_all_realizations(), total time (ms)",
+        elapsed_time_ms,
+    )
+    print("## ------------------")
+
+
+# -------------------------------------------------------------------------
+def _run_perf_tests(factory: EnsembleTimeSeriesFactory) -> None:
+
+    ensembles: Dict[str, str] = {
+        # "iter-0": "/home/sigurdp/webviz_testdata/reek_history_match_reduced/realization-*/iter-0",
+        "iter-0": "/home/sigurdp/webviz_testdata/reek_history_match_large/realization-*/iter-0",
+        # "iter-0": "/home/sigurdp/gitRoot/webviz-subsurface-testdata/reek_history_match/realization-*/iter-0",
+        # "iter-1": "/home/sigurdp/gitRoot/webviz-subsurface-testdata/reek_history_match/realization-*/iter-1",
+        # "iter-2": "/home/sigurdp/gitRoot/webviz-subsurface-testdata/reek_history_match/realization-*/iter-2",
+        # "iter-3": "/home/sigurdp/gitRoot/webviz-subsurface-testdata/reek_history_match/realization-*/iter-3",
+    }
+
+    print("ensembles:")
+    print(json.dumps(ensembles, indent=True))
+
+    print()
+    print("## Creating EnsembleTimeSeriesSet...")
+
+    start_tim = time.perf_counter()
+
+    ts_set: EnsembleTimeSeriesSet = factory.create_time_series_set_from_ensemble_smry(
+        ensembles, "daily"
+    )
+
+    print(
+        "## Done creating EnsembleTimeSeriesSet, elapsed time (s):",
+        time.perf_counter() - start_tim,
+    )
+
+    print()
+    print("## ts_set.ensemble_names()", ts_set.ensemble_names())
+
+    ts = ts_set.ensemble("iter-0")
+    print("## len(ts.vector_names())", len(ts.vector_names()))
+    print("## len(ts.realizations())", len(ts.realizations()))
+    print("## len(ts.dates())", len(ts.dates()))
+
+    all_dates = ts.dates()
+
+    print()
+    print()
+
+    _get_n_vectors_one_by_one_all_realizations(ts, 50)
+
+    _get_n_vectors_in_batch_all_realizations(ts, 50)
+    _get_n_vectors_in_batch_all_realizations(ts, 9999)
+
+    _get_n_vectors_for_date_all_realizations(ts, 9999, all_dates[0])
+    _get_n_vectors_for_date_all_realizations(ts, 9999, all_dates[-1])
+
+
+# Running:
+#   python -m webviz_subsurface._models.ensemble_time_series_perf_testing
+#
+# Memory profiling with memory-profiler:
+#   mprof run --python  webviz_subsurface._models.ensemble_time_series_perf_testing
+# -------------------------------------------------------------------------
+if __name__ == "__main__":
+    print()
+    print("## Running EnsembleTimeSeries performance tests")
+    print("## ============================================")
+
+    ROOT_STORAGE_DIR = Path("/home/sigurdp/buf/webviz_storage_dir")
+    BACKING_TYPE: BackingType = BackingType.ARROW
+
+    factory = EnsembleTimeSeriesFactory(ROOT_STORAGE_DIR, BACKING_TYPE)
+
+    print()
+    print("ROOT_STORAGE_DIR:", ROOT_STORAGE_DIR)
+    print("BACKING_TYPE:", BACKING_TYPE)
+
+    _run_perf_tests(factory)
+
+    print("done")

--- a/webviz_subsurface/_models/ensemble_time_series_perf_testing.py
+++ b/webviz_subsurface/_models/ensemble_time_series_perf_testing.py
@@ -108,6 +108,28 @@ def _get_n_vectors_for_date_all_realizations(
 
 
 # -------------------------------------------------------------------------
+def _get_vector_names_filtered_by_value(ts: EnsembleTimeSeries) -> None:
+
+    print("## ------------------")
+    print("## entering _get_vector_names_filtered_by_value() ...")
+
+    start_tim = time.perf_counter()
+
+    filtered_vec_names = ts.vector_names_filtered_by_value(
+        exclude_all_values_zero=True, exclude_constant_values=True
+    )
+    print("## number of names returned:", len(filtered_vec_names))
+
+    elapsed_time_ms = 1000 * (time.perf_counter() - start_tim)
+
+    print(
+        "## finished _get_vector_names_filtered_by_value(), total time (ms)",
+        elapsed_time_ms,
+    )
+    print("## ------------------")
+
+
+# -------------------------------------------------------------------------
 def _run_perf_tests(factory: EnsembleTimeSeriesFactory) -> None:
 
     ensembles: Dict[str, str] = {
@@ -140,22 +162,32 @@ def _run_perf_tests(factory: EnsembleTimeSeriesFactory) -> None:
     print("## ts_set.ensemble_names()", ts_set.ensemble_names())
 
     ts = ts_set.ensemble("iter-0")
-    print("## len(ts.vector_names())", len(ts.vector_names()))
-    print("## len(ts.realizations())", len(ts.realizations()))
-    print("## len(ts.dates())", len(ts.dates()))
-
+    all_vector_names = ts.vector_names()
+    all_realizations = ts.realizations()
     all_dates = ts.dates()
+    num_vectors = len(all_vector_names)
+    num_realizations = len(all_realizations)
+    num_dates = len(all_dates)
+    print("## num_vectors:", num_vectors)
+    print("## num_realizations:", num_realizations)
+    print("## num_dates", num_dates)
 
     print()
     print()
 
+    _get_vector_names_filtered_by_value(ts)
+
+    _get_n_vectors_one_by_one_all_realizations(ts, 1)
     _get_n_vectors_one_by_one_all_realizations(ts, 50)
 
     _get_n_vectors_in_batch_all_realizations(ts, 50)
-    _get_n_vectors_in_batch_all_realizations(ts, 9999)
+    _get_n_vectors_in_batch_all_realizations(ts, 99999)
 
-    _get_n_vectors_for_date_all_realizations(ts, 9999, all_dates[0])
-    _get_n_vectors_for_date_all_realizations(ts, 9999, all_dates[-1])
+    n = 99999
+    _get_n_vectors_for_date_all_realizations(ts, n, all_dates[0])
+    _get_n_vectors_for_date_all_realizations(ts, n, all_dates[-1])
+    _get_n_vectors_for_date_all_realizations(ts, n, all_dates[int(num_dates / 2)])
+    _get_n_vectors_for_date_all_realizations(ts, n, all_dates[int(num_dates / 4)])
 
 
 # Running:

--- a/webviz_subsurface/_models/ensemble_time_series_set.py
+++ b/webviz_subsurface/_models/ensemble_time_series_set.py
@@ -1,0 +1,14 @@
+from typing import List, Dict
+
+from .ensemble_time_series import EnsembleTimeSeries
+
+
+class EnsembleTimeSeriesSet:
+    def __init__(self, ensembles_dict: Dict[str, EnsembleTimeSeries]) -> None:
+        self._ensembles_dict = ensembles_dict.copy()
+
+    def ensemble_names(self) -> List[str]:
+        return list(self._ensembles_dict.keys())
+
+    def ensemble(self, ensemble_name: str) -> EnsembleTimeSeries:
+        return self._ensembles_dict[ensemble_name]


### PR DESCRIPTION
Experimental implementation of disk-based caching of (smry) time series data using pyarrow.
Also contains a more naive parquet based implementation.

I have been testing with pyarrow 3.0.0 so you may have to manually run `pip install pyarrow==3.0.0`

`ensemble_time_series_perf_testing.py` contains code for doing some simple performance testing. 
Note that the perf testing code must be adapted to local disk system. 
Should be runnable with: `python -m webviz_subsurface._models.ensemble_time_series_perf_testing`
