### PR TITLE
Plot options ReservoirSimulationTimeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED] - YYYY-MM-DD
+### Changed
+- [#612](https://github.com/equinor/webviz-subsurface/pull/612) - New features in ReservoirSimulationTimeSeries: Statistical lines, option to remove history trace, histogram available when plotting individual realizations.
 
 ## [0.2.0] - 2021-03-28
-### Changed
 - [#604](https://github.com/equinor/webviz-subsurface/pull/604) - Consolidates surface loading and statistical calculation of surfaces by introducing a shared
 SurfaceSetModel. Refactored SurfaceViewerFMU to use SurfaceSetModel.
 - [#586](https://github.com/equinor/webviz-subsurface/pull/586) - Added phase ratio vs pressure and density vs pressure plots. Added unit and density functions to PVT library. Refactored code and added checklist for plots to be viewed in PVT plot plugin. Improved the layout.
-- [#599](https://github.com/equinor/webviz-subsurface/pull/599) - Fixed an issue in ParameterAnalysis where the plugin did not initialize without FIELD vectors 
+- [#599](https://github.com/equinor/webviz-subsurface/pull/599) - Fixed an issue in ParameterAnalysis where the plugin did not initialize without FIELD vectors
 
 ### Fixed
 - [#602](https://github.com/equinor/webviz-subsurface/pull/602) - Prevent calculation of data for download at initialisation of ReservoirSimulationTimeSeries.


### PR DESCRIPTION
Modifications to ReservoirSimulationTimeseries:

- Allow statistical lines without fill (including new P50/median). (Easier to read, avoids overlapping color fills)
  - Can choose which statistics to include (Mean, P10, P50, P90, Max, Min)
- Option to remove history trace (and cut history trace at current date, as longer is not realistic even though Eclipse creates it)
- Add `legendgroup` to histogram traces to make them "toggleable"
- Allow histogram together with individual realizations
- Remove history traces in delta plots

---

Technically breaking: `statistics_hist` no longer valid config option (but doubt it is used at all). The default `statistics` now refers to statistical lines, whilst `fanchart` refers to the old default. May consider to change the default to `fanchart`, but I think at least the naming is most descriptive this way.

### Contributor checklist

- [X] :tada: This PR closes #503, closes #504, closes #496, closes #403, relates to (might close) #444, relates to (might close) #226, relates to (will not close) #214. 
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
