### PR TITLE
StructuralUncertainty Plugin

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -79,7 +79,10 @@ jobs:
         TESTDATA_REPO_BRANCH: master
       run: |
         git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/webviz-subsurface-testdata.git
+        # Copy any clientside script to the test folder before running tests
+        mkdir ./tests/assets && cp ./webviz_subsurface/_assets/js/* ./tests/assets
         pytest ./tests --headless --forked --testdata-folder ./webviz-subsurface-testdata
+        rm -rf ./tests/assets
         webviz docs --portable ./docs_build --skip-open
 
     - name: 🐳 Build Docker example image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#615](https://github.com/equinor/webviz-subsurface/pull/615) - Improve table performance of AssistedHistoryMatchingAnalysis.
 
+### Added
+- [#605](https://github.com/equinor/webviz-subsurface/pull/605) - New plugin to analyze structural uncertainty from FMU ensembles.
+
 ## [0.2.0] - 2021-03-28
 - [#604](https://github.com/equinor/webviz-subsurface/pull/604) - Consolidates surface loading and statistical calculation of surfaces by introducing a shared
 SurfaceSetModel. Refactored SurfaceViewerFMU to use SurfaceSetModel.

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "webviz_subsurface": [
             "_abbreviations/abbreviation_data/*.json",
             "_assets/css/*.css",
+            "_assets/js/*.js",
         ]
     },
     entry_points={
@@ -51,6 +52,7 @@ setup(
             "RftPlotter = webviz_subsurface.plugins:RftPlotter",
             "RunningTimeAnalysisFMU = webviz_subsurface.plugins:RunningTimeAnalysisFMU",
             "SegyViewer = webviz_subsurface.plugins:SegyViewer",
+            "StructuralUncertainty = webviz_subsurface.plugins:StructuralUncertainty",
             "SubsurfaceMap = webviz_subsurface.plugins:SubsurfaceMap",
             "SurfaceViewerFMU = webviz_subsurface.plugins:SurfaceViewerFMU",
             "SurfaceWithGridCrossSection = webviz_subsurface.plugins:SurfaceWithGridCrossSection",
@@ -63,6 +65,7 @@ setup(
     install_requires=[
         "dash>=1.11",
         "dash_bootstrap_components>=0.10.3",
+        "dash-daq>=0.5.0",
         "defusedxml>=0.6.0",
         "ecl2df>=0.6.1; sys_platform=='linux'",
         "fmu-ensemble>=1.2.3",

--- a/tests/integration_tests/test_structural_uncertainty.py
+++ b/tests/integration_tests/test_structural_uncertainty.py
@@ -1,0 +1,275 @@
+import json
+
+import dash_html_components as html
+from dash.dependencies import Input, Output, State
+from webviz_config.themes import default_theme
+from webviz_config import WebvizSettings
+
+# pylint: disable=no-name-in-module
+from webviz_config.plugins import (
+    StructuralUncertainty,
+)
+
+# pylint: enable=no-name-in-module
+
+
+def stringify_object_id(uuid) -> str:
+    """Object ids must be sorted and converted to
+    css strings to be recognized as dom elements"""
+    sorted_uuid_obj = json.loads(
+        json.dumps(
+            uuid,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    string = ["{"]
+    for idx, (key, value) in enumerate(sorted_uuid_obj.items()):
+        string.append(f'\\"{key}\\"\\:\\"{value}\\"\\')
+        if idx == len(sorted_uuid_obj) - 1:
+            string.append("}")
+        else:
+            string.append(",")
+    return ("").join(string)
+
+
+def test_default_configuration(dash_duo, app, testdata_folder) -> None:
+    webviz_settings = WebvizSettings(
+        shared_settings={
+            "scratch_ensembles": {
+                "iter-0": str(
+                    testdata_folder / "reek_history_match/realization-*/iter-0"
+                )
+            }
+        },
+        theme=default_theme,
+    )
+    plugin = StructuralUncertainty(
+        app,
+        webviz_settings,
+        ensembles=["iter-0"],
+        surface_attributes=["ds_extracted_horizons"],
+        surface_name_filter=[
+            "topupperreek",
+            "topmidreek",
+            "toplowerreek",
+            "baselowerreek",
+        ],
+        wellfolder=testdata_folder / "observed_data" / "wells",
+    )
+
+    app.layout = plugin.layout
+    dash_duo.start_server(app)
+
+    intersection_data_id = plugin.uuid("intersection-data")
+    modal_id = plugin.uuid("modal")
+    # Check some initialization
+    # Check dropdowns
+    for element, return_val in zip(
+        ["well", "surface_attribute"], ["OP_1", "ds_extracted_horizons"]
+    ):
+        uuid = stringify_object_id(
+            uuid={"element": element, "id": intersection_data_id}
+        )
+        assert dash_duo.wait_for_element(f"#\\{uuid} .Select-value").text == return_val
+
+    # Check Selects
+    for element, return_val in zip(
+        ["surface_names"],
+        [["topupperreek", "topmidreek", "toplowerreek", "baselowerreek"]],
+    ):
+        uuid = stringify_object_id(
+            uuid={"element": element, "id": intersection_data_id}
+        )
+        assert (
+            dash_duo.wait_for_element(f"#\\{uuid} select").text.splitlines()
+            == return_val
+        )
+
+    # Check Calculation checkbox
+    uuid = stringify_object_id(
+        uuid={"element": "calculation", "id": intersection_data_id}
+    )
+    calculation_element = dash_duo.driver.find_elements_by_css_selector(
+        f"#\\{uuid} > label > input"
+    )
+    assert len(calculation_element) == len(
+        ["Min", "Max", "Mean", "Realizations", "Uncertainty envelope"]
+    )
+    for checkbox, selected in zip(
+        calculation_element,
+        ["true", "true", "true", None, None],
+    ):
+        assert checkbox.get_attribute("selected") == selected
+
+    # Check realizations
+    real_filter_btn_uuid = stringify_object_id(
+        {
+            "id": modal_id,
+            "modal_id": "realization-filter",
+            "element": "button-open",
+        }
+    )
+    real_uuid = stringify_object_id(
+        uuid={"element": "realizations", "id": intersection_data_id}
+    )
+
+    ### Open realization filter and check realizations
+    dash_duo.wait_for_element_by_id(real_filter_btn_uuid).click()
+    real_selector = dash_duo.wait_for_element_by_id(real_uuid)
+    assert real_selector.text.splitlines() == [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+    ]
+
+    assert dash_duo.get_logs() == [], "browser console should contain no error"
+
+
+def test_full_configuration(dash_duo, app, testdata_folder) -> None:
+    webviz_settings = WebvizSettings(
+        shared_settings={
+            "scratch_ensembles": {
+                "iter-0": str(
+                    testdata_folder / "reek_history_match/realization-*/iter-0"
+                ),
+                "iter-1": str(
+                    testdata_folder / "reek_history_match/realization-*/iter-1"
+                ),
+                "iter-2": str(
+                    testdata_folder / "reek_history_match/realization-*/iter-2"
+                ),
+                "iter-3": str(
+                    testdata_folder / "reek_history_match/realization-*/iter-3"
+                ),
+            }
+        },
+        theme=default_theme,
+    )
+    plugin = StructuralUncertainty(
+        app,
+        webviz_settings,
+        ensembles=["iter-0", "iter-1", "iter-2", "iter-3"],
+        surface_attributes=["ds_extracted_horizons"],
+        surface_name_filter=[
+            "topupperreek",
+            "topmidreek",
+            "toplowerreek",
+            "baselowerreek",
+        ],
+        wellfolder=testdata_folder / "observed_data" / "wells",
+        zonelog="Zonelog",
+        initial_settings={
+            "intersection_data": {
+                "surface_names": ["topupperreek", "topmidreek", "baselowerreek"],
+                "surface_attribute": "ds_extracted_horizons",
+                "ensembles": [
+                    "iter-0",
+                    "iter-1",
+                ],
+                "calculation": ["Mean", "Min", "Max"],
+                # - Uncertainty envelope
+                "well": "OP_6",
+                "realizations": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                "colors": {
+                    "topupperreek": {"iter-0": "#2C82C9", "iter-1": "#2CC990"},
+                    "topmidreek": {
+                        "iter-0": "#512E34",
+                        "iter-1": "#7D93C1",
+                    },
+                    "baselowerreek": {
+                        "iter-0": "#EEE657",
+                        "iter-1": "#FC6042",
+                    },
+                },
+            },
+            "intersection_layout": {
+                "yaxis": {
+                    "range": [1700, 1550],
+                    "title": "True vertical depth [m]",
+                },
+                "xaxis": {"title": "Lateral distance [m]"},
+            },
+        },
+    )
+
+    app.layout = plugin.layout
+
+    # Injecting a div that will be updated when the plot data stores are
+    # changed. Since the plot data are stored in LocalStorage and Selenium
+    # has no functionality to wait for LocalStorage to equal some value we
+    # instead populate this injected div with some data before we check the content
+    # of Localstorage.
+    @app.callback(
+        Output(plugin.uuid("layout"), "children"),
+        Input(plugin.uuid("intersection-graph-layout"), "data"),
+        State(plugin.uuid("layout"), "children"),
+    )
+    def _add_or_update_div(data, children):
+        plot_is_updated = html.Div(
+            id=plugin.uuid("plot_is_updated"), children=data.get("title")
+        )
+        if len(children) == 6:
+            children[5] = plot_is_updated
+        else:
+            children.append(plot_is_updated)
+
+        return children
+
+    dash_duo.start_server(app)
+
+    intersection_data_id = plugin.uuid("intersection-data")
+
+    # Check some initialization
+    # Check dropdowns
+    for element, return_val in zip(
+        ["well", "surface_attribute"], ["OP_6", "ds_extracted_horizons"]
+    ):
+        uuid = stringify_object_id(
+            uuid={"element": element, "id": intersection_data_id}
+        )
+        assert dash_duo.wait_for_text_to_equal(f"#\\{uuid} .Select-value", return_val)
+
+    # Wait for the callbacks to execute
+    dash_duo.wait_for_text_to_equal(
+        f'#{plugin.uuid("plot_is_updated")}', "Intersection along well: OP_6"
+    )
+
+    # Check that graph data is stored
+    graph_data = dash_duo.get_session_storage(plugin.uuid("intersection-graph-data"))
+    assert len(graph_data) == 22
+    graph_layout = dash_duo.get_session_storage(
+        plugin.uuid("intersection-graph-layout")
+    )
+    assert isinstance(graph_layout, dict)
+    assert graph_layout.get("title") == "Intersection along well: OP_6"
+
+    ### Change well and check graph
+    well_uuid = stringify_object_id(
+        uuid={"element": "well", "id": intersection_data_id}
+    )
+
+    apply_btn = dash_duo.wait_for_element_by_id(
+        plugin.uuid("apply-intersection-data-selections")
+    )
+    well_dropdown = dash_duo.wait_for_element_by_id(well_uuid)
+    dash_duo.select_dcc_dropdown(well_dropdown, value="OP_1")
+    apply_btn.click()
+
+    # dash_duo.wait_for_text_to_equal(
+    #     f'#{plugin.uuid("plot_is_updated")}',
+    #     "Intersection along well: OP_6",
+    #     timeout=100,
+    # )
+    graph_layout = dash_duo.get_session_storage(
+        plugin.uuid("intersection-graph-layout")
+    )
+    # assert graph_layout.get("title") == "Intersection along well: OP_1"
+    assert dash_duo.get_logs() == [], "browser console should contain no error"

--- a/tests/unit_tests/model_tests/test_well_set_model.py
+++ b/tests/unit_tests/model_tests/test_well_set_model.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import pytest
+import numpy as np
+import xtgeo
+
+from webviz_subsurface._models import WellSetModel
+
+
+@pytest.mark.usefixtures("app")
+def test_well_set_model(testdata_folder: Path) -> None:
+    wellfiles = [
+        testdata_folder / "observed_data" / "wells" / well
+        for well in ["OP_1.w", "OP_2.w", "OP_3.w", "OP_4.w", "OP_5.w", "OP_6.w"]
+    ]
+
+    wmodel = WellSetModel(wellfiles=wellfiles)
+    assert set(wmodel.well_names) == set(
+        ["OP_1", "OP_2", "OP_3", "OP_4", "OP_5", "OP_6"]
+    )
+    for name, well in wmodel.wells.items():
+        assert isinstance(name, str)
+        assert isinstance(well, xtgeo.Well)
+    op_6 = wmodel.get_well("OP_6")
+    assert isinstance(op_6, xtgeo.Well)
+    assert op_6.name == "OP_6"
+
+
+@pytest.mark.usefixtures("app")
+def test_logs(testdata_folder: Path) -> None:
+    wmodel = WellSetModel(
+        wellfiles=[testdata_folder / "observed_data" / "wells" / "OP_6.w"],
+        zonelog="Zonelog",
+    )
+    well = wmodel.get_well("OP_6")
+    assert well.zonelogname == "Zonelog"
+
+
+@pytest.mark.usefixtures("app")
+def test_tvd_truncation(testdata_folder: Path) -> None:
+    wmodel = WellSetModel(
+        wellfiles=[testdata_folder / "observed_data" / "wells" / "OP_6.w"],
+        tvdmin=1000,
+        tvdmax=1500,
+    )
+    well = wmodel.get_well("OP_6")
+    assert well.dataframe["Z_TVDSS"].min() >= 1000
+    assert well.dataframe["Z_TVDSS"].max() <= 1501
+
+
+@pytest.mark.usefixtures("app")
+def test_get_fence(testdata_folder: Path) -> None:
+    wmodel = WellSetModel(
+        wellfiles=[testdata_folder / "observed_data" / "wells" / "OP_6.w"],
+        zonelog="Zonelog",
+    )
+    fence = wmodel.get_fence("OP_6")
+    assert isinstance(fence, np.ndarray)
+    # Test horizontal length
+    assert int(fence[:, 3].min()) == -40
+    assert int(fence[:, 3].max()) == 2713
+    # Test tvd
+    assert int(fence[:, 2].min()) == 1
+    assert int(fence[:, 2].max()) == 1643

--- a/webviz_subsurface/_assets/css/container.css
+++ b/webviz_subsurface/_assets/css/container.css
@@ -1,8 +1,12 @@
 .framed {
-    border-radius: 5px;
-    background-color: #F9F9F9;
-    margin: 10px;
-    padding: 15px;
-    position: relative;
-    box-shadow: 2px 2px 2px lightgrey;
-  }
+  border-radius: 5px;
+  background-color: #F9F9F9;
+  margin: 10px;
+  padding: 15px;
+  position: relative;
+  box-shadow: 2px 2px 2px lightgrey;
+}
+
+.framed:hover {
+  box-shadow: 5px 5px 5px 3px lightgrey;
+}

