### PR TITLE
Changed layout: show plots on top of each other instead of side by side

### DIFF
--- a/webviz_subsurface/plugins/_disk_usage.py
+++ b/webviz_subsurface/plugins/_disk_usage.py
@@ -58,16 +58,8 @@ class DiskUsage(WebvizPluginABC):
                     f"Disk usage on {self.scratch_dir} per user as of {self.date}",
                     style={"text-align": "center"},
                 ),
-                wcc.FlexBox(
-                    children=[
-                        wcc.Graph(
-                            style={"flex": 1},
-                            figure=self.pie_chart,
-                            config={"displayModeBar": False},
-                        ),
-                        wcc.Graph(style={"flex": 2}, figure=self.bar_chart),
-                    ]
-                ),
+                wcc.Graph(figure=self.pie_chart),
+                wcc.Graph(figure=self.bar_chart),
             ]
         )
 


### PR DESCRIPTION
Changed layout: show plots on top of each other instead of side by side. This should make it easier to read plots with "normal" window width.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
