### PR TITLE
Add missing `display: block` on selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ found in Eclipse files.
 in the new `StructuralUncertainty` plugin.
 
 ### Fixed
+- [#659](https://github.com/equinor/webviz-subsurface/pull/659) - Added missing `display: block` in option selectors (e.g. radio items).
 - [#621](https://github.com/equinor/webviz-subsurface/pull/621) - Fixed issue in `StructuralUncertainty` where map base layers did not load
 correctly from persisted user settings.
 - [#626](https://github.com/equinor/webviz-subsurface/pull/626) - Fixed small bugs in the docstring of `WellCompletions` and added a tour_steps method

--- a/webviz_subsurface/_assets/css/block_options.css
+++ b/webviz_subsurface/_assets/css/block_options.css
@@ -1,0 +1,3 @@
+.block-options > label, legend {
+  display: block;
+}

--- a/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
+++ b/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
@@ -12,9 +12,12 @@ from dash.dependencies import Input, Output
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC
 from webviz_config import WebvizSettings
+from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 import webviz_core_components as wcc
+
+import webviz_subsurface
 
 
 class AssistedHistoryMatchingAnalysis(WebvizPluginABC):
@@ -56,6 +59,13 @@ class AssistedHistoryMatchingAnalysis(WebvizPluginABC):
     ):
 
         super().__init__()
+
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent
+            / "_assets"
+            / "css"
+            / "block_options.css"
+        )
 
         self.input_dir = input_dir
         self.theme = webviz_settings.theme
@@ -99,6 +109,7 @@ class AssistedHistoryMatchingAnalysis(WebvizPluginABC):
                                 ),
                                 dcc.RadioItems(
                                     id=self.uuid("choice_id"),
+                                    className="block-options",
                                     options=[
                                         {
                                             "label": "One by one observation",

--- a/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
@@ -84,12 +84,13 @@ slow for large models.
         drop_constants: bool = True,
     ):
         super().__init__()
-        WEBVIZ_ASSETS.add(
-            pathlib.Path(webviz_subsurface.__file__).parent
-            / "_assets"
-            / "css"
-            / "container.css"
-        )
+        for filename in ["container.css", "block_options.css"]:
+            WEBVIZ_ASSETS.add(
+                pathlib.Path(webviz_subsurface.__file__).parent
+                / "_assets"
+                / "css"
+                / filename
+            )
         self.theme = webviz_settings.theme
         self.time_index = time_index
         self.column_keys = column_keys

--- a/webviz_subsurface/plugins/_parameter_analysis/views/selector_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/views/selector_view.py
@@ -125,10 +125,11 @@ def sortby_selector(
             ),
             dcc.RadioItems(
                 id=get_uuid("delta-sort"),
+                className="block-options",
                 options=[
                     {"label": "Name", "value": "Name"},
                     {
-                        "label": "StdDev",
+                        "label": "Standard deviation",
                         "value": "Stddev",
                     },
                     {
@@ -137,10 +138,6 @@ def sortby_selector(
                     },
                 ],
                 value=value,
-                labelStyle={
-                    "display": "inline-block",
-                    "margin-right": "5px",
-                },
                 persistence=True,
                 persistence_type="session",
             ),
@@ -154,6 +151,7 @@ def plot_options(get_uuid: Callable, tab: str) -> html.Div:
         children=[
             dcc.Checklist(
                 id={"id": get_uuid("checkbox-options"), "tab": tab},
+                className="block-options",
                 options=[
                     {"label": "Dateline visible", "value": "DateLine"},
                     {"label": "Auto compute correlations", "value": "AutoCompute"},

--- a/webviz_subsurface/plugins/_relative_permeability.py
+++ b/webviz_subsurface/plugins/_relative_permeability.py
@@ -9,10 +9,12 @@ import dash_core_components as dcc
 from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
 import webviz_core_components as wcc
+from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
 from webviz_config import WebvizPluginABC
 from webviz_config import WebvizSettings
 
+import webviz_subsurface
 from .._datainput.relative_permeability import load_satfunc, load_scal_recommendation
 from .._datainput.fmu_input import load_csv
 from .._utils.colors import hex_to_rgba
@@ -95,6 +97,14 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
     ):
 
         super().__init__()
+
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent
+            / "_assets"
+            / "css"
+            / "block_options.css"
+        )
+
         self.ens_paths = {
             ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
             for ens in ensembles
@@ -412,6 +422,7 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
                                 ),
                                 dcc.RadioItems(
                                     id=self.uuid("visualization"),
+                                    className="block-options",
                                     options=[
                                         {
                                             "label": "Individual realizations",
@@ -434,6 +445,7 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
                                 html.Span("Y-axis:", style={"font-weight": "bold"}),
                                 dcc.RadioItems(
                                     id=self.uuid("linlog"),
+                                    className="block-options",
                                     options=[
                                         {
                                             "label": "Linear",
@@ -445,7 +457,6 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
                                         },
                                     ],
                                     value="linear",
-                                    labelStyle={"display": "inline-block"},
                                     persistence=True,
                                     persistence_type="session",
                                 ),

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -16,9 +16,11 @@ import dash_core_components as dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizPluginABC, EncodedFile
 from webviz_config import WebvizSettings
+from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.webviz_store import webvizstore
 from webviz_config.common_cache import CACHE
 
+import webviz_subsurface
 from webviz_subsurface._models import EnsembleSetModel
 from webviz_subsurface._models import caching_ensemble_set_model_factory
 from .._abbreviations.reservoir_simulation import (
@@ -144,6 +146,13 @@ folder, to avoid risk of not extracting the right data.
     ):
 
         super().__init__()
+
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent
+            / "_assets"
+            / "css"
+            / "block_options.css"
+        )
 
         self.csvfile = csvfile
         self.obsfile = obsfile
@@ -347,9 +356,13 @@ folder, to avoid risk of not extracting the right data.
                     style={"display": show_delta},
                     children=html.Label(
                         children=[
-                            html.Span("Mode:", style={"font-weight": "bold"}),
+                            html.Span(
+                                "Mode:",
+                                style={"font-weight": "bold"},
+                            ),
                             dcc.RadioItems(
                                 id=self.uuid("mode"),
+                                className="block-options",
                                 style={"marginBottom": "25px"},
                                 options=[
                                     {
@@ -465,6 +478,7 @@ folder, to avoid risk of not extracting the right data.
                 html.Div(
                     dcc.RadioItems(
                         id=self.uuid("cum_interval"),
+                        className="block-options",
                         options=[
                             {
                                 "label": (f"{i.lower().capitalize()}"),
@@ -550,6 +564,7 @@ folder, to avoid risk of not extracting the right data.
                                 ),
                                 dcc.RadioItems(
                                     id=self.uuid("statistics"),
+                                    className="block-options",
                                     options=[
                                         {
                                             "label": "Individual realizations",
@@ -580,6 +595,7 @@ folder, to avoid risk of not extracting the right data.
                                 html.Summary("Options:", style={"font-weight": "bold"}),
                                 dcc.Checklist(
                                     id=self.uuid("trace_options"),
+                                    className="block-options",
                                     options=[
                                         {"label": val, "value": val}
                                         for val in ["History", "Histogram"]
@@ -597,6 +613,7 @@ folder, to avoid risk of not extracting the right data.
                                     children=[
                                         dcc.Checklist(
                                             id=self.uuid("stat_options"),
+                                            className="block-options",
                                             options=[
                                                 {"label": val, "value": val}
                                                 for val in [

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -16,12 +16,14 @@ import dash_core_components as dcc
 import webviz_core_components as wcc
 from dash.dependencies import Input, Output, State, ALL
 from dash.exceptions import PreventUpdate
+from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
 from webviz_config import WebvizPluginABC
 from webviz_config import WebvizConfigTheme
 from webviz_config import WebvizSettings
 
+import webviz_subsurface
 from webviz_subsurface._models import EnsembleSetModel
 from webviz_subsurface._models import caching_ensemble_set_model_factory
 from .._abbreviations.reservoir_simulation import (
@@ -130,6 +132,14 @@ folder, to avoid risk of not extracting the right data.
     ):
 
         super().__init__()
+
+        WEBVIZ_ASSETS.add(
+            Path(webviz_subsurface.__file__).parent
+            / "_assets"
+            / "css"
+            / "block_options.css"
+        )
+
         self.column_keys = column_keys
         self.time_index = sampling
         if self.time_index not in ("daily", "monthly", "yearly"):
@@ -450,6 +460,7 @@ folder, to avoid risk of not extracting the right data.
                                 ),
                                 dcc.RadioItems(
                                     id=self.selectors_id("timeseries_visualization"),
+                                    className="block-options",
                                     options=[
                                         {
                                             "label": "Individual realizations",


### PR DESCRIPTION
Add back missing `display: block` after https://github.com/equinor/webviz-config-equinor/pull/41.