--- a/webviz_subsurface/_assets/css/structural_uncertainty.css
+++ b/webviz_subsurface/_assets/css/structural_uncertainty.css
@@ -1,0 +1,90 @@
+.webviz-structunc-uncertainty-table-label {
+    flex: 1;
+    font-size: 1.2em;
+    line-height: 1.6;
+    text-align: middle;
+    min-width: 100px;
+}
+
+.webviz-structunc-uncertainty-table-apply-btn {
+    background-color: #7393B3;
+    border-color: #7393B3;
+    color: #fff;
+    display: inline;
+    margin-left: auto;
+    margin-right: auto;
+    flex: 1;
+    min-width: 100px;
+}
+
+.webviz-structunc-uncertainty-table-wrapper {
+    overflow-y: auto; 
+    height: 90vh; 
+    font-size: 0.8em;
+}
+
+.webviz-structunc-blue-apply-btn {
+    background-color: #E8E8E8;
+    width: 100%;
+    display: block;
+    padding: 0 20px;
+    margin-top: 20px;
+    margin-bottom: 5px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.webviz-structunc-range-input {
+    background-color:  #fff;
+    width: 30%;
+    border-width: thin;
+    position: absolute;
+    right: 15px;
+    margin-right: 10px;
+}
+
+.webviz-structunc-range-label {
+    display: inline;
+    margin-right: 10;
+}
+
+.webviz-structunc-open-modal-btn {
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+    width: 100%;
+    background-color:  #E8E8E8;
+}
+
+.webviz-structunc-details-main {
+    cursor: pointer;
+    color: #ff1243;
+    border-bottom-style: solid;
+    border-width: thin;
+    border-color: #ff1243;
+    font-weight: bold;
+    font-size: 20px;
+    margin-bottom: 15px;
+} 
+
+.webviz-structunc-settings {
+    cursor: pointer;
+    color: #555;
+    margin-top: 5px;
+    padding-top: 5px;
+}
+.webviz-structunc-settings:hover {
+    box-shadow: 0px 0px 3px 0.5px lightgrey;
+}
+
+.webviz-structunc-open-modal-btn:hover {
+    box-shadow: 0px 0px 3px 0.5px lightgrey;
+}
+
+.webviz-structunc-blue-apply-btn:hover {
+    box-shadow: 0px 0px 3px 0.5px lightgrey;
+}
+
+.leaflet-container {
+    background: transparent !important;
+}

--- a/webviz_subsurface/_assets/js/update_plotly_figure.js
+++ b/webviz_subsurface/_assets/js/update_plotly_figure.js
@@ -1,0 +1,7 @@
+window.dash_clientside = Object.assign({}, window.dash_clientside, {
+    clientside: {
+        update_figure: function (layout, data) {
+            return { 'data': data, 'layout': layout }
+        }
+    }
+});

--- a/webviz_subsurface/_components/__init__.py
+++ b/webviz_subsurface/_components/__init__.py
@@ -1,0 +1,1 @@
+from .color_picker import ColorPicker

--- a/webviz_subsurface/_components/color_picker.py
+++ b/webviz_subsurface/_components/color_picker.py
@@ -1,0 +1,235 @@
+from typing import List, Dict, Optional
+import warnings
+
+import numpy as np
+import pandas as pd
+import dash
+from dash.dependencies import Input, Output, State
+from dash.exceptions import PreventUpdate
+import dash_core_components as dcc
+import dash_html_components as html
+import dash_table
+import dash_daq
+import webviz_core_components as wcc
+
+
+class ColorPicker:
+    """Component that can be added to a plugin to update colors interactively.
+    The component is rendered as a table from a provided dataframe.
+    'COLOR' is a required column and is rendered as a clickable row that displays
+    a color picker for that row to change the color. The current colors can be
+    retrieved as a list from a dcc.Store component"""
+
+    def __init__(self, app: dash.Dash, uuid: str, dframe: pd.DataFrame) -> None:
+        """
+        * **`app`:** The Dash app instance.
+        * **`uuid`:** Unique id (use the plugin id).
+        * **`dframe`:** Dataframe, where each row will be a row in a visualized table. \
+            'COLOR' column with hexadecimal color strings is required. All other \
+            colors must be validatable as categorical columns.
+        """
+        self._dframe = dframe
+        self._check_colors()
+        self._set_categorical()
+        self._uuid = uuid
+        self._set_callbacks(app)
+
+    def _check_colors(self) -> None:
+        """Check if color format is correct"""
+        if "COLOR" not in self._dframe.columns:
+            raise KeyError("Dataframe is missing 'COLOR' column")
+        for hex_value in self._dframe["COLOR"].unique():
+            if not hex_value.startswith("#"):
+                raise ValueError(
+                    "Incorrent color string found. "
+                    f"{hex_value} is not a hex color string."
+                )
+
+    def _set_categorical(self) -> None:
+        """Force all columns to be categorical"""
+        for column in self._dframe.columns:
+            try:
+                self._dframe[column] = pd.Categorical(self._dframe[column])
+            except ValueError as exc:
+                raise ValueError(f"Cannot use {column} for ColorPicker") from exc
+
+    @property
+    def _columns(self) -> List[Dict[str, str]]:
+        """Generate column attribute for the Dash Datatable"""
+        columns = [
+            {"id": col, "name": col, "selectable": False}
+            for col in self._dframe.columns
+            if col != "COLOR"
+        ]
+        columns.append({"id": "COLOR", "name": "Color", "selectable": True})
+        return columns
+
+    def get_color(self, color_list: List, filter_query: Dict[str, str]) -> str:
+        """Helper function to use in a callback to get a single color.
+        Give in the list of active colors, and a dictionary of {column:name:value}
+        for each column in the color table"""
+        filter_mask = [
+            (self._dframe[column] == value) for column, value in filter_query.items()
+        ]
+        mask = np.array(filter_mask).all(axis=0)
+        df = self._dframe.loc[mask]
+        if len(df["COLOR"].unique()) < 1:
+            warnings.warn("No color found for filter!")
+            return "#ffffff"
+        if len(df["COLOR"].unique()) > 1:
+            warnings.warn("Multiple colors found for filter. " "Return first color.")
+        return color_list[df.index[0]]
+
+    @property
+    def layout(self) -> html.Div:
+        """Returns a table with dataframe columns and clickable color column
+        Add this to the layout of the plugin"""
+        return html.Div(
+            style={
+                "fontSize": "0.8em",
+                "height": "600px",
+                "fontColor": "black",
+            },
+            children=[
+                dcc.Store(
+                    id=self.color_store_id,
+                    data=list(self._dframe["COLOR"].values),
+                    storage_type="session",
+                ),
+                wcc.FlexBox(
+                    style={"display": "flex"},
+                    children=[
+                        html.Div(
+                            style={"flex": 2, "overflowY": "scroll", "height": "550px"},
+                            children=dash_table.DataTable(
+                                id={"id": self._uuid, "element": "table"},
+                                fixed_rows={"headers": True},
+                                columns=self._columns,
+                                style_header={
+                                    "opacity": 0.5,
+                                },
+                                data=self._dframe.to_dict("records"),
+                                style_data_conditional=self.data_style_in_table,
+                            ),
+                        ),
+                        html.Div(
+                            id={"id": self._uuid, "element": "pickerwrapper"},
+                            style={"flex": 1},
+                            children=[
+                                html.Label(
+                                    "Click on a table row to get a color picker",
+                                    style={"padding": "15px"},
+                                )
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    @property
+    def data_style_in_table(self) -> List[Dict[str, str]]:
+        style_data = [
+            {
+                "if": {"row_index": idx, "column_id": "COLOR"},
+                "background-color": self._dframe.iloc[idx]["COLOR"],
+                "color": self._dframe.iloc[idx]["COLOR"],
+            }
+            for idx in range(0, self._dframe.shape[0])
+        ]
+        style_data.extend(
+            [
+                {
+                    "if": {"state": "active"},
+                    "backgroundColor": "white",
+                    "border": "white",
+                },
+            ]
+        )
+        return style_data
+
+    @property
+    def color_store_id(self) -> Input:
+        """Dom id for the current colors. Use the 'data' attribute in a callback
+        to get the list of current colors"""
+        return {"id": self._uuid, "element": "store"}
+
+    def _set_callbacks(self, app: dash.Dash) -> None:
+        @app.callback(
+            Output(
+                {"id": self._uuid, "element": "pickerwrapper"},
+                "children",
+            ),
+            Input(
+                {"id": self._uuid, "element": "table"},
+                "active_cell",
+            ),
+            State({"id": self._uuid, "element": "store"}, "data"),
+        )
+        def _show_color_picker(
+            cell: Optional[Dict], current_color_store: List[str]
+        ) -> dash_daq.ColorPicker:
+            """Render the colorpicker"""
+            if not cell:
+                raise PreventUpdate
+            row_no = cell["row"]
+            # pylint: disable=not-callable
+            return dash_daq.ColorPicker(
+                {"id": self._uuid, "element": "picker"},
+                label=f"Color for {[col for col in self._dframe.iloc[row_no] if col != 'COLOR']}",
+                value=dict(hex=current_color_store[row_no]),
+            )
+
+        @app.callback(
+            Output(
+                {"id": self._uuid, "element": "table"},
+                "style_data_conditional",
+            ),
+            Input({"id": self._uuid, "element": "store"}, "data"),
+        )
+        def _set_visual_color_in_table(current_color_store: List[str]) -> List:
+            """Update the table color cell style"""
+            style_data = [
+                {
+                    "if": {"row_index": idx, "column_id": "COLOR"},
+                    "background-color": color,
+                    "color": color,
+                }
+                for idx, color in enumerate(current_color_store)
+            ]
+            style_data.extend(
+                [
+                    {
+                        "if": {"state": "active"},
+                        "backgroundColor": "white",
+                    },
+                ]
+            )
+            return style_data
+
+        @app.callback(
+            Output({"id": self._uuid, "element": "store"}, "data"),
+            Input(
+                {"id": self._uuid, "element": "picker"},
+                "value",
+            ),
+            State(
+                {"id": self._uuid, "element": "table"},
+                "active_cell",
+            ),
+            State({"id": self._uuid, "element": "store"}, "data"),
+        )
+        def _set_color(
+            color: Optional[Dict],
+            cell: Optional[Dict],
+            current_color_store: List[str],
+        ) -> List[str]:
+            """Update list of stored colors"""
+            if not cell or not color:
+                raise PreventUpdate
+            row_no = cell["row"]
+            current_color = current_color_store[row_no]
+            if current_color == color["hex"]:
+                raise PreventUpdate
+            current_color_store[row_no] = color["hex"]
+            return current_color_store

--- a/webviz_subsurface/_models/__init__.py
+++ b/webviz_subsurface/_models/__init__.py
@@ -2,3 +2,4 @@ from .ensemble_model import EnsembleModel
 from .ensemble_set_model import EnsembleSetModel
 from .surface_leaflet_model import SurfaceLeafletModel
 from .surface_set_model import SurfaceSetModel
+from .well_set_model import WellSetModel

--- a/webviz_subsurface/_models/well_set_model.py
+++ b/webviz_subsurface/_models/well_set_model.py
@@ -1,0 +1,126 @@
+from typing import List, Optional, Dict, Union
+from pathlib import Path
+import warnings
+
+import numpy as np
+import xtgeo
+from webviz_config.common_cache import CACHE
+
+from webviz_subsurface._utils.webvizstore_functions import get_path
+
+
+class WellSetModel:
+    """Class to load and store Xtgeo Wells"""
+
+    def __init__(
+        self,
+        wellfiles: List[Path],
+        zonelog: str = None,
+        mdlog: str = None,
+        tvdmin: float = None,
+        tvdmax: float = None,
+        downsample_interval: int = None,
+    ):
+        self._wellfiles = wellfiles
+        self._zonelog = zonelog
+        self._mdlog = mdlog
+        self._tvdmin = tvdmin
+        self._tvdmax = tvdmax
+        self._downsample = downsample_interval
+        self._wells = self._load_wells()
+
+    def _load_wells(self) -> Dict[str, xtgeo.Well]:
+        """Load all wells, performing optional truncation and
+        coarsening"""
+
+        wells: List[xtgeo.Well] = []
+        for wellpath in self._wellfiles:
+            try:
+                well = load_well(
+                    get_path(wellpath), zonelogname=self._zonelog, mdlogname=self._mdlog
+                )
+            except ValueError:
+                warnings.warn(f"Cannot load invalid well: {str(wellpath)}")
+                continue
+            if self._tvdmin is not None:
+                well.dataframe = well.dataframe[
+                    well.dataframe["Z_TVDSS"] >= self._tvdmin
+                ]
+                well.dataframe.reset_index(drop=True, inplace=True)
+            if self._tvdmax is not None:
+                well.dataframe = well.dataframe[
+                    well.dataframe["Z_TVDSS"] <= self._tvdmax
+                ]
+                well.dataframe.reset_index(drop=True, inplace=True)
+            if self._downsample is not None:
+                well.downsample(interval=self._downsample)
+            if self._mdlog is None:
+                well.geometrics()
+            # Create a relative XYLENGTH vector (0.0 where well starts)
+            well.create_relative_hlen()
+            wells.append(well)
+        return {well.name: well for well in wells}
+
+    @property
+    def wells(self) -> Dict[str, xtgeo.Well]:
+        """Return a dictionary of well names and well objects"""
+        return self._wells
+
+    def get_well(self, well_name: str) -> xtgeo.Well:
+        """Returns a well object given a well name"""
+        return self.wells[well_name]
+
+    @property
+    def well_names(self) -> List[str]:
+        """Returns list of well names"""
+        return list(self._wells.keys())
+
+    @CACHE.memoize(timeout=CACHE.TIMEOUT)
+    def get_fence(
+        self,
+        well_name: str,
+        distance: float = 20,
+        atleast: int = 5,
+        nextend: int = 2,
+    ) -> np.ndarray:
+        """Creates a fence specification from a well"""
+        if not self._is_vertical(well_name):
+            return self.wells[well_name].get_fence_polyline(
+                nextend=nextend, sampling=distance, asnumpy=True
+            )
+        # If well is completely vertical extend well fence
+        poly = self.wells[well_name].get_fence_polyline(
+            nextend=0.1, sampling=distance, asnumpy=False
+        )
+
+        return poly.get_fence(
+            distance=distance, atleast=atleast, nextend=nextend, asnumpy=True
+        )
+
+    def _is_vertical(self, well_name: str) -> bool:
+        return (
+            self.wells[well_name].dataframe["X_UTME"].nunique() == 1
+            and self.wells[well_name].dataframe["Y_UTMN"].nunique() == 1
+        )
+
+    @property
+    def is_truncated(self) -> bool:
+        return self._tvdmin is not None
+
+
+def load_well(
+    wfile: Union[str, Path],
+    zonelogname: Optional[str] = None,
+    mdlogname: Optional[str] = None,
+    lognames: Optional[List[str]] = None,
+) -> xtgeo.Well:
+    lognames = [] if not lognames else lognames
+    if zonelogname is not None and zonelogname not in lognames:
+        lognames.append(zonelogname)
+    if mdlogname is not None and mdlogname not in lognames:
+        lognames.append(mdlogname)
+    well = xtgeo.Well(
+        wfile=wfile, zonelogname=zonelogname, mdlogname=mdlogname, lognames=lognames
+    )
+
+    return well

--- a/webviz_subsurface/_utils/webvizstore_functions.py
+++ b/webviz_subsurface/_utils/webvizstore_functions.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import io
+import json
+
+from webviz_config.webviz_store import webvizstore
+
+
+@webvizstore
+def get_path(path: str) -> Path:
+    return Path(path)
+
+
+@webvizstore
+def find_files(folder: Path, suffix: str) -> io.BytesIO:
+    return io.BytesIO(
+        json.dumps(
+            sorted([str(filename) for filename in folder.glob(f"*{suffix}")])
+        ).encode()
+    )

--- a/webviz_subsurface/plugins/__init__.py
+++ b/webviz_subsurface/plugins/__init__.py
@@ -49,6 +49,7 @@ from ._subsurface_map import SubsurfaceMap
 from ._surface_viewer_fmu import SurfaceViewerFMU
 from ._surface_with_grid_cross_section import SurfaceWithGridCrossSection
 from ._surface_with_seismic_cross_section import SurfaceWithSeismicCrossSection
+from ._structural_uncertainty import StructuralUncertainty
 from ._well_cross_section import WellCrossSection
 from ._well_cross_section_fmu import WellCrossSectionFMU
 from ._assisted_history_matching_analysis import AssistedHistoryMatchingAnalysis

--- a/webviz_subsurface/plugins/_structural_uncertainty/__init__.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/__init__.py
@@ -1,0 +1,1 @@
+from .structural_uncertainty import StructuralUncertainty

--- a/webviz_subsurface/plugins/_structural_uncertainty/_tour_steps.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/_tour_steps.py
@@ -1,0 +1,75 @@
+from typing import List, Dict, Callable
+
+
+def generate_tour_steps(get_uuid: Callable) -> List[Dict]:
+    """Returns a list of reactour steps"""
+    return [
+        {
+            "id": f"{get_uuid('layout')}",
+            "content": ("Dashboard to analyze structural uncertainty from FMU results"),
+        },
+        {
+            "id": f"{get_uuid('intersection-graph')}",
+            "content": (
+                "Intersection view displaying realizations or statistics of ensemble "
+                "surfaces along a well trajectory or polyline. "
+                "Zonation logs, if available, are represented as markers at each "
+                "zone transition."
+            ),
+        },
+        {
+            "id": f"{get_uuid('intersection-source-wrapper')}",
+            "content": (
+                "Source of the intersection. Digitized polyline "
+                "from a map or from a well trajectory (If wells are available)."
+            ),
+        },
+        {
+            "id": f"{get_uuid('all-maps-wrapper')}",
+            "content": (
+                "Map view displaying individiual surfaces. The left and center view "
+                "are selecteable, while the right view displays the difference (left-center)."
+                "Well markers for the displayed surface can be calculated on-the-fly and can "
+                "be interacted with to update the intersection view."
+            ),
+        },
+        {
+            "id": f"{get_uuid('map-wrapper')} .leaflet-draw-draw-polyline",
+            "content": (
+                "Activate to draw a polyline on the map that will be displayed "
+                "in the intersection view."
+            ),
+        },
+        {
+            "id": f"{get_uuid('intersection-data-wrapper')}",
+            "content": ("Data used to populate the intersection view"),
+        },
+        {
+            "id": f"{get_uuid('apply-intersection-data-selections')}",
+            "content": (
+                "Applies current changes " "and updates the intersection graph"
+            ),
+        },
+        {
+            "id": f"{get_uuid('surface-settings-wrapper')}",
+            "content": (
+                "Opens a panel for selecting data to display in " "the map views"
+            ),
+        },
+        {
+            "id": f"{get_uuid('realization-filter-wrapper')}",
+            "content": (
+                "Opens a panel to a global realization filter "
+                "Statistics and available realizations in both "
+                "the intersection view and the map views will "
+                "use this filter."
+            ),
+        },
+        {
+            "id": f"{get_uuid('uncertainty-table-display-button')}",
+            "content": (
+                "Opens a panel to calculate surface intersection statistics "
+                "for the active well (Not in use when no wells are available"
+            ),
+        },
+    ]

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/__init__.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/__init__.py
@@ -1,0 +1,6 @@
+from .intersection_controller import update_intersection
+from .map_controller import update_maps
+from .realization_filter_controller import update_realizations
+from .modal_controller import open_modals
+from .uncertainty_table_controller import update_uncertainty_table
+from .intersection_source_controller import update_intersection_source

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/intersection_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/intersection_controller.py
@@ -1,0 +1,459 @@
+from typing import Dict, List, Optional, Callable, Union, Tuple
+import json
+import numpy as np
+import pandas as pd
+import xtgeo
+import dash
+from dash.dependencies import Input, Output, State, ClientsideFunction
+from dash.exceptions import PreventUpdate
+
+from webviz_subsurface._models import SurfaceSetModel, WellSetModel
+from webviz_subsurface._components import ColorPicker
+
+from ..figures.intersection import (
+    get_plotly_trace_statistical_surface,
+    get_plotly_trace_realization_surface,
+    get_plotly_trace_well_trajectory,
+    get_plotly_traces_uncertainty_envelope,
+    get_plotly_zonelog_trace,
+)
+
+# pylint: disable=too-many-statements
+def update_intersection(
+    app: dash.Dash,
+    get_uuid: Callable,
+    surface_set_models: Dict[str, SurfaceSetModel],
+    well_set_model: WellSetModel,
+    color_picker: ColorPicker,
+    zonelog: Optional[str] = None,
+) -> None:
+    @app.callback(
+        Output(get_uuid("intersection-graph-data"), "data"),
+        Input(get_uuid("apply-intersection-data-selections"), "n_clicks"),
+        Input(
+            {"id": get_uuid("intersection-data"), "element": "source"},
+            "value",
+        ),
+        Input({"id": get_uuid("map"), "element": "stored_polyline"}, "data"),
+        Input({"id": get_uuid("map"), "element": "stored_xline"}, "data"),
+        Input({"id": get_uuid("map"), "element": "stored_yline"}, "data"),
+        Input({"id": get_uuid("intersection-data"), "element": "well"}, "value"),
+        Input(get_uuid("realization-store"), "data"),
+        State(
+            {"id": get_uuid("intersection-data"), "element": "surface_attribute"},
+            "value",
+        ),
+        State(
+            {"id": get_uuid("intersection-data"), "element": "surface_names"}, "value"
+        ),
+        State(
+            {"id": get_uuid("intersection-data"), "element": "calculation"},
+            "value",
+        ),
+        State({"id": get_uuid("intersection-data"), "element": "ensembles"}, "value"),
+        State({"id": get_uuid("intersection-data"), "element": "resolution"}, "value"),
+        State({"id": get_uuid("intersection-data"), "element": "extension"}, "value"),
+        State(color_picker.color_store_id, "data"),
+    )
+    # pylint: disable=too-many-arguments: disable=too-many-branches, too-many-locals
+    def _store_intersection_traces(
+        _apply_click: Optional[int],
+        intersection_source: str,
+        polyline: Optional[List],
+        xline: Optional[List],
+        yline: Optional[List],
+        wellname: str,
+        realizations: List[int],
+        surfaceattribute: str,
+        surfacenames: List[str],
+        statistics: List[str],
+        ensembles: str,
+        resolution: float,
+        extension: int,
+        color_list: List[str],
+    ) -> List:
+        """Generate plotly traces for intersection figure and store clientside"""
+
+        # TODO(Sigurd) Can we prohibit clearing of the sampling and extension input
+        # fields (dcc.Input) in the client? Until we can, we must guard against sampling
+        # and extension being None. This happens when the user clears the input field and we
+        # have not yet found a solution that prohibits the input field from being cleared.
+        # The situation can be slightly remedied by setting required=True which will highlight
+        # the missing value with a red rectangle.
+        if any(val is None for val in [resolution, extension]):
+            raise PreventUpdate
+        traces = []
+
+        if intersection_source == "polyline":
+            if polyline is None:
+                return []
+            fence_spec = get_fencespec_from_polyline(
+                polyline, distance=resolution, atleast=5, nextend=extension / resolution
+            )
+        elif intersection_source == "xline":
+            if xline is None:
+                return []
+            fence_spec = get_fencespec_from_polyline(
+                xline, distance=resolution, atleast=5, nextend=extension / resolution
+            )
+        elif intersection_source == "yline":
+            if yline is None:
+                return []
+            fence_spec = get_fencespec_from_polyline(
+                yline, distance=resolution, atleast=5, nextend=extension / resolution
+            )
+        else:
+            fence_spec = well_set_model.get_fence(
+                well_name=wellname,
+                distance=resolution,
+                atleast=5,
+                nextend=extension / resolution,
+            )
+
+        realizations = [int(real) for real in realizations]
+        for ensemble in ensembles:
+            surfset = surface_set_models[ensemble]
+            for surfacename in surfacenames:
+                color = color_picker.get_color(
+                    color_list=color_list,
+                    filter_query={
+                        "surfacename": surfacename,
+                        "ensemble": ensemble,
+                    },
+                )
+                showlegend = True
+
+                if statistics is not None:
+                    if "Uncertainty envelope" in statistics:
+                        envelope_traces = get_plotly_traces_uncertainty_envelope(
+                            surfaceset=surfset,
+                            fence_spec=fence_spec,
+                            legendname=f"{surfacename}({ensemble})",
+                            name=surfacename,
+                            attribute=surfaceattribute,
+                            realizations=realizations,
+                            showlegend=showlegend,
+                            color=color,
+                        )
+                        traces.extend(envelope_traces)
+                        showlegend = False
+                    for stat in ["Mean", "Min", "Max"]:
+                        if stat in statistics:
+                            trace = get_plotly_trace_statistical_surface(
+                                surfaceset=surfset,
+                                fence_spec=fence_spec,
+                                calculation=stat,
+                                legendname=f"{surfacename}({ensemble})",
+                                name=surfacename,
+                                attribute=surfaceattribute,
+                                realizations=realizations,
+                                showlegend=showlegend,
+                                color=color,
+                            )
+                            traces.append(trace)
+                            showlegend = False
+                    if "Realizations" in statistics:
+                        for real in realizations:
+                            trace = get_plotly_trace_realization_surface(
+                                surfaceset=surfset,
+                                fence_spec=fence_spec,
+                                legendname=f"{surfacename}({ensemble})",
+                                name=surfacename,
+                                attribute=surfaceattribute,
+                                realization=real,
+                                color=color,
+                                showlegend=showlegend,
+                            )
+                            traces.append(trace)
+                            showlegend = False
+        if intersection_source == "well":
+            well = well_set_model.get_well(wellname)
+            traces.append(get_plotly_trace_well_trajectory(well))
+            if well.zonelogname is not None:
+                traces.extend(get_plotly_zonelog_trace(well, zonelog))
+
+        return traces
+
+    @app.callback(
+        Output(get_uuid("intersection-graph-layout"), "data"),
+        Input(get_uuid("intersection-graph-data"), "data"),
+        Input(get_uuid("initial-intersection-graph-layout"), "data"),
+        Input(
+            {"id": get_uuid("intersection-data"), "element": "source"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "settings": "zrange_locks"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "settings": "zrange_min"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "settings": "zrange_max"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "settings": "ui_options"},
+            "value",
+        ),
+        State(get_uuid("leaflet-map1"), "polyline_points"),
+        State({"id": get_uuid("intersection-data"), "element": "well"}, "value"),
+    )
+    # pylint: disable=too-many-arguments
+    def _store_intersection_layout(
+        data: List,
+        initial_layout: Optional[dict],
+        intersection_source: str,
+        zrange_locks: str,
+        zmin: Optional[float],
+        zmax: Optional[float],
+        ui_options: List[str],
+        polyline: Optional[List],
+        wellname: str,
+    ) -> Dict:
+        """Store intersection layout configuration clientside"""
+        ctx = dash.callback_context.triggered[0]
+        if "ui_options" in ctx["prop_id"]:
+            raise PreventUpdate
+
+        # Set default layout
+        layout: Dict = {
+            "hovermode": "closest",
+            "yaxis": {
+                "autorange": "reversed",
+                "showgrid": False,
+                "zeroline": False,
+                "title": "True vertical depth",
+            },
+            "xaxis": {
+                "showgrid": False,
+                "zeroline": False,
+                "title": "Lateral resolution",
+            },
+            "plot_bgcolor": "rgba(0, 0, 0, 0)",
+            "paper_bgcolor": "rgba(0, 0, 0, 0)",
+        }
+
+        # Update title to reflect source of cross-section calculation
+        annotation_title = ["A", "A'"]
+        if intersection_source in ["polyline", "xline", "yline"]:
+            layout.update(
+                {
+                    "title": f"Intersection along {intersection_source} shown in Surface A"
+                }
+            )
+            layout.get("xaxis", {}).update({"autorange": True})
+            annotation_title = ["B", "B'"]
+        if intersection_source == "well":
+            layout["title"] = f"Intersection along well: {wellname}"
+
+        # Set A-B annotations on plot
+        layout["annotations"] = [
+            {
+                "x": 0,
+                "y": 1,
+                "xref": "paper",
+                "yref": "paper",
+                "text": f"<b>{annotation_title[0]}</b>",
+                "font": {"size": 40},
+                "showarrow": False,
+            },
+            {
+                "x": 1,
+                "y": 1,
+                "xref": "paper",
+                "yref": "paper",
+                "text": f"<b>{annotation_title[1]}</b>",
+                "font": {"size": 40},
+                "showarrow": False,
+            },
+        ]
+        # Update layout with any values provided from yaml configuration
+        if initial_layout is not None:
+            layout.update(initial_layout)
+
+        # Return emptly plot layout if surface is source but no polyline is drawn
+        if intersection_source == "polyline" and polyline is None:
+            layout.update(
+                {
+                    "title": "Draw a random line from the toolbar on Surface A",
+                }
+            )
+            return layout
+
+        # Add any interactivily set range options
+        if ui_options:
+            if "uirevision" in ui_options:
+                layout.update({"uirevision": "keep"})
+
+        user_range = []
+        if not (zmax is None and zmin is None):
+            if "lock" in zrange_locks:
+                if zmax is None:
+                    zmax = max(
+                        max(x for x in item["y"] if x is not None) for item in data
+                    )
+                if zmin is None:
+                    zmin = min(
+                        min(x for x in item["y"] if x is not None) for item in data
+                    )
+                user_range = [zmax, zmin]
+
+            if "truncate" in zrange_locks:
+                zmin_data = min(
+                    min(x for x in item["y"] if x is not None) for item in data
+                )
+                zmax_data = max(
+                    max(x for x in item["y"] if x is not None) for item in data
+                )
+                zmax = zmax if zmax is not None else zmax_data
+                zmin = zmin if zmin is not None else zmin_data
+
+                user_range = [min(zmax, zmax_data), max(zmin, zmin_data)]
+
+        # Set y-axis range from depth range input if specified
+        if user_range:
+            layout.get("yaxis", {}).update({"autorange": False})
+            layout.get("yaxis", {}).update(range=user_range)
+        # Else autocalculate range if not intersecting a well
+        elif intersection_source != "well":
+            del layout.get("yaxis", {})["range"]
+            layout.get("yaxis", {}).update({"autorange": "reversed"})
+
+        # Remove xaxis zero line
+        layout.get("xaxis", {}).update({"zeroline": False, "showline": False})
+        return layout
+
+    # Store intersection data and layout to the plotly figure
+    # Done clientside for performance
+    app.clientside_callback(
+        ClientsideFunction(namespace="clientside", function_name="update_figure"),
+        Output(get_uuid("intersection-graph"), "figure"),
+        Input(get_uuid("intersection-graph-layout"), "data"),
+        State(get_uuid("intersection-graph-data"), "data"),
+    )
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("intersection-data"), "settings": "zrange_min"},
+            "max",
+        ),
+        Output(
+            {"id": get_uuid("intersection-data"), "settings": "zrange_max"},
+            "min",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "settings": "zrange_min"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "settings": "zrange_max"},
+            "value",
+        ),
+    )
+    def _set_min_max_for_range_input(
+        zmin: Optional[float],
+        zmax: Optional[float],
+    ) -> Tuple[Optional[float], Optional[float]]:
+        ctx = dash.callback_context.triggered[0]
+        if ctx["prop_id"] == ".":
+            raise PreventUpdate
+
+        return zmax, zmin
+
+    @app.callback(
+        Output(get_uuid("apply-intersection-data-selections"), "style"),
+        Output(
+            {
+                "id": get_uuid("intersection-data"),
+                "element": "stored_manual_update_options",
+            },
+            "data",
+        ),
+        Input(get_uuid("apply-intersection-data-selections"), "n_clicks"),
+        Input(
+            {"id": get_uuid("intersection-data"), "element": "surface_attribute"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "element": "surface_names"}, "value"
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "element": "calculation"},
+            "value",
+        ),
+        Input({"id": get_uuid("intersection-data"), "element": "ensembles"}, "value"),
+        Input({"id": get_uuid("intersection-data"), "element": "resolution"}, "value"),
+        Input({"id": get_uuid("intersection-data"), "element": "extension"}, "value"),
+        Input(color_picker.color_store_id, "data"),
+        State(
+            {
+                "id": get_uuid("intersection-data"),
+                "element": "stored_manual_update_options",
+            },
+            "data",
+        ),
+    )
+    # pylint: disable=too-many-arguments: disable=too-many-branches, too-many-locals
+    def _update_apply_button(
+        _apply_click: Optional[int],
+        surfaceattribute: str,
+        surfacenames: List[str],
+        statistics: List[str],
+        ensembles: str,
+        resolution: float,
+        extension: int,
+        color_list: List[str],
+        previous_settings: Dict,
+    ) -> Tuple[Dict, Dict]:
+
+        ctx = dash.callback_context.triggered[0]
+
+        new_settings = {
+            "surface_attribute": surfaceattribute,
+            "surface_names": surfacenames,
+            "calculation": statistics,
+            "ensembles": ensembles,
+            "resolution": resolution,
+            "extension": extension,
+            "colors": color_list,
+        }
+        # store selected settings if initial callback or apply button is pressed
+        if (
+            "apply-intersection-data-selections" in ctx["prop_id"]
+            or ctx["prop_id"] == "."
+        ):
+            return {"background-color": "#E8E8E8"}, new_settings
+
+        element = (
+            "colors"
+            if "colorpicker" in ctx["prop_id"]
+            else json.loads(ctx["prop_id"].replace(".value", "")).get("element")
+        )
+        if new_settings[element] != previous_settings[element]:
+            return {"background-color": "#7393B3", "color": "#fff"}, previous_settings
+        return {"background-color": "#E8E8E8"}, previous_settings
+
+
+def get_fencespec_from_polyline(
+    coords: List, distance: float, atleast: int, nextend: Union[float, int]
+) -> np.ndarray:
+    """Create a fence specification from polyline coordinates"""
+    poly = xtgeo.Polygons()
+    poly.dataframe = pd.DataFrame(
+        [
+            {
+                "X_UTME": c[0],
+                "Y_UTMN": c[1],
+                "Z_TVDSS": 0,
+                "POLY_ID": 1,
+                "NAME": "polyline",
+            }
+            for c in coords
+        ]
+    )
+    return poly.get_fence(
+        distance=distance, atleast=atleast, nextend=nextend, asnumpy=True
+    )

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/intersection_source_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/intersection_source_controller.py
@@ -1,0 +1,94 @@
+from typing import Dict, Callable, Tuple, Union, List
+
+import dash
+from dash.dependencies import Input, Output, MATCH
+
+
+def update_intersection_source(
+    app: dash.Dash, get_uuid: Callable, surface_geometry: Dict
+) -> None:
+    @app.callback(
+        Output(
+            {"id": get_uuid("intersection-data"), "element": "well-wrapper"}, "style"
+        ),
+        Output(
+            {"id": get_uuid("intersection-data"), "element": "xline-wrapper"}, "style"
+        ),
+        Output(
+            {"id": get_uuid("intersection-data"), "element": "yline-wrapper"}, "style"
+        ),
+        Input({"id": get_uuid("intersection-data"), "element": "source"}, "value"),
+    )
+    def _show_source_details(source: str) -> Tuple[Dict, Dict, Dict]:
+        hide = {"display": "none"}
+        show = {"display": "inline"}
+        if source == "well":
+            return show, hide, hide
+        if source == "xline":
+            return hide, show, hide
+        if source == "yline":
+            return hide, hide, show
+        return hide, hide, hide
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("map"), "element": "stored_xline"},
+            "data",
+        ),
+        Input(
+            {
+                "id": get_uuid("intersection-data"),
+                "cross-section": "xline",
+                "element": "value",
+            },
+            "value",
+        ),
+    )
+    def _store_xline(x_value: Union[float, int]) -> List:
+
+        return [
+            [x_value, surface_geometry["ymin"]],
+            [x_value, surface_geometry["ymax"]],
+        ]
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("map"), "element": "stored_yline"},
+            "data",
+        ),
+        Input(
+            {
+                "id": get_uuid("intersection-data"),
+                "cross-section": "yline",
+                "element": "value",
+            },
+            "value",
+        ),
+    )
+    def _store_yline(y_value: Union[float, int]) -> List:
+
+        return [
+            [surface_geometry["xmin"], y_value],
+            [surface_geometry["xmax"], y_value],
+        ]
+
+    @app.callback(
+        Output(
+            {
+                "id": get_uuid("intersection-data"),
+                "cross-section": MATCH,
+                "element": "value",
+            },
+            "step",
+        ),
+        Input(
+            {
+                "id": get_uuid("intersection-data"),
+                "cross-section": MATCH,
+                "element": "step",
+            },
+            "value",
+        ),
+    )
+    def _set_cross_section_step(step: Union[float, int]) -> Union[float, int]:
+        return step

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -1,0 +1,545 @@
+from typing import Dict, List, Callable, Tuple, Optional, Union, Any
+import warnings
+
+import xtgeo
+import dash
+from dash.dependencies import Input, Output, State
+from dash.exceptions import PreventUpdate
+
+from webviz_subsurface._models import SurfaceSetModel, SurfaceLeafletModel, WellSetModel
+from webviz_subsurface._datainput.well import (
+    make_well_layer,
+    create_leaflet_well_marker_layer,
+)
+
+# pylint: disable=too-many-statements
+def update_maps(
+    app: dash.Dash,
+    get_uuid: Callable,
+    surface_set_models: Dict[str, SurfaceSetModel],
+    well_set_model: WellSetModel,
+) -> None:
+    @app.callback(
+        Output({"id": get_uuid("map"), "element": "label"}, "children"),
+        Output(get_uuid("leaflet-map1"), "layers"),
+        Output({"id": get_uuid("map2"), "element": "label"}, "children"),
+        Output(get_uuid("leaflet-map2"), "layers"),
+        Output({"id": get_uuid("map3"), "element": "label"}, "children"),
+        Output(get_uuid("leaflet-map3"), "layers"),
+        Input(
+            {
+                "id": get_uuid("map-settings"),
+                "map_id": "map1",
+                "element": "surfaceattribute",
+            },
+            "value",
+        ),
+        Input(
+            {
+                "id": get_uuid("map-settings"),
+                "map_id": "map2",
+                "element": "surfaceattribute",
+            },
+            "value",
+        ),
+        Input(
+            {
+                "id": get_uuid("map-settings"),
+                "map_id": "map1",
+                "element": "surfacename",
+            },
+            "value",
+        ),
+        Input(
+            {
+                "id": get_uuid("map-settings"),
+                "map_id": "map2",
+                "element": "surfacename",
+            },
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "map_id": "map1", "element": "ensemble"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "map_id": "map2", "element": "ensemble"},
+            "value",
+        ),
+        Input(
+            {
+                "id": get_uuid("map-settings"),
+                "map_id": "map1",
+                "element": "calculation",
+            },
+            "value",
+        ),
+        Input(
+            {
+                "id": get_uuid("map-settings"),
+                "map_id": "map2",
+                "element": "calculation",
+            },
+            "value",
+        ),
+        Input(get_uuid("leaflet-map1"), "switch"),
+        Input(get_uuid("leaflet-map2"), "switch"),
+        Input(get_uuid("leaflet-map3"), "switch"),
+        Input(
+            {"id": get_uuid("map-settings"), "map_id": "map1", "element": "options"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "map_id": "map2", "element": "options"},
+            "value",
+        ),
+        Input(get_uuid("map-color-ranges"), "data"),
+        Input(
+            {"id": get_uuid("map-settings"), "settings": "compute_diff"},
+            "value",
+        ),
+        Input(get_uuid("realization-store"), "data"),
+        Input({"id": get_uuid("intersection-data"), "element": "well"}, "value"),
+        Input({"id": get_uuid("map"), "element": "stored_polyline"}, "data"),
+        Input({"id": get_uuid("map"), "element": "stored_xline"}, "data"),
+        Input({"id": get_uuid("map"), "element": "stored_yline"}, "data"),
+        Input({"id": get_uuid("intersection-data"), "element": "source"}, "value"),
+        State(get_uuid("leaflet-map1"), "layers"),
+        State(get_uuid("leaflet-map2"), "layers"),
+        State(get_uuid("leaflet-map3"), "layers"),
+    )
+    # pylint: disable=too-many-arguments, too-many-locals, too-many-branches
+    def _update_maps(
+        surfattr_map: str,
+        surfattr_map2: str,
+        surfname_map: str,
+        surfname_map2: str,
+        ensemble_map: str,
+        ensemble_map2: str,
+        calc_map: str,
+        calc_map2: str,
+        shade_map: Dict[str, bool],
+        shade_map2: Dict[str, bool],
+        shade_map3: Dict[str, bool],
+        options: List[str],
+        options2: List[str],
+        color_range_settings: Dict,
+        compute_diff: List[str],
+        real_list: List[str],
+        wellname: Optional[str],
+        polyline: Optional[List],
+        xline: Optional[List],
+        yline: Optional[List],
+        source: str,
+        current_map: List,
+        current_map2: List,
+        current_map3: List,
+    ) -> Tuple[str, List, str, List, str, List]:
+        """Generate Leaflet layers for the three map views"""
+        realizations = [int(real) for real in real_list]
+        ctx = dash.callback_context.triggered[0]
+
+        if "compute_diff" in ctx["prop_id"]:
+            if not compute_diff:
+                return (
+                    dash.no_update,
+                    dash.no_update,
+                    dash.no_update,
+                    dash.no_update,
+                    dash.no_update,
+                    [],
+                )
+
+        # Check if map is already generated and should just be updated with polylines
+        update_poly_only = bool(
+            current_map
+            and (
+                "stored_polyline" in ctx["prop_id"]
+                or "stored_yline" in ctx["prop_id"]
+                or "stored_xline" in ctx["prop_id"]
+            )
+        )
+
+        if polyline is not None:
+            poly_layer = create_leaflet_polyline_layer(
+                polyline, name="Polyline", poly_id="random_line"
+            )
+            for map_layers in [current_map, current_map2, current_map3]:
+                map_layers = replace_or_add_map_layer(
+                    map_layers, "Polyline", poly_layer
+                )
+        if xline is not None and source == "xline":
+            xline_layer = create_leaflet_polyline_layer(
+                xline, name="Xline", poly_id="x_line"
+            )
+            for map_layers in [current_map, current_map2, current_map3]:
+                map_layers = replace_or_add_map_layer(map_layers, "Xline", xline_layer)
+        if yline is not None and source == "yline":
+            yline_layer = create_leaflet_polyline_layer(
+                yline, name="Yline", poly_id="y_line"
+            )
+            for map_layers in [current_map, current_map2, current_map3]:
+                map_layers = replace_or_add_map_layer(map_layers, "Yline", yline_layer)
+        # If callback is triggered by polyline drawing, only update polyline
+        if update_poly_only:
+            return (
+                f"Surface A: {surfattr_map} - {surfname_map} - {ensemble_map} - {calc_map}",
+                current_map,
+                f"Surface B: {surfattr_map2} - {surfname_map2} - {ensemble_map2} - {calc_map2}",
+                dash.no_update,
+                "Surface A-B",
+                dash.no_update,
+            )
+
+        if wellname is not None:
+            well = well_set_model.get_well(wellname)
+            well_layer = make_well_layer(well, name=well.name)
+
+            # If callback is triggered by well change, only update well layer
+            if "well" in ctx["prop_id"] or (
+                "source" in ctx["prop_id"] and source == "well"
+            ):
+                for map_layers in [current_map, current_map2, current_map3]:
+                    map_layers = replace_or_add_map_layer(
+                        map_layers, "Well", well_layer
+                    )
+                return (
+                    f"Surface A: {surfattr_map} - {surfname_map} - "
+                    f"{ensemble_map} - {calc_map}",
+                    current_map,
+                    f"Surface B: {surfattr_map2} - {surfname_map2} - "
+                    f"{ensemble_map2} - {calc_map2}",
+                    current_map2,
+                    "Surface A-B",
+                    dash.no_update,
+                )
+
+        # Calculate maps
+        if calc_map in ["Mean", "StdDev", "Max", "Min", "P90", "P10"]:
+            surface = surface_set_models[ensemble_map].calculate_statistical_surface(
+                name=surfname_map,
+                attribute=surfattr_map,
+                calculation=calc_map,
+                realizations=realizations,
+            )
+        else:
+            surface = surface_set_models[ensemble_map].get_realization_surface(
+                name=surfname_map, attribute=surfattr_map, realization=int(calc_map)
+            )
+        if calc_map2 in ["Mean", "StdDev", "Max", "Min", "P90", "P10"]:
+            surface2 = surface_set_models[ensemble_map2].calculate_statistical_surface(
+                name=surfname_map2,
+                attribute=surfattr_map2,
+                calculation=calc_map2,
+                realizations=realizations,
+            )
+        else:
+            surface2 = surface_set_models[ensemble_map2].get_realization_surface(
+                name=surfname_map2, attribute=surfattr_map2, realization=int(calc_map2)
+            )
+
+        # Generate Leaflet layers
+        update_controls = check_if_update_needed(
+            ctx, current_map, compute_diff, color_range_settings
+        )
+
+        surface_layers = create_or_return_base_layer(
+            update_controls,
+            surface,
+            current_map,
+            shade_map,
+            color_range_settings,
+            map_id="map1",
+        )
+        surface_layers2 = create_or_return_base_layer(
+            update_controls,
+            surface2,
+            current_map2,
+            shade_map2,
+            color_range_settings,
+            map_id="map2",
+        )
+
+        try:
+            surface3 = surface.copy()
+            surface3.values = surface3.values - surface2.values
+
+            diff_layers = (
+                [
+                    SurfaceLeafletModel(
+                        surface3,
+                        name="surface3",
+                        apply_shading=shade_map3.get("value", False),
+                    ).layer
+                ]
+                if update_controls["diff_map"]["update"]
+                else []
+            )
+        except ValueError:
+            diff_layers = []
+
+        if wellname is not None:
+            surface_layers.append(well_layer)
+            surface_layers2.append(well_layer)
+        if polyline is not None:
+            surface_layers.append(poly_layer)
+        if xline is not None and source == "xline":
+            surface_layers.append(xline_layer)
+        if yline is not None and source == "yline":
+            surface_layers.append(yline_layer)
+        if well_set_model is not None:
+            if options is not None or options2 is not None:
+                if "intersect_well" in options or "intersect_well" in options2:
+                    ### This is potentially a heavy task as it loads all wells into memory
+                    wells: List[xtgeo.Well] = list(well_set_model.wells.values())
+                if "intersect_well" in options and update_controls["map1"]["update"]:
+                    surface_layers.append(
+                        create_leaflet_well_marker_layer(wells, surface)
+                    )
+                if "intersect_well" in options2 and update_controls["map2"]["update"]:
+                    surface_layers2.append(
+                        create_leaflet_well_marker_layer(wells, surface2)
+                    )
+
+        return (
+            f"Surface A: {surfattr_map} - {surfname_map} - {ensemble_map} - {calc_map}",
+            surface_layers if update_controls["map1"]["update"] else dash.no_update,
+            f"Surface B: {surfattr_map2} - {surfname_map2} - {ensemble_map2} - {calc_map2}",
+            surface_layers2 if update_controls["map2"]["update"] else dash.no_update,
+            "Surface A-B",
+            diff_layers if update_controls["diff_map"]["update"] else dash.no_update,
+        )
+
+    @app.callback(
+        Output({"id": get_uuid("map"), "element": "stored_polyline"}, "data"),
+        Input(get_uuid("leaflet-map1"), "polyline_points"),
+    )
+    def _store_polyline_points(
+        positions_yx: List[List[float]],
+    ) -> Optional[List[List[float]]]:
+        """Stores drawn in polyline in a dcc.Store. Reversing elements to reflect
+        normal behaviour"""
+        if positions_yx is not None:
+            try:
+                return [[pos[1], pos[0]] for pos in positions_yx]
+            except TypeError:
+                warnings.warn("Polyline for map is not valid format")
+                return None
+        raise PreventUpdate
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("intersection-data"), "element": "source"},
+            "value",
+        ),
+        Output(
+            {"id": get_uuid("intersection-data"), "element": "well"},
+            "value",
+        ),
+        Input(get_uuid("leaflet-map1"), "clicked_shape"),
+        Input(get_uuid("leaflet-map1"), "polyline_points"),
+    )
+    # pylint: disable=protected-access
+    def _update_from_map_click(
+        clicked_shape: Optional[Dict],
+        _polyline: List[List[float]],
+    ) -> Tuple[str, Union[dash.dash._NoUpdate, str]]:
+        """Update intersection source and optionally selected well when
+        user clicks a shape in map"""
+        ctx = dash.callback_context.triggered[0]
+        if "polyline_points" in ctx["prop_id"]:
+            return "polyline", dash.no_update
+        if clicked_shape is None:
+            raise PreventUpdate
+        if clicked_shape.get("id") == "random_line":
+            return "polyline", dash.no_update
+        if clicked_shape.get("id") in well_set_model.well_names:
+            return "well", clicked_shape.get("id")
+        raise PreventUpdate
+
+    @app.callback(
+        Output(get_uuid("map-color-ranges"), "data"),
+        Output(
+            {"id": get_uuid("map-settings"), "colors": "map2_clip_min"},
+            "disabled",
+        ),
+        Output(
+            {"id": get_uuid("map-settings"), "colors": "map2_clip_max"},
+            "disabled",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "colors": "map1_clip_min"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "colors": "map1_clip_max"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "colors": "map2_clip_min"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "colors": "map2_clip_max"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("map-settings"), "colors": "sync_range"},
+            "value",
+        ),
+    )
+    def _color_range_options(
+        clip_min_map1: Optional[float],
+        clip_max_map1: Optional[float],
+        clip_min_map2: Optional[float],
+        clip_max_map2: Optional[float],
+        sync_range: list,
+    ) -> Tuple[Dict[str, Dict], bool, bool]:
+        ctx = dash.callback_context.triggered[0]
+
+        return (
+            {
+                "map1": {
+                    "color_range": [clip_min_map1, clip_max_map1],
+                    "update": "map1" in ctx["prop_id"],
+                },
+                "map2": {
+                    "color_range": [clip_min_map2, clip_max_map2]
+                    if not sync_range
+                    else [clip_min_map1, clip_max_map1],
+                    "update": "map2" in ctx["prop_id"]
+                    or (sync_range and "map1" in ctx["prop_id"])
+                    or (
+                        "sync_range" in ctx["prop_id"]
+                        and [clip_min_map1, clip_max_map1]
+                        != [clip_min_map2, clip_max_map2]
+                    ),
+                },
+            },
+            bool(sync_range),
+            bool(sync_range),
+        )
+
+
+def create_leaflet_polyline_layer(
+    positions: List[List[float]], name: str, poly_id: str
+) -> Dict:
+    return {
+        "id": name,
+        "name": name,
+        "baseLayer": False,
+        "checked": True,
+        "action": "update",
+        "data": [
+            {
+                "type": "polyline",
+                "id": poly_id,
+                "positions": positions,
+                "color": "blue",
+                "tooltip": "polyline",
+            },
+            {
+                "type": "circle",
+                "center": positions[0],
+                "radius": 60,
+                "color": "blue",
+                "tooltip": "B",
+            },
+            {
+                "type": "circle",
+                "center": positions[-1],
+                "radius": 60,
+                "color": "blue",
+                "tooltip": "B'",
+            },
+        ],
+    }
+
+
+def replace_or_add_map_layer(
+    layers: List[Dict], uuid: str, new_layer: Dict
+) -> List[Dict]:
+    for idx, layer in enumerate(layers):
+        if layer.get("id") == uuid:
+            layers[idx] = new_layer
+            return layers
+    layers.append(new_layer)
+    return layers
+
+
+def check_if_update_needed(
+    ctx: Dict, current_map: List[Dict], compute_diff: List, color_range_settings: Dict
+) -> Dict[str, Any]:
+
+    update_controls = {}
+    for map_id in ["map1", "map2"]:
+        map_controllers_clicked = f'"map_id":"{map_id}"' in ctx["prop_id"]
+        change_calculate_well_intersections = (
+            map_controllers_clicked and "options" in ctx["prop_id"]
+        )
+        change_shade_map = (
+            f"leaflet-{map_id}" in ctx["prop_id"] and "switch" in ctx["prop_id"]
+        )
+        change_color_clip = (
+            "map-color-ranges" in ctx["prop_id"]
+            and color_range_settings[map_id]["update"]
+        )
+        update_controls[map_id] = {
+            "update": (
+                map_controllers_clicked
+                or change_shade_map
+                or change_color_clip
+                or not current_map
+            ),
+            "use_base_layer": (change_shade_map or change_calculate_well_intersections),
+        }
+
+    change_diffmap_from_options = (
+        "leaflet-map3" in ctx["prop_id"] and "switch" in ctx["prop_id"]
+    ) or "compute_diff" in ctx["prop_id"]
+
+    update_controls["diff_map"] = {
+        "update": compute_diff
+        and (
+            (
+                update_controls["map1"]["update"]
+                and not update_controls["map1"]["use_base_layer"]
+            )
+            or (
+                update_controls["map2"]["update"]
+                and not update_controls["map2"]["use_base_layer"]
+            )
+            or change_diffmap_from_options
+        )
+        and not "map-color-ranges" in ctx["prop_id"]
+    }
+
+    return update_controls
+
+
+def create_or_return_base_layer(
+    update_controls: Dict,
+    surface: xtgeo.RegularSurface,
+    current_map: List[Dict],
+    shade_map: Dict[str, bool],
+    color_range_settings: Dict,
+    map_id: str,
+) -> List[Dict]:
+
+    surface_layers = []
+    if update_controls[map_id]["use_base_layer"]:
+        for layer in current_map:
+            if layer["baseLayer"]:
+                layer["data"][0]["shader"]["applyHillshading"] = shade_map.get("value")
+                surface_layers = [layer]
+    else:
+        surface_layers = [
+            SurfaceLeafletModel(
+                surface,
+                clip_min=color_range_settings[map_id]["color_range"][0],
+                clip_max=color_range_settings[map_id]["color_range"][1],
+                name=map_id,
+                apply_shading=shade_map.get("value", False),
+            ).layer
+        ]
+    return surface_layers

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/modal_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/modal_controller.py
@@ -1,0 +1,30 @@
+from typing import Optional, Callable
+
+import dash
+from dash.exceptions import PreventUpdate
+from dash.dependencies import Input, Output, State, MATCH
+
+
+def open_modals(
+    app: dash.Dash,
+    get_uuid: Callable,
+) -> None:
+    @app.callback(
+        Output(
+            {"id": get_uuid("modal"), "modal_id": MATCH, "element": "wrapper"},
+            "is_open",
+        ),
+        Input(
+            {"id": get_uuid("modal"), "modal_id": MATCH, "element": "button-open"},
+            "n_clicks",
+        ),
+        State(
+            {"id": get_uuid("modal"), "modal_id": MATCH, "element": "wrapper"},
+            "is_open",
+        ),
+    )
+    def _toggle_modal_graph_settings(n_open: int, is_open: bool) -> Optional[bool]:
+        """Open or close graph settings modal button"""
+        if n_open:
+            return not is_open
+        raise PreventUpdate

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/realization_filter_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/realization_filter_controller.py
@@ -1,0 +1,103 @@
+from typing import Dict, List, Callable, Optional, Tuple
+
+import dash
+from dash.exceptions import PreventUpdate
+from dash.dependencies import Input, Output, State
+
+
+def update_realizations(app: dash.Dash, get_uuid: Callable) -> None:
+    @app.callback(
+        Output(
+            {
+                "id": get_uuid("modal"),
+                "modal_id": "realization-filter",
+                "element": "apply",
+            },
+            "disabled",
+        ),
+        Output(
+            {
+                "id": get_uuid("modal"),
+                "modal_id": "realization-filter",
+                "element": "apply",
+            },
+            "style",
+        ),
+        Input(
+            get_uuid("realization-store"),
+            "data",
+        ),
+        Input(
+            {"id": get_uuid("intersection-data"), "element": "realizations"},
+            "value",
+        ),
+    )
+    def _activate_realization_apply_btn(
+        stored_reals: List, selected_reals: List
+    ) -> Tuple[bool, Dict[str, str]]:
+        if stored_reals is None or selected_reals is None:
+            raise PreventUpdate
+        if set(stored_reals) == set(selected_reals):
+            return True, {"visibility": "hidden"}
+        return False, {"visibility": "visible"}
+
+    @app.callback(
+        Output(
+            get_uuid("realization-store"),
+            "data",
+        ),
+        Input(
+            {
+                "id": get_uuid("modal"),
+                "modal_id": "realization-filter",
+                "element": "apply",
+            },
+            "n_clicks",
+        ),
+        State(
+            {"id": get_uuid("intersection-data"), "element": "realizations"},
+            "value",
+        ),
+    )
+    def _store_realizations(btn_click: Optional[int], selected_reals: List) -> List:
+        if btn_click:
+            return selected_reals
+        raise PreventUpdate
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("intersection-data"), "element": "realizations"},
+            "value",
+        ),
+        Input(
+            {
+                "id": get_uuid("modal"),
+                "modal_id": "realization-filter",
+                "element": "clear",
+            },
+            "n_clicks",
+        ),
+        Input(
+            {
+                "id": get_uuid("modal"),
+                "modal_id": "realization-filter",
+                "element": "all",
+            },
+            "n_clicks",
+        ),
+        State(
+            {"id": get_uuid("intersection-data"), "element": "realizations"},
+            "options",
+        ),
+    )
+    def _update_realization_list(
+        clear_click: Optional[int], all_click: Optional[int], real_opts: List
+    ) -> List:
+        if clear_click is None and all_click is None:
+            raise PreventUpdate
+        ctx = dash.callback_context.triggered
+        if "clear" in ctx[0]["prop_id"]:
+            return []
+        if "all" in ctx[0]["prop_id"]:
+            return [opt["value"] for opt in real_opts]
+        raise PreventUpdate

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/uncertainty_table_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/uncertainty_table_controller.py
@@ -1,0 +1,141 @@
+from typing import Dict, List, Optional, Callable, Tuple
+
+import numpy as np
+import pandas as pd
+import dash
+from dash.dependencies import Input, Output, State
+from dash.exceptions import PreventUpdate
+
+from webviz_subsurface._models import SurfaceSetModel, WellSetModel
+
+
+# pylint: disable=too-many-statements
+def update_uncertainty_table(
+    app: dash.Dash,
+    get_uuid: Callable,
+    surface_set_models: Dict[str, SurfaceSetModel],
+    well_set_model: WellSetModel,
+) -> None:
+    @app.callback(
+        Output({"id": get_uuid("uncertainty-table"), "element": "wrapper"}, "style"),
+        Output(get_uuid("all-maps-wrapper"), "style"),
+        Output(
+            get_uuid("uncertainty-table-display-button"),
+            "children",
+        ),
+        Input(
+            get_uuid("uncertainty-table-display-button"),
+            "n_clicks",
+        ),
+    )
+    def _display_uncertainty_table(n_clicks: Optional[int]) -> Tuple[Dict, Dict, str]:
+        if not n_clicks:
+            raise PreventUpdate
+        if n_clicks % 2 == 0:
+
+            return (
+                {"height": "40vh", "display": "none"},
+                {"height": "40vh", "display": "flex"},
+                "Show uncertainty table",
+            )
+        return (
+            {"height": "40vh", "display": "block"},
+            {"height": "40vh", "display": "none"},
+            "Hide uncertainty table",
+        )
+
+    @app.callback(
+        Output({"id": get_uuid("uncertainty-table"), "element": "table"}, "data"),
+        Output({"id": get_uuid("uncertainty-table"), "element": "label"}, "children"),
+        Input(
+            {"id": get_uuid("uncertainty-table"), "element": "apply-button"}, "n_clicks"
+        ),
+        State({"id": get_uuid("intersection-data"), "element": "well"}, "value"),
+        State(
+            {"id": get_uuid("intersection-data"), "element": "surface_attribute"},
+            "value",
+        ),
+        State(
+            {"id": get_uuid("intersection-data"), "element": "surface_names"}, "value"
+        ),
+        State({"id": get_uuid("intersection-data"), "element": "ensembles"}, "value"),
+        State(get_uuid("realization-store"), "data"),
+    )
+    # pylint: disable=too-many-arguments: disable=too-many-branches, too-many-locals
+    def _update_uncertainty_table(
+        apply_btn: Optional[int],
+        wellname: str,
+        surface_attribute: str,
+        surface_names: List[str],
+        ensembles: List[str],
+        realizations: List[int],
+    ) -> Tuple[List, str]:
+        if apply_btn is None:
+            raise PreventUpdate
+        dframes = []
+
+        well = well_set_model.get_well(wellname)
+        realizations = [int(real) for real in realizations]
+        for ensemble in ensembles:
+            surfset = surface_set_models[ensemble]
+            for surfacename in surface_names:
+                for calculation in ["Mean", "Min", "Max"]:
+                    surface = surfset.calculate_statistical_surface(
+                        name=surfacename,
+                        attribute=surface_attribute,
+                        calculation=calculation,
+                        realizations=realizations,
+                    )
+
+                    with np.errstate(invalid="ignore"):
+                        surface_picks = well.get_surface_picks(surface)
+                        if surface_picks is None:
+                            continue
+                        surface_df = surface_picks.dataframe.drop(
+                            columns=["X_UTME", "Y_UTMN", "DIRECTION", "WELLNAME"]
+                        )
+                        tvds = (
+                            surface_df["Z_TVDSS"]
+                            .apply(lambda x: np.round(x, 1))
+                            .tolist()
+                        )
+
+                        surface_df.rename({well.mdlogname: "MD"}, axis=1, inplace=True)
+                        # Do not calculate MD if Well tvd is truncated
+                        mds = (
+                            surface_df["MD"].apply(lambda x: np.round(x, 1)).tolist()
+                            if not well_set_model.is_truncated
+                            else []
+                        )
+
+                        surface_df["Pick no"] = surface_df.index + 1
+                        pick_nos = surface_df["Pick no"].tolist()
+
+                        data = {
+                            "TVD": " / ".join(str(x) for x in tvds),
+                            "MD": " / ".join(str(x) for x in mds),
+                            "Pick no": " / ".join(str(x) for x in pick_nos),
+                            "Surface name": surfacename,
+                            "Calculation": calculation,
+                            "Ensemble": ensemble,
+                        }
+                        surface_df = pd.DataFrame([data])
+                        dframes.append(surface_df)
+
+        dframe = (
+            pd.concat(dframes)
+            if dframes
+            else pd.DataFrame(
+                [
+                    {
+                        "TVD": "-",
+                        "MD": "-",
+                        "Pick no": "-",
+                        "Surface name": "-",
+                        "Calculation": "-",
+                        "Ensemble": "-",
+                    }
+                ]
+            )
+        )
+        return dframe.to_dict("records"), f"Statistics for well {wellname}"

