### PR TITLE
Including stratigraphy in the well completion plugin

### DIFF
--- a/tests/unit_tests/plugin_tests/test_well_completions.py
+++ b/tests/unit_tests/plugin_tests/test_well_completions.py
@@ -16,7 +16,7 @@ def test_extract_stratigraphy():
         },
         {
             "name": "ZoneC",
-        }
+        },
     ]
     zone_color_mapping = {"ZoneA": "#111111", "ZoneA.1": "#222222"}
     theme_colors = ["#FFFFFF"]
@@ -24,35 +24,30 @@ def test_extract_stratigraphy():
     result = extract_stratigraphy(
         layer_zone_mapping, stratigraphy, zone_color_mapping, theme_colors
     )
-    # Merging of stratigraphy and layer_zone_mapping logic
-    top_level_zones = [zonedict["name"] for zonedict in result]
-    zoneA_subzones = [zonedict["name"] for zonedict in result[0]["subzones"]] # pylint: disable=invalid-name
-    assert result[0]["name"] == "ZoneA"
-    assert result[1]["name"] == "ZoneB"
-    assert (
-        "ZoneC" not in top_level_zones
-    )  # ZoneC is not in the layer_zone_mapping and should be removed
-    assert (
-        result[2]["name"] == "ZoneD"
-    )  # ZoneD is in the layer_zone_mapping and not in the stratigrapy. Should be added to the end
-    assert (
-        "ZoneA.3" not in zoneA_subzones
-    )  # ZoneA.3 is not in the layer_zone_mapping and should be removed
-    assert (
-        "subzones" not in result[1]["subzones"][0]
-    )  # The subzones of ZoneB.1 should be removed since they are not in the layer_zone_mapping
-
-    # Colors logic
-    assert result[0]["color"] == "#000000"  # colors in stratigraphy have priority
-    assert (
-        "color" not in result[1]
-    )  # no color specified for ZoneA in the stratigraphy or zone_color_map
-    assert (
-        result[0]["subzones"][0]["color"] == "#222222"
-    )  # Zone A.1 should get it's color from the zone_color_map
-    assert (
-        result[1]["subzones"][0]["color"] == "#FFFFFF"
-    )  # Zone B.1 is a leaf and should have theme color
-    assert (
-        result[2]["color"] == "#FFFFFF"
-    )  # Zone D is a leaf and should have theme color
+    assert result == [
+        {
+            "name": "ZoneA",
+            "color": "#000000",  # colors given in the stratigraphy has priority
+            "subzones": [
+                {
+                    "name": "ZoneA.1",
+                    "color": "#222222",  # color from zone_color_mapping
+                },
+                {"name": "ZoneA.2", "color": "#FFFFFF"}  # color from theme_colors
+                # ZoneA.3 is not here because it is not in the layer_zone_mapping
+            ],
+        },
+        {
+            "name": "ZoneB",
+            # Color not specified for ZoneB, and it is not a leaf
+            "subzones": [
+                {
+                    "name": "ZoneB.1",
+                    "color": "#FFFFFF"  # color from theme_colors
+                    # No subzones here because ZoneB.1.1 is not in the layer_zone_mapping
+                }
+            ],
+        },
+        # ZoneC is removed since it's not in the layer_zone_mapping
+        {"name": "ZoneD", "color": "#FFFFFF"},  # color from theme colors
+    ]

