### PR TITLE
ParameterAnalysis: Allow initialization without field vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 ### Changed
 - [#586](https://github.com/equinor/webviz-subsurface/pull/586) - Added phase ratio vs pressure and density vs pressure plots. Added unit and density functions to PVT library. Refactored code and added checklist for plots to be viewed in PVT plot plugin. Improved the layout.
+- [#599](https://github.com/equinor/webviz-subsurface/pull/599) - Fixed an issue in ParameterAnalysis where the plugin did not initialize without FIELD vectors 
 
 ### Fixed
 - [#602](https://github.com/equinor/webviz-subsurface/pull/602) - Prevent calculation of data for download at initialisation of ReservoirSimulationTimeSeries.

--- a/webviz_subsurface/plugins/_parameter_analysis/models/simulation_timeseries_model.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/models/simulation_timeseries_model.py
@@ -99,9 +99,10 @@ class SimulationTimeSeriesModel:
                 chain.from_iterable([vgroups[vtype]["vectors"] for vtype in vgroups])
             )
         ]
-        vgroups["Others"] = dict(
-            vectors=other_vectors, shortnames=other_vectors, items=[]
-        )
+        if other_vectors:
+            vgroups["Others"] = dict(
+                vectors=other_vectors, shortnames=other_vectors, items=[]
+            )
         return vgroups
 
     @staticmethod

--- a/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
@@ -136,12 +136,22 @@ slow for large models.
 
     @property
     def layout(self) -> dcc.Tabs:
-        return main_view(parent=self)
+        return main_view(
+            get_uuid=self.uuid,
+            vectormodel=self.vmodel,
+            parametermodel=self.pmodel,
+            theme=self.theme,
+        )
 
     def set_callbacks(self, app) -> None:
-        parameter_qc_controller(self, app)
+        parameter_qc_controller(app=app, get_uuid=self.uuid, parametermodel=self.pmodel)
         if self.vmodel is not None:
-            parameter_response_controller(self, app)
+            parameter_response_controller(
+                app=app,
+                get_uuid=self.uuid,
+                parametermodel=self.pmodel,
+                vectormodel=self.vmodel,
+            )
 
     def add_webvizstore(self):
         store = []

--- a/webviz_subsurface/plugins/_parameter_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/views/main_view.py
@@ -1,27 +1,43 @@
+from typing import Callable
+
 import dash_html_components as html
 import dash_core_components as dcc
+from webviz_config import WebvizConfigTheme
 
 from .parameter_qc_view import parameter_qc_view
 from .parameter_response_view import parameter_response_view
+from ..models import ParametersModel, SimulationTimeSeriesModel
 
 
-def main_view(parent) -> dcc.Tabs:
+def main_view(
+    get_uuid: Callable,
+    vectormodel: SimulationTimeSeriesModel,
+    parametermodel: ParametersModel,
+    theme: WebvizConfigTheme,
+) -> dcc.Tabs:
     tabs = [
         make_tab(
             label="Parameter distributions",
-            children=parameter_qc_view(parent=parent),
+            children=parameter_qc_view(
+                get_uuid=get_uuid, parametermodel=parametermodel
+            ),
         )
     ]
-    if parent.vmodel is not None:
+    if vectormodel is not None:
         tabs.append(
             make_tab(
                 label="Parameters impact on simulation profiles",
-                children=parameter_response_view(parent=parent),
+                children=parameter_response_view(
+                    get_uuid=get_uuid,
+                    parametermodel=parametermodel,
+                    vectormodel=vectormodel,
+                    theme=theme,
+                ),
             )
         )
 
     return html.Div(
-        id=parent.uuid("layout"),
+        id=get_uuid("layout"),
         children=dcc.Tabs(
             style={"width": "100%"},
             persistence=True,

--- a/webviz_subsurface/plugins/_parameter_analysis/views/parameter_qc_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/views/parameter_qc_view.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import dash_html_components as html
 import dash_core_components as dcc
 import webviz_core_components as wcc
@@ -9,9 +11,10 @@ from .selector_view import (
     html_details,
     sortby_selector,
 )
+from ..models import ParametersModel
 
 
-def selector_view(parent) -> html.Div:
+def selector_view(get_uuid: Callable, parametermodel: ParametersModel) -> html.Div:
     return html.Div(
         className="framed",
         style={"height": "80vh", "overflowY": "auto", "font-size": "15px"},
@@ -22,24 +25,27 @@ def selector_view(parent) -> html.Div:
                         summary="Selections",
                         children=[
                             ensemble_selector(
-                                parent=parent,
+                                get_uuid=get_uuid,
+                                parametermodel=parametermodel,
                                 tab="qc",
                                 id_string="ensemble-selector",
                                 heading="Ensemble A:",
-                                value=parent.pmodel.ensembles[0],
+                                value=parametermodel.ensembles[0],
                             ),
                             ensemble_selector(
-                                parent=parent,
+                                get_uuid=get_uuid,
+                                parametermodel=parametermodel,
                                 tab="qc",
                                 id_string="delta-ensemble-selector",
                                 heading="Ensemble B:",
-                                value=parent.pmodel.ensembles[-1],
+                                value=parametermodel.ensembles[-1],
                             ),
-                            sortby_selector(parent=parent, value="Name"),
+                            sortby_selector(get_uuid=get_uuid, value="Name"),
                             filter_parameter(
-                                parent=parent,
+                                get_uuid=get_uuid,
+                                parametermodel=parametermodel,
                                 tab="qc",
-                                value=[parent.pmodel.parameters[0]],
+                                value=[parametermodel.parameters[0]],
                             ),
                         ],
                         open_details=True,
@@ -50,11 +56,18 @@ def selector_view(parent) -> html.Div:
     )
 
 
-def parameter_qc_view(parent) -> wcc.FlexBox:
+def parameter_qc_view(
+    get_uuid: Callable, parametermodel: ParametersModel
+) -> wcc.FlexBox:
     return wcc.FlexBox(
         style={"margin": "20px"},
         children=[
-            html.Div(style={"flex": 1}, children=selector_view(parent=parent)),
+            html.Div(
+                style={"flex": 1},
+                children=selector_view(
+                    get_uuid=get_uuid, parametermodel=parametermodel
+                ),
+            ),
             html.Div(
                 style={"flex": 4, "height": "80vh"},
                 className="framed",
@@ -62,7 +75,7 @@ def parameter_qc_view(parent) -> wcc.FlexBox:
                     wcc.FlexBox(
                         children=[
                             dcc.RadioItems(
-                                id=parent.uuid("property-qc-plot-type"),
+                                id=get_uuid("property-qc-plot-type"),
                                 options=[
                                     {
                                         "label": "Distribution plots",
@@ -79,7 +92,7 @@ def parameter_qc_view(parent) -> wcc.FlexBox:
                         ]
                     ),
                     html.Div(
-                        style={"height": "75vh"}, id=parent.uuid("property-qc-wrapper")
+                        style={"height": "75vh"}, id=get_uuid("property-qc-wrapper")
                     ),
                 ],
             ),


### PR DESCRIPTION
Fixed issue in Parameteranalysis when no `Field` vectors were available.

---

### Contributor checklist

- [ ] :tada: This PR closes #591.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Allow initialization of plugin with no `Field` vectors
   - [ ] Changed view and controller function arguments to be more specific instead of parsing the whole plugin class.
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