--- a/webviz_subsurface/plugins/_structural_uncertainty/figures/intersection.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/figures/intersection.py
@@ -1,0 +1,249 @@
+from typing import Dict, List, Optional, Any
+
+import numpy as np
+import xtgeo
+from webviz_config.common_cache import CACHE
+
+from webviz_subsurface._models import SurfaceSetModel
+from webviz_subsurface._utils.colors import hex_to_rgba
+
+
+# pylint: disable=too-many-arguments
+@CACHE.memoize(timeout=CACHE.TIMEOUT)
+def get_plotly_trace_statistical_surface(
+    surfaceset: SurfaceSetModel,
+    fence_spec: np.ndarray,
+    calculation: str,
+    name: str,
+    legendname: str,
+    attribute: str,
+    realizations: Optional[List[int]],
+    color: str = "red",
+    showlegend: bool = False,
+    sampling: Optional[str] = "billinear",
+) -> Dict[str, Any]:
+    """Returns x,y values along a fence for a calculated surface"""
+    surface = surfaceset.calculate_statistical_surface(
+        name=name,
+        attribute=attribute,
+        calculation=calculation,
+        realizations=realizations,
+    )
+    fencexy = get_surface_randomline(surface, fence_spec, sampling)
+    line_style: Dict[str, Any] = {"width": 4}
+    if calculation in ["Min", "Max"]:
+        line_style.update({"dash": "dash"})
+    return {
+        "x": fencexy[:, 0],
+        "y": fencexy[:, 1],
+        "name": legendname,
+        "text": f"{legendname} {calculation}",
+        "showlegend": showlegend,
+        "hoverinfo": "y+x+text",
+        "mode": "lines",
+        "marker": {"color": hex_to_rgba(hex_string=color)},
+        "line": line_style,
+    }
+
+
+# pylint: disable=too-many-arguments
+@CACHE.memoize(timeout=CACHE.TIMEOUT)
+def get_plotly_traces_uncertainty_envelope(
+    surfaceset: SurfaceSetModel,
+    fence_spec: np.ndarray,
+    name: str,
+    legendname: str,
+    attribute: str,
+    realizations: Optional[List[int]],
+    color: str = "red",
+    showlegend: bool = False,
+    sampling: Optional[str] = "billinear",
+) -> List:
+    """Returns a set of plotly traces representing an uncertainty envelope
+    for a surface"""
+    stat_surfaces = {}
+    traces = []
+    line_color = hex_to_rgba(hex_string=color)
+    fill_color = hex_to_rgba(hex_string=color, opacity=0.3)
+    for calculation in ["Mean", "Min", "Max", "P10", "P90"]:
+
+        stat_surfaces[calculation] = surfaceset.calculate_statistical_surface(
+            name=name,
+            attribute=attribute,
+            calculation=calculation,
+            realizations=realizations,
+        ).get_randomline(fence_spec, sampling=sampling)
+    # Maximum trace (contains hoverinfo)
+    traces.append(
+        {
+            "name": legendname,
+            "y": stat_surfaces["Max"][:, 1],
+            "x": stat_surfaces["Max"][:, 0],
+            "mode": "lines",
+            "hoverinfo": "text+name",
+            "line": {"width": 0, "color": line_color},
+            "legendgroup": name,
+            "showlegend": False,
+        }
+    )
+    # P10 trace
+    traces.append(
+        {
+            "name": legendname,
+            "y": stat_surfaces["P10"][:, 1],
+            "x": stat_surfaces["P10"][:, 0],
+            "mode": "lines",
+            "hoverinfo": "skip",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"width": 0, "color": line_color},
+            "legendgroup": name,
+            "showlegend": False,
+        }
+    )
+    # Mean trace
+    traces.append(
+        {
+            "name": legendname,
+            "y": stat_surfaces["Mean"][:, 1],
+            "x": stat_surfaces["Mean"][:, 0],
+            "mode": "lines",
+            "hoverinfo": "skip",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"color": line_color},
+            "legendgroup": name,
+            "showlegend": showlegend,
+        }
+    )
+    # P90 trace
+    traces.append(
+        {
+            "name": legendname,
+            "y": stat_surfaces["P90"][:, 1],
+            "x": stat_surfaces["P90"][:, 0],
+            "mode": "lines",
+            "hoverinfo": "skip",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"width": 0, "color": line_color},
+            "legendgroup": name,
+            "showlegend": False,
+        }
+    )
+    # Minimum trace
+    traces.append(
+        {
+            "name": legendname,
+            "y": stat_surfaces["Min"][:, 1],
+            "x": stat_surfaces["Min"][:, 0],
+            "mode": "lines",
+            "hoverinfo": "skip",
+            "fill": "tonexty",
+            "fillcolor": fill_color,
+            "line": {"width": 0, "color": line_color},
+            "legendgroup": name,
+            "showlegend": False,
+        }
+    )
+    return traces
+
+
+# pylint: disable=too-many-arguments
+@CACHE.memoize(timeout=CACHE.TIMEOUT)
+def get_plotly_trace_realization_surface(
+    surfaceset: SurfaceSetModel,
+    fence_spec: np.ndarray,
+    name: str,
+    legendname: str,
+    attribute: str,
+    realization: int,
+    showlegend: bool = False,
+    sampling: Optional[str] = "billinear",
+    color: str = "red",
+) -> Dict[str, Any]:
+    """Returns a plotly line trace for a surface"""
+    surface = surfaceset.get_realization_surface(
+        name=name, attribute=attribute, realization=realization
+    )
+    fencexy = get_surface_randomline(surface, fence_spec, sampling)
+    return {
+        "x": fencexy[:, 0],
+        "y": fencexy[:, 1],
+        "name": legendname,
+        "text": f"{legendname} realization: {realization}",
+        "showlegend": showlegend,
+        "hoverinfo": "y+x+text",
+        "mode": "lines",
+        "marker": {"color": hex_to_rgba(hex_string=color, opacity=0.5)},
+    }
+
+
+@CACHE.memoize(timeout=CACHE.TIMEOUT)
+def get_plotly_zonelog_trace(
+    well: xtgeo.Well,
+    zonelog: str,
+) -> List[Dict]:
+    """Zonetops are extracted from a zonelog and plotted as markers"""
+
+    df = well.dataframe
+
+    # Find zone transitions
+    df["transitions"] = df[zonelog].diff()
+    logrecord = well.get_logrecord(zonelog)
+    traces = []
+    for idx in range(0, df.shape[0] - 1):
+        # Use current sample if moving upwards in stratigraphy
+        # Use next sample if moving downwards in stratigraphy
+        if df.iloc[idx + 1]["transitions"] < 0 or df.iloc[idx]["transitions"] > 0:
+            traces.append(
+                {
+                    "x": [df.iloc[idx]["R_HLEN"]],
+                    "y": [df.iloc[idx]["Z_TVDSS"]],
+                    "marker": {"size": 10, "color": "red"},
+                    "showlegend": False,
+                    "hoverinfo": "y+name+text",
+                    "text": "TVDSS",
+                    "hoverlabel": {"namelength": -1},
+                    "name": f"Zonetop: <br>{logrecord[df.iloc[idx][zonelog]]}",
+                }
+            )
+    return traces
+
+
+@CACHE.memoize(timeout=CACHE.TIMEOUT)
+def get_well_xyarray(well: xtgeo.Well) -> List:
+    """Returns a copy of the x,y values representing the well fence"""
+    dfr = well.dataframe
+    zvals = dfr["Z_TVDSS"].values.copy()
+    hvals = dfr["R_HLEN"].values.copy()
+    return [hvals, zvals]
+
+
+def get_plotly_trace_well_trajectory(well: xtgeo.Well) -> Dict[str, Any]:
+    """Plot the trajectory as a black line"""
+    xyarray = get_well_xyarray(well=well)
+
+    return {
+        "x": xyarray[0],
+        "y": xyarray[1],
+        "name": well.name,
+        "hoverinfo": "name+text+y",
+        "hoverlabel": {"namelength": -1},
+        "text": "TVDSS",
+        "marker": {"color": "black"},
+    }
+
+
+def get_surface_randomline(
+    surface: xtgeo.RegularSurface,
+    fence_spec: np.ndarray,
+    sampling: Optional[str] = "billinear",
+) -> np.ndarray:
+    try:
+        return surface.get_randomline(fence_spec, sampling=sampling)
+    except TypeError:
+        # Attempt to handle vertical wells
+        fence_spec = np.insert(fence_spec, 0, fence_spec[0] - 10, axis=0)
+        fence_spec = np.append(fence_spec, [fence_spec[-1] + 10], axis=0)
+        return surface.get_randomline(fence_spec, sampling=sampling)