--- a/tests/unit_tests/plugin_tests/test_well_completions.py
+++ b/tests/unit_tests/plugin_tests/test_well_completions.py
@@ -1,0 +1,58 @@
+from webviz_subsurface.plugins._well_completions import extract_stratigraphy
+
+
+def test_extract_stratigraphy():
+
+    layer_zone_mapping = {1: "ZoneA.1", 2: "ZoneA.2", 3: "ZoneB.1", 4: "ZoneD"}
+    stratigraphy = [
+        {
+            "name": "ZoneA",
+            "color": "#000000",
+            "subzones": [{"name": "ZoneA.1"}, {"name": "ZoneA.2"}, {"name": "ZoneA.3"}],
+        },
+        {
+            "name": "ZoneB",
+            "subzones": [{"name": "ZoneB.1", "subzones": [{"name": "ZoneB.1.1"}]}],
+        },
+        {
+            "name": "ZoneC",
+        }
+    ]
+    zone_color_mapping = {"ZoneA": "#111111", "ZoneA.1": "#222222"}
+    theme_colors = ["#FFFFFF"]
+
+    result = extract_stratigraphy(
+        layer_zone_mapping, stratigraphy, zone_color_mapping, theme_colors
+    )
+    # Merging of stratigraphy and layer_zone_mapping logic
+    top_level_zones = [zonedict["name"] for zonedict in result]
+    zoneA_subzones = [zonedict["name"] for zonedict in result[0]["subzones"]] # pylint: disable=invalid-name
+    assert result[0]["name"] == "ZoneA"
+    assert result[1]["name"] == "ZoneB"
+    assert (
+        "ZoneC" not in top_level_zones
+    )  # ZoneC is not in the layer_zone_mapping and should be removed
+    assert (
+        result[2]["name"] == "ZoneD"
+    )  # ZoneD is in the layer_zone_mapping and not in the stratigrapy. Should be added to the end
+    assert (
+        "ZoneA.3" not in zoneA_subzones
+    )  # ZoneA.3 is not in the layer_zone_mapping and should be removed
+    assert (
+        "subzones" not in result[1]["subzones"][0]
+    )  # The subzones of ZoneB.1 should be removed since they are not in the layer_zone_mapping
+
+    # Colors logic
+    assert result[0]["color"] == "#000000"  # colors in stratigraphy have priority
+    assert (
+        "color" not in result[1]
+    )  # no color specified for ZoneA in the stratigraphy or zone_color_map
+    assert (
+        result[0]["subzones"][0]["color"] == "#222222"
+    )  # Zone A.1 should get it's color from the zone_color_map
+    assert (
+        result[1]["subzones"][0]["color"] == "#FFFFFF"
+    )  # Zone B.1 is a leaf and should have theme color
+    assert (
+        result[2]["color"] == "#FFFFFF"
+    )  # Zone D is a leaf and should have theme color

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -6,6 +6,7 @@ import glob
 
 from ecl2df import common
 
+
 def read_zone_layer_mapping(
     ensemble_path: str, zone_layer_mapping_file: str
 ) -> Optional[Dict[int, str]]:
