### PR TITLE
Remove `mock` as test requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ TESTS_REQUIRE = [
     "selenium>=3.141",
     "pylint",
     "mypy",
-    "mock",
     "black>=21.4b0",
     "bandit",
     "pytest-xdist",

--- a/tests/integration_tests/test_parameter_corr.py
+++ b/tests/integration_tests/test_parameter_corr.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import dash
 import pandas as pd
 from webviz_config.common_cache import CACHE


### PR DESCRIPTION
`unittest.mock` new in Python 3.3+