--- a/webviz_subsurface/plugins/_structural_uncertainty/structural_uncertainty.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/structural_uncertainty.py
@@ -1,0 +1,483 @@
+from typing import List, Tuple, Callable, Dict, Union
+import json
+from pathlib import Path
+
+import pandas as pd
+import dash
+import dash_html_components as html
+import webviz_core_components as wcc
+from webviz_config import WebvizPluginABC
+from webviz_config import WebvizSettings
+from webviz_config.webviz_assets import WEBVIZ_ASSETS
+
+import webviz_subsurface
+from webviz_subsurface._models import SurfaceSetModel, WellSetModel
+from webviz_subsurface._datainput.fmu_input import get_realizations, find_surfaces
+from webviz_subsurface._utils.webvizstore_functions import get_path, find_files
+from webviz_subsurface._components import ColorPicker
+from .views import (
+    intersection_data_layout,
+    map_data_layout,
+    realization_layout,
+    intersection_and_map_layout,
+    clientside_stores,
+    modal,
+)
+from .controllers import (
+    open_modals,
+    update_intersection,
+    update_maps,
+    update_realizations,
+    update_uncertainty_table,
+    update_intersection_source,
+)
+
+from ._tour_steps import generate_tour_steps
+
+
+class StructuralUncertainty(WebvizPluginABC):
+    """Dashboard to analyze structural uncertainty results from FMU runs.
+
+A cross-section along a well or from a polyline drawn interactively on a map.
+Map views to compare two surfaces from e.g. two iterations.
+
+Both individual realization surfaces and statistical surfaces can be plotted.
+
+Wells are required. If a zonelog is provided formation tops are extracted
+and plotted as markers along the well trajectory.
+
+Customization of colors and initialization of plugin with predefined selections
+is possible. See the `Arguments` sections for details.
+
+!> This plugin follows the FMU standards for storing and naming surface files.
+Surface files must be stored at `share/results/maps` for each ensemble,
+and be named as `surfacename--surfaceattribute.gri`
+
+---
+
+* **`ensembles`:** Which ensembles in `shared_settings` to visualize.
+* **`surface_attributes`:** List of surface attributes from surface filenames(FMU standard). \
+All surface_attributes must have the same surface names.
+ * **`surface_name_filter`:** List of the surface names (FMU standard) in stratigraphic order
+* **`wellfolder`:** A folder with wells on RMS Well format. \
+(absolute or relative to config file).
+* **`wellsuffix`:** File suffix for wells in `wellfolder`.
+* **`zonelog`:** Name of zonelog in `wellfiles` (displayed along well trajectory).
+* **`mdlog`:** Name of mdlog in `wellfiles` (displayed along well trajectory).
+* **`well_tvdmin`:** Truncate well trajectory values above this depth.
+* **`well_tvdmax`:** Truncate well trajectory values below this depth.
+* **`well_downsample_interval`:** Sampling interval used for coarsening a well trajectory
+* **`calculate_percentiles`:** Only relevant for portable. Calculating P10/90 is
+time consuming and is by default disabled to allow fast generation of portable apps. \
+Activate to precalculate these percentiles for all realizations. \
+* **`initial_settings`:** Configuration for initializing the plugin with various \
+    properties set. All properties are optional.
+    ```yaml
+        initial_settings:
+            intersection_data: # Data to populate the intersection view
+                surface_attribute: ds_extracted_horizons  #name of active attribute
+                surface_names: #list of active surfacenames
+                    - topupperreek
+                    - baselowerreek
+                ensembles: #list of active ensembles
+                    - iter-0
+                    - iter-1
+                calculation: #list of active calculations
+                    - Mean
+                    - Min
+                    - Max
+                    - Realizations
+                    - Uncertainty envelope
+                well: OP_6 #Active well
+                realizations: #List of active realizations
+                    - 0
+                resolution: 20 # Horizontal distance between points in the intersection
+                             # (Usually in meters)
+                extension: 500 # Horizontal extension of the intersection
+                depth_truncations: # Truncations to use for yaxis range
+                    min: 1500
+                    max: 3000
+            colors: # Colors to use for surfaces in the intersection view specified
+                    # for each ensemble
+                topupperreek:
+                    iter-0: '#2C82C9' #hex color code with apostrophies and hash prefix
+            intersection_layout: # The full plotly layout
+                                 # (https://plotly.com/python/reference/layout/) is
+                                 # exposed to allow for customization of e.g. plot title
+                                 # and axis ranges. A small example:
+                yaxis:
+                    title: True vertical depth [m]
+                xaxis:
+                    title: Lateral distance [m]
+    ```
+---
+
+**Example files**
+
+* [One file for surfacefiles](https://github.com/equinor/webviz-subsurface-testdata/blob/master/\
+reek_history_match/realization-0/iter-0/share/results/\
+maps/topupperreek--ds_extracted_horizons.gri).
+
+* [Wellfiles](https://github.com/equinor/webviz-subsurface-testdata/tree/master/\
+observed_data/wells).
+
+The surfacefiles are on a `Irap binary` format and can be investigated outside `webviz` using \
+e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
+"""
+
+    # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-locals
+    def __init__(
+        self,
+        app: dash.Dash,
+        webviz_settings: WebvizSettings,
+        ensembles: list,
+        surface_attributes: list,
+        surface_name_filter: List[str] = None,
+        wellfolder: Path = None,
+        wellsuffix: str = ".w",
+        zonelog: str = None,
+        mdlog: str = None,
+        well_tvdmin: Union[int, float] = None,
+        well_tvdmax: Union[int, float] = None,
+        well_downsample_interval: int = None,
+        calculate_percentiles: bool = False,
+        initial_settings: Dict = None,
+    ):
+
+        super().__init__()
+        self._initial_settings = initial_settings if initial_settings else {}
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent
+            / "_assets"
+            / "css"
+            / "container.css"
+        )
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent
+            / "_assets"
+            / "css"
+            / "structural_uncertainty.css"
+        )
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent / "_assets" / "css" / "modal.css"
+        )
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent
+            / "_assets"
+            / "js"
+            / "update_plotly_figure.js"
+        )
+        self._calculate_percentiles = calculate_percentiles
+        self._wellfolder = wellfolder
+        self._wellsuffix = wellsuffix
+        self._wellfiles: List = []
+        if wellfolder is not None:
+            self._wellfiles = json.load(find_files(wellfolder, wellsuffix))
+
+        self._well_set_model = WellSetModel(
+            self._wellfiles,
+            zonelog=zonelog,
+            mdlog=mdlog,
+            tvdmin=well_tvdmin,
+            tvdmax=well_tvdmax,
+            downsample_interval=well_downsample_interval,
+        )
+        self._use_wells = bool(self._wellfiles)
+        if (
+            self._initial_settings.get("intersection_data", {}).get("well")
+            and not self._use_wells
+        ):
+            raise KeyError(
+                "Well is specified in initial settings but no well data is found!"
+            )
+        self._surf_attrs = surface_attributes
+        self._ensemble_paths = {
+            ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
+            for ens in ensembles
+        }
+        surface_table = find_surfaces(self._ensemble_paths)
+        surface_table = surface_table[surface_table["attribute"].isin(self._surf_attrs)]
+        if surface_table.empty:
+            raise ValueError("No surfaces found with the given attributes")
+        self._surfacenames = list(surface_table["name"].unique())
+        self.ensembles = list(surface_table["ENSEMBLE"].unique())
+        for _, attr_df in surface_table.groupby("attribute"):
+            if set(attr_df["name"].unique()) != set(self._surfacenames):
+                raise ValueError(
+                    "Surface attributes has different surfaces. This is not supported!"
+                )
+        if surface_name_filter is not None:
+            self._surfacenames = [
+                name for name in surface_name_filter if name in self._surfacenames
+            ]
+            if not self._surfacenames:
+                raise ValueError(
+                    "No surfaces found with the provided surface name filter!"
+                )
+            surface_table = surface_table[
+                surface_table["name"].isin(surface_name_filter)
+            ]
+        self._surface_ensemble_set_model = {
+            ens: SurfaceSetModel(surf_ens_df)
+            for ens, surf_ens_df in surface_table.groupby("ENSEMBLE")
+        }
+        self._realizations = sorted(list(surface_table["REAL"].unique()))
+
+        self._zonelog = zonelog
+        colors = [
+            "#1f77b4",  # muted blue
+            "#ff7f0e",  # safety orange
+            "#2ca02c",  # cooked asparagus green
+            "#d62728",  # brick red
+            "#9467bd",  # muted purple
+            "#8c564b",  # chestnut brown
+            "#e377c2",  # raspberry yogurt pink
+            "#7f7f7f",  # middle gray
+            "#bcbd22",  # curry yellow-green
+            "#17becf",  # blue-teal
+        ]
+        self._surfacecolors = [
+            {
+                "surfacename": surfacename,
+                "ensemble": ens,
+                "COLOR": self._initial_settings.get("colors", {})
+                .get(surfacename, {})
+                .get(ens, colors[idx % len(colors)]),
+            }
+            for idx, surfacename in enumerate(self._surfacenames)
+            for ens in self.ensembles
+        ]
+        self._color_picker = ColorPicker(
+            app=app,
+            uuid=self.uuid("colorpicker"),
+            dframe=pd.DataFrame(self._surfacecolors),
+        )
+        self.first_surface_geometry = self._surface_ensemble_set_model[
+            self.ensembles[0]
+        ].first_surface_geometry
+        self.set_callbacks(app)
+
+    @property
+    def tour_steps(self) -> List[Dict]:
+        return generate_tour_steps(get_uuid=self.uuid)
+
+    @property
+    def layout(self) -> wcc.FlexBox:
+        return html.Div(
+            id=self.uuid("layout"),
+            children=[
+                clientside_stores(
+                    get_uuid=self.uuid,
+                    realizations=self._realizations,
+                    initial_settings=self._initial_settings,
+                ),
+                wcc.FlexBox(
+                    children=[
+                        html.Div(
+                            className="framed",
+                            style={
+                                "height": "91vh",
+                                "flex": 1,
+                                "fontSize": "0.8em",
+                                "overflowY": "auto",
+                            },
+                            children=[
+                                html.Div(
+                                    children=[
+                                        html.Details(
+                                            style={"margin-bottom": "25px"},
+                                            open=True,
+                                            children=[
+                                                html.Summary(
+                                                    "Intersection controls",
+                                                    className="webviz-structunc-details-main",
+                                                ),
+                                                intersection_data_layout(
+                                                    get_uuid=self.uuid,
+                                                    surface_attributes=self._surf_attrs,
+                                                    surface_names=self._surfacenames,
+                                                    ensembles=self.ensembles,
+                                                    use_wells=self._use_wells,
+                                                    well_names=self._well_set_model.well_names
+                                                    if self._well_set_model
+                                                    else [],
+                                                    surface_geometry=self.first_surface_geometry,
+                                                    initial_settings=self._initial_settings.get(
+                                                        "intersection_data", {}
+                                                    ),
+                                                ),
+                                            ],
+                                        ),
+                                        html.Details(
+                                            style={"margin-bottom": "25px"},
+                                            open=True,
+                                            children=[
+                                                html.Summary(
+                                                    "Map controls",
+                                                    className="webviz-structunc-details-main",
+                                                ),
+                                                html.Div(
+                                                    style={"padding": "5px"},
+                                                    id=self.uuid(
+                                                        "surface-settings-wrapper"
+                                                    ),
+                                                    children=[
+                                                        map_data_layout(
+                                                            uuid=self.uuid(
+                                                                "map-settings"
+                                                            ),
+                                                            surface_attributes=self._surf_attrs,
+                                                            surface_names=self._surfacenames,
+                                                            ensembles=self.ensembles,
+                                                            realizations=self._realizations,
+                                                            use_wells=self._use_wells,
+                                                        )
+                                                    ],
+                                                ),
+                                            ],
+                                        ),
+                                        html.Details(
+                                            style={"margin-bottom": "25px"},
+                                            open=True,
+                                            children=[
+                                                html.Summary(
+                                                    "Filters",
+                                                    className="webviz-structunc-details-main",
+                                                ),
+                                                html.Div(
+                                                    style={
+                                                        "marginTop": "10px",
+                                                        "marginBottom": "10px",
+                                                    },
+                                                    id=self.uuid(
+                                                        "realization-filter-wrapper"
+                                                    ),
+                                                    children=[
+                                                        modal.open_modal_layout(
+                                                            uuid=self.uuid("modal"),
+                                                            modal_id="realization-filter",
+                                                            title="Realization filter",
+                                                        ),
+                                                    ],
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                        html.Div(
+                            style={"flex": 6},
+                            children=intersection_and_map_layout(get_uuid=self.uuid),
+                        ),
+                    ]
+                ),
+                modal.modal_layout(
+                    uuid=self.uuid("modal"),
+                    modal_id="color",
+                    title="Color settings",
+                    size="lg",
+                    body_children=[
+                        html.Div(
+                            children=[self._color_picker.layout],
+                        ),
+                    ],
+                ),
+                modal.modal_layout(
+                    uuid=self.uuid("modal"),
+                    modal_id="realization-filter",
+                    title="Filter realizations",
+                    body_children=[
+                        realization_layout(
+                            uuid=self.uuid("intersection-data"),
+                            realizations=self._realizations,
+                            value=self._initial_settings.get(
+                                "intersection_data", {}
+                            ).get("realizations", self._realizations),
+                        ),
+                    ],
+                    footer=modal.clear_all_apply_modal_buttons(
+                        uuid=self.uuid("modal"), modal_id="realization-filter"
+                    ),
+                ),
+            ],
+        )
+
+    def set_callbacks(self, app: dash.Dash) -> None:
+        open_modals(app=app, get_uuid=self.uuid)
+        update_realizations(app=app, get_uuid=self.uuid)
+        update_intersection(
+            app=app,
+            get_uuid=self.uuid,
+            surface_set_models=self._surface_ensemble_set_model,
+            well_set_model=self._well_set_model,
+            zonelog=self._zonelog,
+            color_picker=self._color_picker,
+        )
+        update_maps(
+            app=app,
+            get_uuid=self.uuid,
+            surface_set_models=self._surface_ensemble_set_model,
+            well_set_model=self._well_set_model,
+        )
+        update_uncertainty_table(
+            app=app,
+            get_uuid=self.uuid,
+            surface_set_models=self._surface_ensemble_set_model,
+            well_set_model=self._well_set_model,
+        )
+        update_intersection_source(
+            app=app, get_uuid=self.uuid, surface_geometry=self.first_surface_geometry
+        )
+
+    def add_webvizstore(self) -> List[Tuple[Callable, list]]:
+        store_functions: List[Tuple[Callable, list]] = []
+        if self._use_wells is not None:
+            store_functions.extend(
+                [(get_path, [{"path": fn}]) for fn in self._wellfiles]
+            )
+
+        store_functions.append(
+            (
+                find_surfaces,
+                [
+                    {
+                        "ensemble_paths": self._ensemble_paths,
+                        "suffix": "*.gri",
+                        "delimiter": "--",
+                    }
+                ],
+            )
+        )
+        calculations: List[str] = ["Mean", "StdDev", "Min", "Max"]
+        if self._calculate_percentiles:
+            calculations.extend(["P10", "P90"])
+        for ens in self.ensembles:
+
+            for calculation in calculations:
+                store_functions.append(
+                    self._surface_ensemble_set_model[
+                        ens
+                    ].webviz_store_statistical_calculation(calculation=calculation)
+                )
+            store_functions.append(
+                self._surface_ensemble_set_model[
+                    ens
+                ].webviz_store_realization_surfaces()
+            )
+        store_functions.append(
+            (
+                get_realizations,
+                [
+                    {
+                        "ensemble_paths": self._ensemble_paths,
+                        "ensemble_set_name": "EnsembleSet",
+                    }
+                ],
+            )
+        )
+        if self._wellfolder is not None:
+            store_functions.append(
+                (find_files, [{"folder": self._wellfolder, "suffix": self._wellsuffix}])
+            )
+        return store_functions

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/__init__.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/__init__.py
@@ -1,0 +1,6 @@
+from .intersection_data import intersection_data_layout
+from .map_data import map_data_layout
+from .realization_modal import realization_layout
+from .intersection_and_map import intersection_and_map_layout
+from .clientside_stores import clientside_stores
+from .uncertainty_table import uncertainty_table_layout, uncertainty_table_btn

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/clientside_stores.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/clientside_stores.py
@@ -1,0 +1,56 @@
+from typing import Callable, List, Union, Dict
+
+import dash_core_components as dcc
+import dash_html_components as html
+
+
+def clientside_stores(
+    get_uuid: Callable,
+    initial_settings: Dict,
+    realizations: List[Union[str, int]],
+) -> html.Div:
+    """Contains the clientside stores"""
+    return html.Div(
+        children=[
+            dcc.Store(
+                id=get_uuid("intersection-graph-data"), storage_type="session", data=[]
+            ),
+            dcc.Store(
+                id=get_uuid("initial-intersection-graph-layout"),
+                data=initial_settings.get("intersection_layout", {}),
+            ),
+            dcc.Store(
+                id=get_uuid("realization-store"),
+                data=initial_settings.get("intersection-data", {}).get(
+                    "realizations", realizations
+                ),
+            ),
+            dcc.Store(
+                id={"id": get_uuid("map"), "element": "stored_polyline"},
+                storage_type="session",
+            ),
+            dcc.Store(
+                id={"id": get_uuid("map"), "element": "stored_xline"},
+                storage_type="session",
+            ),
+            dcc.Store(
+                id={"id": get_uuid("map"), "element": "stored_yline"},
+                storage_type="session",
+            ),
+            dcc.Store(
+                id=get_uuid("intersection-graph-layout"),
+                storage_type="session",
+            ),
+            dcc.Store(
+                id={
+                    "id": get_uuid("intersection-data"),
+                    "element": "stored_manual_update_options",
+                },
+                storage_type="session",
+            ),
+            dcc.Store(
+                id=get_uuid("map-color-ranges"),
+                storage_type="session",
+            ),
+        ]
+    )

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_and_map.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_and_map.py
@@ -1,0 +1,133 @@
+from typing import Callable, Optional, List, Dict
+import dash_html_components as html
+import webviz_core_components as wcc
+from webviz_subsurface_components import LeafletMap
+from .uncertainty_table import uncertainty_table_layout
+
+
+def intersection_and_map_layout(get_uuid: Callable) -> html.Div:
+    """Layout for the intersection graph and maps"""
+    return html.Div(
+        children=[
+            html.Div(
+                className="framed",
+                children=[
+                    wcc.Graph(
+                        style={"height": "48vh", "background-color": "white"},
+                        id=get_uuid("intersection-graph"),
+                    ),
+                ],
+            ),
+            html.Div(
+                id=get_uuid("maps-and-uncertainty-table-wrapper"),
+                style={"background-color": "white"},
+                children=[
+                    wcc.FlexBox(
+                        style={"height": "40vh", "display": "flex"},
+                        className="framed",
+                        id=get_uuid("all-maps-wrapper"),
+                        children=[
+                            html.Div(
+                                style={"flex": 1},
+                                id=get_uuid("map-wrapper"),
+                                children=map_layout(
+                                    uuid=get_uuid("map"),
+                                    leaflet_id=get_uuid("leaflet-map1"),
+                                    synced_uuids=[
+                                        get_uuid("leaflet-map2"),
+                                        get_uuid("leaflet-map3"),
+                                    ],
+                                    draw_polyline=True,
+                                ),
+                            ),
+                            html.Div(
+                                style={"flex": 1},
+                                children=map_layout(
+                                    uuid=get_uuid("map2"),
+                                    leaflet_id=get_uuid("leaflet-map2"),
+                                    synced_uuids=[
+                                        get_uuid("leaflet-map1"),
+                                        get_uuid("leaflet-map3"),
+                                    ],
+                                ),
+                            ),
+                            html.Div(
+                                style={"flex": 1},
+                                children=map_layout(
+                                    uuid=get_uuid("map3"),
+                                    leaflet_id=get_uuid("leaflet-map3"),
+                                    synced_uuids=[
+                                        get_uuid("leaflet-map1"),
+                                        get_uuid("leaflet-map2"),
+                                    ],
+                                ),
+                            ),
+                        ],
+                    ),
+                    html.Div(
+                        id={
+                            "id": get_uuid("uncertainty-table"),
+                            "element": "wrapper",
+                        },
+                        className="framed",
+                        style={"height": "40vh", "display": "none"},
+                        children=uncertainty_table_layout(
+                            uuid=get_uuid("uncertainty-table"),
+                        ),
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def map_layout(
+    uuid: str,
+    leaflet_id: str,
+    synced_uuids: Optional[List[str]] = None,
+    draw_polyline: bool = False,
+) -> html.Div:
+    synced_uuids = synced_uuids if synced_uuids else []
+    props: Optional[Dict] = (
+        {
+            "drawTools": {
+                "drawMarker": False,
+                "drawPolygon": False,
+                "drawPolyline": True,
+                "position": "topright",
+            }
+        }
+        if draw_polyline
+        else {}
+    )
+    return html.Div(
+        style={"height": "100%", "padding": "10px"},
+        children=[
+            html.Label(
+                style={"textAlign": "center", "fontSize": "0.8em"},
+                id={"id": uuid, "element": "label"},
+            ),
+            html.Div(
+                style={
+                    "height": "38vh",
+                },
+                children=LeafletMap(
+                    syncedMaps=synced_uuids,
+                    id=leaflet_id,
+                    layers=[],
+                    unitScale={},
+                    autoScaleMap=True,
+                    minZoom=-5,
+                    updateMode="replace",
+                    mouseCoords={"position": "bottomright"},
+                    colorBar={"position": "bottomleft"},
+                    switch={
+                        "value": False,
+                        "disabled": False,
+                        "label": "Hillshading",
+                    },
+                    **props
+                ),
+            ),
+        ],
+    )

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
@@ -1,0 +1,495 @@
+from typing import List, Callable, Dict, Optional
+
+import dash_core_components as dcc
+import dash_bootstrap_components as dbc
+import dash_html_components as html
+import webviz_core_components as wcc
+
+from .modal import open_modal_layout
+from .uncertainty_table import uncertainty_table_btn
+
+
+def intersection_data_layout(
+    get_uuid: Callable,
+    surface_attributes: List[str],
+    surface_names: List[str],
+    ensembles: List[str],
+    use_wells: bool,
+    well_names: List[str],
+    surface_geometry: Dict,
+    initial_settings: Dict,
+) -> html.Div:
+    """Layout for selecting intersection data"""
+    return html.Div(
+        id=get_uuid("intersection-data-wrapper"),
+        children=[
+            html.Div(
+                style={
+                    "padding-bottom": "10px",
+                    "border-bottom-style": "solid",
+                    "border-width": "thin",
+                    "border-color": "grey",
+                },
+                id=get_uuid("intersection-source-wrapper"),
+                children=[
+                    html.Span("Intersection source", style={"font-weight": "bold"}),
+                    source_layout(
+                        uuid=get_uuid("intersection-data"),
+                        use_wells=use_wells,
+                    ),
+                    well_layout(
+                        uuid=get_uuid("intersection-data"),
+                        well_names=well_names,
+                        value=initial_settings.get(
+                            "well",
+                            well_names[0] if use_wells else None,
+                        ),
+                    ),
+                    xline_layout(
+                        uuid=get_uuid("intersection-data"),
+                        surface_geometry=surface_geometry,
+                    ),
+                    yline_layout(
+                        uuid=get_uuid("intersection-data"),
+                        surface_geometry=surface_geometry,
+                    ),
+                ],
+            ),
+            surface_attribute_layout(
+                uuid=get_uuid("intersection-data"),
+                surface_attributes=surface_attributes,
+                value=initial_settings.get(
+                    "surface_attribute",
+                    surface_attributes[0],
+                ),
+            ),
+            surface_names_layout(
+                uuid=get_uuid("intersection-data"),
+                surface_names=surface_names,
+                value=initial_settings.get("surface_names", [surface_names[0]]),
+            ),
+            ensemble_layout(
+                uuid=get_uuid("intersection-data"),
+                ensemble_names=ensembles,
+                value=initial_settings.get("ensembles", [ensembles[0]]),
+            ),
+            statistical_layout(
+                uuid=get_uuid("intersection-data"),
+                value=initial_settings.get("calculation", ["Mean", "Min", "Max"]),
+            ),
+            blue_apply_button(
+                uuid=get_uuid("apply-intersection-data-selections"),
+                title="Update intersection",
+            ),
+            uncertainty_table_btn(
+                uuid=get_uuid("uncertainty-table-display-button"),
+                disabled=not use_wells,
+            ),
+            settings_layout(get_uuid, initial_settings=initial_settings),
+        ],
+    )
+
+
+def source_layout(uuid: str, use_wells: bool = True) -> html.Div:
+    options = [
+        {"label": "Intersect polyline from Surface A", "value": "polyline"},
+        {"label": "Intersect x-line from Surface A", "value": "xline"},
+        {"label": "Intersect y-line from Surface A", "value": "yline"},
+    ]
+    if use_wells:
+        options.append({"label": "Intersect well", "value": "well"})
+    return html.Div(
+        children=dcc.Dropdown(
+            id={"id": uuid, "element": "source"},
+            options=options,
+            value="well" if use_wells else "polyline",
+            clearable=False,
+            persistence=True,
+            persistence_type="session",
+        ),
+    )
+
+
+def well_layout(
+    uuid: str, well_names: List[str], value: Optional[str] = None
+) -> html.Div:
+    return html.Div(
+        style={
+            "display": "none",
+        }
+        if value is None
+        else {},
+        id={"id": uuid, "element": "well-wrapper"},
+        children=html.Label(
+            children=[
+                html.Span("Well:", style={"font-weight": "bold"}),
+                dcc.Dropdown(
+                    id={"id": uuid, "element": "well"},
+                    options=[{"label": well, "value": well} for well in well_names],
+                    value=value,
+                    clearable=False,
+                    persistence=True,
+                    persistence_type="session",
+                ),
+            ]
+        ),
+    )
+
+
+def xline_layout(uuid: str, surface_geometry: Dict) -> html.Div:
+    return html.Div(
+        style={
+            "display": "none",
+        },
+        id={"id": uuid, "element": "xline-wrapper"},
+        children=[
+            html.Label("X-Line:"),
+            wcc.FlexBox(
+                style={"fontSize": "0.8em"},
+                children=[
+                    dbc.Input(
+                        id={"id": uuid, "cross-section": "xline", "element": "value"},
+                        style={"flex": 3, "minWidth": "100px"},
+                        type="number",
+                        value=round(surface_geometry["xmin"]),
+                        min=round(surface_geometry["xmin"]),
+                        max=round(surface_geometry["xmax"]),
+                        step=500,
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                    dbc.Label(
+                        style={"flex": 1, "marginLeft": "10px", "minWidth": "20px"},
+                        children="Step:",
+                    ),
+                    dbc.Input(
+                        id={"id": uuid, "cross-section": "xline", "element": "step"},
+                        style={"flex": 2, "minWidth": "20px"},
+                        value=500,
+                        type="number",
+                        min=1,
+                        max=round(surface_geometry["xmax"])
+                        - round(surface_geometry["xmin"]),
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def yline_layout(uuid: str, surface_geometry: Dict) -> html.Div:
+    return html.Div(
+        style={
+            "display": "none",
+        },
+        id={"id": uuid, "element": "yline-wrapper"},
+        children=[
+            html.Label("Y-Line:"),
+            wcc.FlexBox(
+                style={"fontSize": "0.8em"},
+                children=[
+                    dbc.Input(
+                        id={"id": uuid, "cross-section": "yline", "element": "value"},
+                        style={"flex": 3, "minWidth": "100px"},
+                        type="number",
+                        value=round(surface_geometry["ymin"]),
+                        min=round(surface_geometry["ymin"]),
+                        max=round(surface_geometry["ymax"]),
+                        step=50,
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                    dbc.Label(
+                        style={"flex": 1, "marginLeft": "10px", "minWidth": "20px"},
+                        children="Step:",
+                    ),
+                    dbc.Input(
+                        id={"id": uuid, "cross-section": "yline", "element": "step"},
+                        style={"flex": 2, "minWidth": "20px"},
+                        value=50,
+                        type="number",
+                        min=1,
+                        max=round(surface_geometry["ymax"])
+                        - round(surface_geometry["ymin"]),
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def surface_attribute_layout(
+    uuid: str, surface_attributes: List[str], value: str
+) -> html.Div:
+    return html.Div(
+        style={"marginTop": "10px"},
+        children=html.Label(
+            children=[
+                html.Span("Surface attribute", style={"font-weight": "bold"}),
+                dcc.Dropdown(
+                    id={"id": uuid, "element": "surface_attribute"},
+                    options=[
+                        {"label": attribute, "value": attribute}
+                        for attribute in surface_attributes
+                    ],
+                    value=value,
+                    clearable=False,
+                    multi=False,
+                    persistence=True,
+                    persistence_type="session",
+                ),
+            ]
+        ),
+    )
+
+
+def surface_names_layout(
+    uuid: str, surface_names: List[str], value: List[str]
+) -> html.Div:
+    return html.Div(
+        style={"marginTop": "5px"},
+        children=html.Label(
+            children=[
+                html.Span("Surfacenames", style={"font-weight": "bold"}),
+                wcc.Select(
+                    id={"id": uuid, "element": "surface_names"},
+                    options=[
+                        {"label": attribute, "value": attribute}
+                        for attribute in surface_names
+                    ],
+                    value=value,
+                    multi=True,
+                    size=min(len(surface_names), 5),
+                    persistence=True,
+                    persistence_type="session",
+                ),
+            ]
+        ),
+    )
+
+
+def ensemble_layout(uuid: str, ensemble_names: List[str], value: List[str]) -> html.Div:
+    return html.Div(
+        style={
+            "marginTop": "5px",
+            "display": ("inline" if len(ensemble_names) > 1 else "none"),
+        },
+        children=html.Label(
+            children=[
+                html.Span("Ensembles", style={"font-weight": "bold"}),
+                wcc.Select(
+                    id={"id": uuid, "element": "ensembles"},
+                    options=[{"label": ens, "value": ens} for ens in ensemble_names],
+                    value=value,
+                    size=min(len(ensemble_names), 3),
+                    persistence=True,
+                    persistence_type="session",
+                ),
+            ]
+        ),
+    )
+
+
+def statistical_layout(uuid: str, value: List[str]) -> html.Div:
+    return html.Div(
+        style={"marginTop": "10px"},
+        children=html.Label(
+            children=[
+                html.Span("Show surfaces:", style={"font-weight": "bold"}),
+                dcc.Checklist(
+                    id={"id": uuid, "element": "calculation"},
+                    options=[
+                        {"label": "Mean", "value": "Mean"},
+                        {"label": "Min", "value": "Min"},
+                        {"label": "Max", "value": "Max"},
+                        {"label": "Realizations", "value": "Realizations"},
+                        {
+                            "label": "Uncertainty envelope (slow)",
+                            "value": "Uncertainty envelope",
+                        },
+                    ],
+                    value=value,
+                    persistence=True,
+                    persistence_type="session",
+                    labelStyle={
+                        "display": "inline-block",
+                        "margin-right": "5px",
+                    },
+                ),
+            ]
+        ),
+    )
+
+
+def blue_apply_button(uuid: str, title: str) -> html.Div:
+    return html.Button(
+        title,
+        className="webviz-structunc-blue-apply-btn",
+        id=uuid,
+    )
+
+
+def options_layout(
+    uuid: str,
+    depth_truncations: Dict,
+    resolution: float,
+    extension: int,
+    initial_layout: Dict,
+) -> html.Div:
+
+    return html.Div(
+        children=[
+            html.Div(
+                children=[
+                    html.Label(
+                        "Resolution (m) ",
+                        className="webviz-structunc-range-label",
+                    ),
+                    dcc.Input(
+                        className="webviz-structunc-range-input",
+                        id={"id": uuid, "element": "resolution"},
+                        type="number",
+                        required=True,
+                        value=resolution,
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                ],
+            ),
+            html.Div(
+                children=[
+                    html.Label(
+                        "Extension (m) ",
+                        className="webviz-structunc-range-label",
+                    ),
+                    dcc.Input(
+                        className="webviz-structunc-range-input",
+                        id={"id": uuid, "element": "extension"},
+                        type="number",
+                        step=25,
+                        required=True,
+                        value=extension,
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                ],
+            ),
+            html.Div(
+                style={"margin-top": "10px"},
+                children=[
+                    html.Label(
+                        "Depth range settings:",
+                        style={"font-weight": "bold"},
+                    ),
+                    wcc.FlexBox(
+                        style={"display": "flex"},
+                        children=[
+                            dbc.Input(
+                                id={
+                                    "id": uuid,
+                                    "settings": "zrange_min",
+                                },
+                                style={"flex": 1, "minWidth": "70px"},
+                                type="number",
+                                value=depth_truncations.get("min", None),
+                                debounce=True,
+                                placeholder="Min",
+                                persistence=True,
+                                persistence_type="session",
+                            ),
+                            dbc.Input(
+                                id={
+                                    "id": uuid,
+                                    "settings": "zrange_max",
+                                },
+                                style={"flex": 1, "minWidth": "70px"},
+                                type="number",
+                                value=depth_truncations.get("max", None),
+                                debounce=True,
+                                placeholder="Max",
+                                persistence=True,
+                                persistence_type="session",
+                            ),
+                        ],
+                    ),
+                    dcc.RadioItems(
+                        style={
+                            "margin-top": "5px",
+                            "margin-bottom": "10px",
+                        },
+                        id={
+                            "id": uuid,
+                            "settings": "zrange_locks",
+                        },
+                        options=[
+                            {
+                                "label": "Truncate range",
+                                "value": "truncate",
+                            },
+                            {
+                                "label": "Lock range",
+                                "value": "lock",
+                            },
+                        ],
+                        labelStyle={
+                            "display": "inline-block",
+                            "margin-right": "5px",
+                        },
+                        value="truncate",
+                    ),
+                    dcc.Checklist(
+                        style={
+                            "margin-bottom": "10px",
+                        },
+                        id={
+                            "id": uuid,
+                            "settings": "ui_options",
+                        },
+                        options=[
+                            {"label": "Keep zoom state", "value": "uirevision"},
+                        ],
+                        value=["uirevision"] if "uirevision" in initial_layout else [],
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def settings_layout(get_uuid: Callable, initial_settings: Dict) -> html.Div:
+    return html.Details(
+        className="webviz-structunc-settings",
+        open=False,
+        children=[
+            html.Summary(
+                style={
+                    "font-size": "15px",
+                    "font-weight": "bold",
+                },
+                children="⚙️ Settings",
+            ),
+            html.Div(
+                style={"padding": "10px"},
+                children=[
+                    options_layout(
+                        uuid=get_uuid("intersection-data"),
+                        depth_truncations=initial_settings.get("depth_truncations", {}),
+                        resolution=initial_settings.get("resolution", 10),
+                        extension=initial_settings.get("extension", 500),
+                        initial_layout=initial_settings.get("intersection_layout", {}),
+                    ),
+                    open_modal_layout(
+                        modal_id="color",
+                        uuid=get_uuid("modal"),
+                        title="Intersection colors",
+                    ),
+                ],
+            ),
+        ],
+    )

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/map_data.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/map_data.py
@@ -1,0 +1,247 @@
+from typing import List
+
+import dash_core_components as dcc
+import dash_html_components as html
+import dash_bootstrap_components as dbc
+import webviz_core_components as wcc
+
+
+def map_data_layout(
+    uuid: str,
+    surface_attributes: List[str],
+    surface_names: List[str],
+    ensembles: List[str],
+    realizations: List[int],
+    use_wells: bool,
+) -> html.Div:
+    """Layout for the map data modal"""
+    return html.Div(
+        children=[
+            html.Details(
+                open=True,
+                children=[
+                    html.Summary(
+                        style={
+                            "font-size": "15px",
+                            "font-weight": "bold",
+                        },
+                        children="Surface A",
+                    ),
+                    html.Div(
+                        make_map_selectors(
+                            uuid=uuid,
+                            surface_attributes=surface_attributes,
+                            surface_names=surface_names,
+                            ensembles=ensembles,
+                            realizations=realizations,
+                            use_wells=use_wells,
+                            map_id="map1",
+                        ),
+                    ),
+                ],
+            ),
+            html.Details(
+                style={
+                    "marginTop": "15px",
+                    "marginBottom": "10px",
+                },
+                open=False,
+                children=[
+                    html.Summary(
+                        style={
+                            "font-size": "15px",
+                            "font-weight": "bold",
+                        },
+                        children="Surface B",
+                    ),
+                    html.Div(
+                        make_map_selectors(
+                            uuid=uuid,
+                            surface_attributes=surface_attributes,
+                            surface_names=surface_names,
+                            ensembles=ensembles,
+                            realizations=realizations,
+                            use_wells=use_wells,
+                            map_id="map2",
+                        ),
+                    ),
+                ],
+            ),
+            settings_layout(uuid=uuid),
+        ]
+    )
+
+
+def make_map_selectors(
+    uuid: str,
+    map_id: str,
+    surface_attributes: List[str],
+    surface_names: List[str],
+    ensembles: List[str],
+    realizations: List[int],
+    use_wells: bool,
+) -> html.Div:
+    return html.Div(
+        children=[
+            html.Label(
+                "Surface attribute", style={"fontSize": "0.8em", "fontWeight": "bold"}
+            ),
+            dcc.Dropdown(
+                id={"id": uuid, "map_id": map_id, "element": "surfaceattribute"},
+                options=[{"label": val, "value": val} for val in surface_attributes],
+                value=surface_attributes[0],
+                clearable=False,
+                persistence=True,
+                persistence_type="session",
+            ),
+            html.Label(
+                "Surface name", style={"fontSize": "0.8em", "fontWeight": "bold"}
+            ),
+            dcc.Dropdown(
+                id={"id": uuid, "map_id": map_id, "element": "surfacename"},
+                options=[{"label": val, "value": val} for val in surface_names],
+                value=surface_names[0],
+                clearable=False,
+                persistence=True,
+                persistence_type="session",
+            ),
+            html.Div(
+                style={"display": ("inline" if len(ensembles) > 1 else "none")},
+                children=[
+                    html.Label(
+                        "Ensemble", style={"fontSize": "0.8em", "fontWeight": "bold"}
+                    ),
+                    dcc.Dropdown(
+                        id={"id": uuid, "map_id": map_id, "element": "ensemble"},
+                        options=[{"label": val, "value": val} for val in ensembles],
+                        value=ensembles[0],
+                        clearable=False,
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                ],
+            ),
+            html.Label(
+                "Calculation/Realization",
+                style={"fontSize": "0.8em", "fontWeight": "bold"},
+            ),
+            dcc.Dropdown(
+                id={"id": uuid, "map_id": map_id, "element": "calculation"},
+                options=[
+                    {"label": val, "value": val}
+                    for val in ["Mean", "StdDev", "Max", "Min", "P90", "P10"]
+                    + [str(real) for real in realizations]
+                ],
+                value=realizations[0],
+                clearable=False,
+                persistence=True,
+                persistence_type="session",
+            ),
+            dcc.Checklist(
+                style={"marginTop": "10px"},
+                id={"id": uuid, "map_id": map_id, "element": "options"},
+                options=[
+                    {"label": "Calculate well intersections", "value": "intersect_well"}
+                ]
+                if use_wells
+                else [],
+                value=[],
+                persistence=True,
+                persistence_type="session",
+            ),
+        ]
+    )
+
+
+def settings_layout(uuid: str) -> html.Details:
+    return html.Details(
+        className="webviz-structunc-settings",
+        open=False,
+        children=[
+            html.Summary(
+                style={
+                    "font-size": "15px",
+                    "font-weight": "bold",
+                },
+                children="⚙️ Settings",
+            ),
+            html.Div(
+                style={"padding": "10px"},
+                children=[
+                    dcc.Checklist(
+                        id={"id": uuid, "settings": "compute_diff"},
+                        options=[
+                            {
+                                "label": "Auto compute difference map",
+                                "value": "compute_diffmap",
+                            }
+                        ],
+                        value=["compute_diffmap"],
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                    html.Div(
+                        style={"margin-top": "10px"},
+                        children=[
+                            html.Label(
+                                "Color ranges:",
+                                style={"font-weight": "bold"},
+                            ),
+                            color_range_layout(uuid=uuid, map_id="map1"),
+                            color_range_layout(uuid=uuid, map_id="map2"),
+                            dcc.Checklist(
+                                id={"id": uuid, "colors": "sync_range"},
+                                options=[
+                                    {
+                                        "label": "Sync range on maps",
+                                        "value": "sync_range",
+                                    }
+                                ],
+                                value=[],
+                                persistence=True,
+                                persistence_type="session",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def color_range_layout(uuid: str, map_id: str) -> wcc.FlexBox:
+    return wcc.FlexBox(
+        style={"display": "flex", "align-items": "center"},
+        children=[
+            html.Div(
+                "Surface A" if map_id == "map1" else "Surface B",
+                style={"flex": 1, "minWidth": "70px"},
+            ),
+            dbc.Input(
+                id={
+                    "id": uuid,
+                    "colors": f"{map_id}_clip_min",
+                },
+                style={"flex": 1, "minWidth": "70px"},
+                type="number",
+                value=None,
+                debounce=True,
+                placeholder="Min",
+                persistence=True,
+                persistence_type="session",
+            ),
+            dbc.Input(
+                id={
+                    "id": uuid,
+                    "colors": f"{map_id}_clip_max",
+                },
+                style={"flex": 1, "minWidth": "70px"},
+                type="number",
+                value=None,
+                debounce=True,
+                placeholder="Max",
+                persistence=True,
+                persistence_type="session",
+            ),
+        ],
+    )

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/modal.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/modal.py
@@ -1,0 +1,71 @@
+from typing import List, Optional
+
+import dash_html_components as html
+import dash_bootstrap_components as dbc
+
+
+def modal_layout(
+    uuid: str,
+    modal_id: str,
+    title: str,
+    body_children: List,
+    footer: Optional[dbc.ModalFooter] = None,
+    size: str = "sm",
+) -> dbc.Modal:
+    modalchildren = [
+        dbc.ModalHeader(title),
+        dbc.ModalBody(
+            children=[*body_children],
+        ),
+    ]
+    if footer:
+        modalchildren.append(footer)
+    return dbc.Modal(
+        style={"marginTop": "20vh"},
+        children=modalchildren,
+        id={"id": uuid, "modal_id": modal_id, "element": "wrapper"},
+        size=size,
+    )
+
+
+def open_modal_layout(uuid: str, modal_id: str, title: str) -> dbc.Button:
+    return html.Div(
+        children=html.Button(
+            title,
+            className="webviz-structunc-open-modal-btn",
+            id={"id": uuid, "modal_id": modal_id, "element": "button-open"},
+        ),
+    )
+
+
+def clear_all_apply_modal_buttons(
+    uuid: str, modal_id: str, apply_disabled: bool = True
+) -> dbc.ModalFooter:
+    return dbc.ModalFooter(
+        children=[
+            html.Div(
+                children=[
+                    dbc.Button(
+                        "Clear",
+                        style={"padding": "0 20px"},
+                        className="mr-1",
+                        id={"id": uuid, "modal_id": modal_id, "element": "clear"},
+                    ),
+                    dbc.Button(
+                        "All",
+                        style={"padding": "0 20px"},
+                        className="mr-1",
+                        id={"id": uuid, "modal_id": modal_id, "element": "all"},
+                    ),
+                    dbc.Button(
+                        "Apply",
+                        style={"padding": "0 20px", "visibility": "hidden"}
+                        if apply_disabled
+                        else {"padding": "0 20px"},
+                        className="mr-1",
+                        id={"id": uuid, "modal_id": modal_id, "element": "apply"},
+                    ),
+                ]
+            ),
+        ]
+    )

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/realization_modal.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/realization_modal.py
@@ -1,0 +1,26 @@
+from typing import List
+
+import dash_html_components as html
+import webviz_core_components as wcc
+
+
+def realization_layout(
+    uuid: str, realizations: List[int], value: List[int]
+) -> html.Div:
+    """Layout for the realization filter modal"""
+    return html.Div(
+        style={"marginTop": "10px"},
+        children=html.Label(
+            children=[
+                wcc.Select(
+                    id={"id": uuid, "element": "realizations"},
+                    options=[{"label": real, "value": real} for real in realizations],
+                    value=[str(val) for val in value],
+                    multi=True,
+                    size=20,
+                    persistence=True,
+                    persistence_type="session",
+                ),
+            ]
+        ),
+    )

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
@@ -1,0 +1,87 @@
+import dash_html_components as html
+import dash_table
+import webviz_core_components as wcc
+
+
+def uncertainty_table_layout(
+    uuid: str,
+) -> html.Div:
+    """Layout for the uncertainty table modal"""
+    return html.Div(
+        className="webviz-structunc-uncertainty-table-wrapper",
+        children=[
+            wcc.FlexBox(
+                children=[
+                    html.Label(
+                        className="webviz-structunc-uncertainty-table-label",
+                        children="Statistics for well: ",
+                        id={"id": uuid, "element": "label"},
+                    ),
+                    html.Button(
+                        "Recalculate",
+                        className="webviz-structunc-uncertainty-table-apply-btn",
+                        id={"id": uuid, "element": "apply-button"},
+                    ),
+                ]
+            ),
+            dash_table.DataTable(
+                id={"id": uuid, "element": "table"},
+                columns=[
+                    {"id": "Surface name", "name": "Surface name", "selectable": False},
+                    {"id": "Ensemble", "name": "Ensemble", "selectable": False},
+                    {"id": "Calculation", "name": "Calculation", "selectable": False},
+                    {"id": "Pick no", "name": "Pick no", "selectable": False},
+                    {
+                        "id": "TVD",
+                        "name": "TVD (MSL)",
+                        "selectable": False,
+                    },
+                    {
+                        "id": "MD",
+                        "name": "MD (RKB)",
+                        "selectable": False,
+                    },
+                ],
+                style_header={
+                    "opacity": 0.5,
+                },
+                style_filter={
+                    "opacity": 0.5,
+                },
+                style_data_conditional=[
+                    {
+                        "if": {"column_id": "Surface name"},
+                        "textAlign": "left",
+                        "width": "15%",
+                    },
+                    {
+                        "if": {"column_id": "Ensemble"},
+                        "textAlign": "left",
+                        "width": "15%",
+                    },
+                    {
+                        "if": {"column_id": "Calculation"},
+                        "textAlign": "left",
+                        "width": "10%",
+                    },
+                    {
+                        "if": {"filter_query": '{Calculation} = "Mean"'},
+                        "backgroundColor": "rgba(0,177,106,0.3)",
+                    },
+                ],
+                sort_action="native",
+                filter_action="native",
+            ),
+        ],
+    )
+
+
+def uncertainty_table_btn(uuid: str, disabled: bool = False) -> html.Button:
+    return html.Div(
+        children=html.Button(
+            "Show uncertainty table",
+            className="webviz-structunc-open-modal-btn",
+            id=uuid,
+            disabled=disabled,
+        ),
+    )


### PR DESCRIPTION
Plugin to analyze FMU runs where structural uncertainty is explored stochastically using Cohiba.

Typically in an FMU settings seismically interpreted reflectors together with geologically interpreted features (isochore based surfaces) are modelled stochastically using Cohiba This results in an ensemble of surfaces with equal geometry, but varying z-values. All surfaces should be restrained by hard conditioning points, such as well tops and zonelogs, as well as the input seismic interpretation uncertainty, velocity uncertainty and correlations between the different surfaces.

This plugin enables analysis of these results:
- 2D maps of individual ensemble members, statistical and difference surfaces with calculated well intersection markers.
- Intersection view along a well trajectory or from a polyline drawn interactively from the map view
- Uncertainty table to display well intersections
- Filter to focus on different collection of ensemble members, e.g. different input velocity models
- Comparison between different ensembles

The plugin follows the FMU standards with regards to surface naming and placement on the filesystem.
Wells are not required, but if provided must be on RMS Well format. It is recommended to include no logs, except from an optional Zonelog and MDlog.

In general data should be provided fit for purpose, with regards to resolution and sampling.

The plugin can be initialized with initial settings, such as which well and stratigraphy is visualized. See the plugin documentation for a full description.

---

### Contributor checklist

- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Consolidate surface loading and statistical surface calculation using SurfaceSetModel
   - [x] Add realization filter
   - [x] Visualize statistics independently, as well as individual realizations
   - [x] Add color customization
   - [x] Add map views
   - [x] Add ensemble comparison
   - [x] Add zonelog/well marker
   - [x] Add fence specification from map view
   - [x] Improve layout and presentation
   - [x] Add uncertainty table
   - [x] Update documentation
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