@@ -17,7 +18,8 @@ def read_zone_layer_mapping(
         zonelist = common.parse_lyrfile(filename=filename)
         layer_zone_mapping = common.convert_lyrlist_to_zonemap(zonelist)
         zone_color_mapping = {
-            zonedict["name"]:zonedict["color"] for zonedict in zonelist
+            zonedict["name"]: zonedict["color"]
+            for zonedict in zonelist
             if "color" in zonedict and re.match("^#([A-Fa-f0-9]{6})", zonedict["color"])
         }
         return layer_zone_mapping, zone_color_mapping
@@ -67,6 +69,7 @@ def read_well_attributes(
             for well_data in file_content["wells"]
         }
     return None
+
 
 def read_stratigraphy(
     ensemble_path: str, stratigraphy_file: str

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 import json
 import re
 from pathlib import Path
@@ -66,4 +66,14 @@ def read_well_attributes(
             well_data["alias"]["eclipse"]: well_data["attributes"]
             for well_data in file_content["wells"]
         }
+    return None
+
+def read_stratigraphy(
+    ensemble_path: str, stratigraphy_file: str
+) -> Optional[List[Dict]]:
+    """Searches for a stratigraphy json file on the scratch disk. \
+    If a file is found the content is returned as a list of dicts.
+    """
+    for filename in glob.glob(f"{ensemble_path}/{stratigraphy_file}"):
+        return json.loads(Path(filename).read_text())
     return None

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -1,10 +1,10 @@
 from typing import Optional, Dict
 import json
+import re
 from pathlib import Path
 import glob
 
-import ecl2df
-
+from ecl2df import common
 
 def read_zone_layer_mapping(
     ensemble_path: str, zone_layer_mapping_file: str
@@ -14,8 +14,14 @@ def read_zone_layer_mapping(
     library.
     """
     for filename in glob.glob(f"{ensemble_path}/{zone_layer_mapping_file}"):
-        return ecl2df.EclFiles("").get_zonemap(filename=filename)
-    return None
+        zonelist = common.parse_lyrfile(filename=filename)
+        layer_zone_mapping = common.convert_lyrlist_to_zonemap(zonelist)
+        zone_color_mapping = {
+            zonedict["name"]:zonedict["color"] for zonedict in zonelist
+            if "color" in zonedict and re.match("^#([A-Fa-f0-9]{6})", zonedict["color"])
+        }
+        return layer_zone_mapping, zone_color_mapping
+    return None, None
 
 
 def read_well_attributes(

--- a/webviz_subsurface/plugins/_well_completions.py
+++ b/webviz_subsurface/plugins/_well_completions.py
@@ -530,7 +530,7 @@ def add_colors_to_stratigraphy(
     return stratigraphy
 
 
-def filter_valid_nodes(stratigraphy: List[Dict], valid_zone_names: list):
+def filter_valid_nodes(stratigraphy: List[Dict], valid_zone_names: list) -> List[Dict]:
     """Returns the stratigraphy tree with only valid nodes.
     A node is considered valid if it self or one of it's subzones are in the
     valid zone names list (passed from the lyr file)
@@ -547,6 +547,13 @@ def filter_valid_nodes(stratigraphy: List[Dict], valid_zone_names: list):
             "subzones" in zonedict and zonedict["subzones"]
         ):
             output.append(zonedict)
+            valid_zone_names = [
+                zone for zone in valid_zone_names if zone != zonedict["name"]
+            ]  # remove zone name from valid zones if it is found in the stratigraphy
+
+    # if any zones are left in the valid zone names they will be added to the end of the list
+    for zone_name in valid_zone_names:
+        output.append({"name": zone_name})
     return output
 
 

--- a/webviz_subsurface/plugins/_well_completions.py
+++ b/webviz_subsurface/plugins/_well_completions.py
@@ -18,7 +18,7 @@ from webviz_config import WebvizSettings
 import webviz_subsurface_components
 
 from .._datainput.fmu_input import load_csv
-from .._datainput.well_completions import read_zone_layer_mapping, read_well_attributes
+from .._datainput.well_completions import read_zone_layer_mapping, read_well_attributes, read_stratigraphy
 
 
 class WellCompletions(WebvizPluginABC):
@@ -30,6 +30,7 @@ class WellCompletions(WebvizPluginABC):
     * **`ensembles`:** Which ensembles in `shared_settings` to visualize.
     * **`compdat_file`:** csvfile with compdat data per realization
     * **`zone_layer_mapping_file`:** Lyr file specifying the zone->layer mapping \
+    * **`stratigraphy_file`:** Json file defining the stratigraphic levels \
     * **`well_attributes_file`:** Json file with categorical well attributes \
     * **`kh_unit`:** Will normally be mDm
     * **`kh_decimal_places`:**
@@ -58,6 +59,10 @@ class WellCompletions(WebvizPluginABC):
     Zone colors can be specified in the lyr file, but only 6 digit hexadecimal codes will be used.
 
     If no file exists, layers will be used as zones.
+
+    **Stratigraphy file **
+
+    Description of the stratigraphy file
 
     **Well Attributes file**
 
@@ -105,6 +110,7 @@ class WellCompletions(WebvizPluginABC):
         ensembles: list,
         compdat_file: str = "share/results/wells/compdat.csv",
         zone_layer_mapping_file: str = "rms/output/zone/simgrid_zone_layer_mapping.lyr",
+        stratigraphy_file: str = "rms/output/zone/stratigraphy.json",
         well_attributes_file: str = "rms/output/wells/well_attributes.json",
         kh_unit: str = "",
         kh_decimal_places: int = 2,
@@ -114,6 +120,7 @@ class WellCompletions(WebvizPluginABC):
         self.theme = webviz_settings.theme
         self.compdat_file = compdat_file
         self.zone_layer_mapping_file = zone_layer_mapping_file
+        self.stratigraphy_file = stratigraphy_file
         self.well_attributes_file = well_attributes_file
         self.ensembles = ensembles
         self.kh_unit = kh_unit
@@ -137,6 +144,7 @@ class WellCompletions(WebvizPluginABC):
                         "ensemble_path": self.ens_paths[ensemble],
                         "compdat_file": self.compdat_file,
                         "zone_layer_mapping_file": self.zone_layer_mapping_file,
+                        "stratigraphy_file": self.stratigraphy_file,
                         "well_attributes_file": self.well_attributes_file,
                         "colors": self.colors,
                         "kh_unit": self.kh_unit,
@@ -217,6 +225,7 @@ class WellCompletions(WebvizPluginABC):
                     self.ens_paths[ensemble_name],
                     self.compdat_file,
                     self.zone_layer_mapping_file,
+                    self.stratigraphy_file,
                     self.well_attributes_file,
                     self.theme_colors,
                     self.kh_unit,
@@ -239,6 +248,7 @@ def create_ensemble_dataset(
     ensemble_path: str,
     compdat_file: str,
     zone_layer_mapping_file: str,
+    stratigraphy_file: str,
     well_attributes_file: str,
     theme_colors: list,
     kh_unit: str,
@@ -256,6 +266,11 @@ def create_ensemble_dataset(
         ensemble_path=ensemble_path,
         zone_layer_mapping_file=zone_layer_mapping_file,
     )
+    stratigraphy = read_stratigraphy(
+        ensemble_path=ensemble_path,
+        stratigraphy_file=stratigraphy_file
+    )
+    print(stratigraphy)
     well_attributes = read_well_attributes(
         ensemble_path=ensemble_path,
         well_attributes_file=well_attributes_file,

--- a/webviz_subsurface/plugins/_well_completions.py
+++ b/webviz_subsurface/plugins/_well_completions.py
@@ -160,7 +160,7 @@ class WellCompletions(WebvizPluginABC):
         zone_layer_mapping_file: str = "rms/output/zone/simgrid_zone_layer_mapping.lyr",
         stratigraphy_file: str = "rms/output/zone/stratigraphy.json",
         well_attributes_file: str = "rms/output/wells/well_attributes.json",
-        kh_unit: str = "",
+        kh_unit: Optional[str] = None,
         kh_decimal_places: int = 2,
     ):
         # pylint: disable=too-many-arguments
@@ -299,7 +299,7 @@ def create_ensemble_dataset(
     stratigraphy_file: str,
     well_attributes_file: str,
     theme_colors: list,
-    kh_unit: str,
+    kh_unit: Optional[str],
     kh_decimal_places: int,
 ) -> io.BytesIO:
     # pylint: disable=too-many-arguments
@@ -322,7 +322,7 @@ def create_ensemble_dataset(
         ensemble_path=ensemble_path,
         well_attributes_file=well_attributes_file,
     )
-    if kh_unit == "":
+    if kh_unit is None:
         kh_unit, kh_decimal_places = get_kh_unit(ensemble_path=ensemble_path)
 
     time_steps = sorted(df.DATE.unique())

--- a/webviz_subsurface/plugins/_well_completions.py
+++ b/webviz_subsurface/plugins/_well_completions.py
@@ -68,9 +68,9 @@ class WellCompletions(WebvizPluginABC):
     **Stratigraphy file **
 
     `stratigraphy_file` file is intended to be generated per realizaiont by an internal \
-    RMS script as part of the FMU workflow. The stratigraphy is a tree structure, where each node \
-    has a name, an optional `color` parameter, and an optional `subzones` parameter which itself \
-    is a list of exactly the same format.
+    RMS script as part of the FMU workflow, but can also be set up manually. The stratigraphy \
+    is a tree structure, where each node has a name, an optional `color` parameter, and an \
+    optional `subzones` parameter which itself is a list of exactly the same format.
     ```json
     [
         {

--- a/webviz_subsurface/plugins/_well_completions.py
+++ b/webviz_subsurface/plugins/_well_completions.py
@@ -66,7 +66,50 @@ class WellCompletions(WebvizPluginABC):
 
     **Stratigraphy file **
 
-    Description of the stratigraphy file
+    `stratigraphy_file` file is intended to be generated per realizaiont by an internal \
+    RMS script as part of the FMU workflow. The stratigraphy is a tree structure, where each node \
+    has a name, and optional `color` parameter, and an optional `subzones` parameter which itself \
+    needs to be a list of exactly the same format.
+    ```json
+    [
+        {
+            "name": "ZoneA",
+            "color": "#FFFFFF",
+            "subzones": [
+                {
+                    "name": "ZoneA.1
+                },
+                {
+                    "name": "ZoneA.2
+                }
+            ]
+        },
+        {
+            "name": "ZoneB",
+            "color": "#FFF000",
+            "subzones": [
+                {
+                    "name": "ZoneB.1",
+                    "color": "#FFF111"
+                },
+                {
+                    "name": "ZoneB.2,
+                    "subzones: {"name": "ZoneB.2.2"}
+                }
+            ]
+        },
+    ]
+    ```
+    The stratigraphy file and the zone_layer_mapping will be combined to create the final \
+    stratigraphy. A node will be removed if the name or any of the subnode names are not \
+    present in the zone_layer_mapping. Any zones in zone_layer_mapping that are not present \
+    in the stratigraphy will be added to the end of the stratigraphy.
+
+    Colors can be supplied both trough the stratigraphy and through the zone_layer_mapping. \
+    The following prioritization will be applied:
+    1. Colors specified in the stratigraphy
+    2. Colors specified in the zone layer mapping lyr file
+    3. If none of the above is specified, theme colors will be added, but only to the leaves.
 
     **Well Attributes file**
 


### PR DESCRIPTION
The main change in this PR is the possibility to pass a json file with a stratigraphic tree to the plugin. The stratigraphy will be combined with the zone_layer mapping file (lyr-file) to generate the final stratigraphy that is passed to the wsc component.

There is also new logic around colors. Colors can be supplied through both the stratigraphy file and the lyr file. If colors is passed in both files, the stratigraphy has priority. If no colors is passed, the theme colors will be used. The parsing of the lyr files with colors is depending on new functionality in ecl2df.

There is a file with tests around the logic of the above.

There is also some new functionality around the kh units. If now kh unit is supplied, the plugin will look in the eclipse DATA file for the unit system, and choose the correct unit according to that.