### PR TITLE
Remove SyntaxWarning on Python3.8 in RelativePemerability

### DIFF
--- a/webviz_subsurface/plugins/_relative_permeability.py
+++ b/webviz_subsurface/plugins/_relative_permeability.py
@@ -118,7 +118,7 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
                 + [
                     key
                     for key in RelativePermeability.SCAL_COLORMAP
-                    if key is not "Missing"
+                    if key != "Missing"
                 ]
             )
             self.satfunc = self.satfunc[


### PR DESCRIPTION
Closes #638.