### PR TITLE
`WellCompletion` history from summary data

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -73,10 +73,10 @@ jobs:
       env:
         # If you want the CI to (temporarily) run against your fork of the testdada,
         # change the value her from "equinor" to your username.
-        TESTDATA_REPO_OWNER: equinor
+        TESTDATA_REPO_OWNER: lindjoha
         # If you want the CI to (temporarily) run against another branch than master,
         # change the value her from "master" to the relevant branch name.
-        TESTDATA_REPO_BRANCH: master
+        TESTDATA_REPO_BRANCH: summary_parquet_to_testdata
       run: |
         git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/webviz-subsurface-testdata.git
         # Copy any clientside script to the test folder before running tests

--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -73,10 +73,10 @@ jobs:
       env:
         # If you want the CI to (temporarily) run against your fork of the testdada,
         # change the value her from "equinor" to your username.
-        TESTDATA_REPO_OWNER: lindjoha
+        TESTDATA_REPO_OWNER: equinor
         # If you want the CI to (temporarily) run against another branch than master,
         # change the value her from "master" to the relevant branch name.
-        TESTDATA_REPO_BRANCH: summary_parquet_to_testdata
+        TESTDATA_REPO_BRANCH: master
       run: |
         git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/webviz-subsurface-testdata.git
         # Copy any clientside script to the test folder before running tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#666](https://github.com/equinor/webviz-subsurface/pull/666) - Handle operations between surfaces with different topology in `SurfaceViewerFMU`
 - [#675](https://github.com/equinor/webviz-subsurface/pull/675) - Adjust minimum zoom level in surface plugins for visualization of large surfaces.
-- 
+
+### Added
+- [#662](https://github.com/equinor/webviz-subsurface/pull/662) - Added support in `WellCompletion` for connection history from summary data.
+
 ## [0.2.3] - 2021-06-07
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ TESTS_REQUIRE = [
     "selenium>=3.141",
     "types-pyyaml",
     "types-pkg-resources",
+    "ert"
 ]
 
 # pylint: disable=line-too-long

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ TESTS_REQUIRE = [
     "selenium>=3.141",
     "types-pyyaml",
     "types-pkg-resources",
-    "ert"
+    "ert",
 ]
 
 # pylint: disable=line-too-long

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "_abbreviations/abbreviation_data/*.json",
             "_assets/css/*.css",
             "_assets/js/*.js",
+            "ert_jobs/config_jobs/*",
         ]
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,11 @@ setup(
             "WellCrossSectionFMU = webviz_subsurface.plugins:WellCrossSectionFMU",
             "AssistedHistoryMatchingAnalysis = webviz_subsurface.plugins:AssistedHistoryMatchingAnalysis",
             "WellCompletions = webviz_subsurface.plugins:WellCompletions",
-        ]
+        ],
+        "ert": ["webviz_subsurface_jobs = webviz_subsurface.ert_jobs.jobs"],
+        "console_scripts": [
+            "export_connection_status=webviz_subsurface.ert_jobs.export_connection_status:main",
+        ],
     },
     install_requires=[
         "dash>=1.11",

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ TESTS_REQUIRE = [
     "bandit",
     "black>=21.4b0",
     "dash[testing]",
+    "ert",
     "mypy",
     "pylint",
     "pytest-xdist",
     "selenium>=3.141",
     "types-pyyaml",
     "types-pkg-resources",
-    "ert",
 ]
 
 # pylint: disable=line-too-long

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -1,4 +1,4 @@
-import subprocess
+import subprocess  # nosec
 from pathlib import Path
 
 

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -12,7 +12,7 @@ QUEUE_OPTION   LSF MAX_RUNNING 1\n
 QUEUE_SYSTEM LOCAL\n
 FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)\n
 """
-    ert_config_file = tmp_path / "ert" / "config.ert"
+    ert_config_file = tmp_path / "config.ert"
     with open(ert_config_file, "w") as file:
         file.write(ert_config)
 

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -1,15 +1,6 @@
 import subprocess
 from pathlib import Path
 
-# ERT_CONFIG = """
-# ECLBASE     something
-# RUNPATH     /private/olind/webviz/webviz-subsurface-testdata/reek_history_match/realization-0/iter-0/
-# NUM_REALIZATIONS    1
-# QUEUE_OPTION   LSF MAX_RUNNING 1
-# QUEUE_SYSTEM LOCAL
-# FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)
-# """
-
 
 def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None:
 

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -6,25 +6,36 @@ import pandas as pd
 
 def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None:
 
-    runpath = f"{testdata_folder}/reek_history_match/realization-0/iter-0"
+    runpath = tmp_path / Path("output")
+    ert_config_file = tmp_path / "config.ert"
+
+    input_file = (
+        testdata_folder
+        / "reek_history_match"
+        / "realization-0"
+        / "iter-0"
+        / "share"
+        / "results"
+        / "tables"
+        / "summary.parquet"
+    ).resolve()
+    assert input_file.exists()
+
+    output_file = runpath / "output.parquet"
+
     ert_config = f"""
-ECLBASE     something\n
-RUNPATH     {runpath}\n
-NUM_REALIZATIONS    1\n
-QUEUE_OPTION   LSF MAX_RUNNING 1\n
-QUEUE_SYSTEM LOCAL\n
-FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)\n
+ECLBASE          something
+RUNPATH          {runpath}
+NUM_REALIZATIONS 1
+QUEUE_OPTION     LSF MAX_RUNNING 1
+QUEUE_SYSTEM     LOCAL
+FORWARD_MODEL    EXPORT_CONNECTION_STATUS(<INPUT>={input_file}, <OUTPUT>={output_file})
 """
 
-    ert_config_file = tmp_path / "config.ert"
-    with open(ert_config_file, "w") as file:
-        file.write(ert_config)
+    ert_config_file.write_text(ert_config)
 
-    subprocess.check_output(  # nosec
-        ["ert", "test_run", ert_config_file], stderr=subprocess.STDOUT
-    )
+    subprocess.check_output(["ert", "test_run", ert_config_file], cwd=tmp_path)  # nosec
 
-    output_file = Path(f"{runpath}/output.parquet")
     assert output_file.exists()
 
     df = pd.read_parquet(output_file)

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -1,19 +1,29 @@
 import subprocess  # nosec
 from pathlib import Path
 
+import pandas as pd
+
 
 def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None:
 
+    runpath = f"{testdata_folder}/reek_history_match/realization-0/iter-0/"
     ert_config = f"""
 ECLBASE     something\n
-RUNPATH     {testdata_folder}/reek_history_match/realization-0/iter-0/\n
+RUNPATH     {runpath}\n
 NUM_REALIZATIONS    1\n
 QUEUE_OPTION   LSF MAX_RUNNING 1\n
 QUEUE_SYSTEM LOCAL\n
 FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)\n
 """
+
     ert_config_file = tmp_path / "config.ert"
     with open(ert_config_file, "w") as file:
         file.write(ert_config)
 
     subprocess.call(["ert", "test_run", ert_config_file])  # nosec
+
+    output_file = Path(f"{runpath}output.parquet")
+    assert output_file.exists()
+
+    df = pd.read_parquet(output_file)
+    assert list(df.columns) == ["DATE", "WELL", "I", "J", "K", "OP/SH"]

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -14,16 +14,16 @@ def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None
         / "reek_history_match"
         / "realization-0"
         / "iter-0"
-        / "share"
-        / "results"
-        / "tables"
-        / "summary.parquet"
+        / "eclipse"
+        / "model"
+        / "5_R001_REEK-0.UNSMRY"
     ).resolve()
     assert input_file.exists()
 
     output_file = runpath / "output.parquet"
 
-    ert_config = f"""
+    ert_config_file.write_text(
+        f"""
 ECLBASE          something
 RUNPATH          {runpath}
 NUM_REALIZATIONS 1
@@ -31,8 +31,7 @@ QUEUE_OPTION     LSF MAX_RUNNING 1
 QUEUE_SYSTEM     LOCAL
 FORWARD_MODEL    EXPORT_CONNECTION_STATUS(<INPUT>={input_file}, <OUTPUT>={output_file})
 """
-
-    ert_config_file.write_text(ert_config)
+    )
 
     subprocess.check_output(["ert", "test_run", ert_config_file], cwd=tmp_path)  # nosec
 

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -1,24 +1,29 @@
 import subprocess
 from pathlib import Path
 
-ERT_CONFIG = """
-DEFINE <USER>              test
-DEFINE <SCRATCH>           webviz/webviz-subsurface-testdata/reek_history_match
-DEFINE <CASE_DIR>          reek_history_match
-RUNPATH     <SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-0/
+# ERT_CONFIG = """
+# ECLBASE     something
+# RUNPATH     /private/olind/webviz/webviz-subsurface-testdata/reek_history_match/realization-0/iter-0/
+# NUM_REALIZATIONS    1
+# QUEUE_OPTION   LSF MAX_RUNNING 1
+# QUEUE_SYSTEM LOCAL
+# FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)
+# """
 
-NUM_REALIZATIONS    1
---MAX_RUNTIME         18000
---MIN_REALIZATIONS    1
---MAX_SUBMIT          1
-QUEUE_SYSTEM LOCAL
+def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None:
 
-FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)
-
+    ert_config = f"""
+ECLBASE     something\n
+RUNPATH     {testdata_folder}/reek_history_match/realization-0/iter-0/\n
+NUM_REALIZATIONS    1\n
+QUEUE_OPTION   LSF MAX_RUNNING 1\n
+QUEUE_SYSTEM LOCAL\n
+FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)\n
 """
+    ert_config_file = tmp_path / "ert" / "config.ert"
+    with open(ert_config_file, "w") as file:
+        file.write(ert_config)
 
-def test_export_connection_status(testdata_folder: Path) -> None:
     subprocess.call(  # nosec
-        ["ert", "test_run", "config.ert"],
-        cwd=testdata_folder / "webviz_examples",
+        ["ert", "test_run", ert_config_file]
     )

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -1,0 +1,24 @@
+import subprocess
+from pathlib import Path
+
+ERT_CONFIG = """
+DEFINE <USER>              test
+DEFINE <SCRATCH>           webviz/webviz-subsurface-testdata/reek_history_match
+DEFINE <CASE_DIR>          reek_history_match
+RUNPATH     <SCRATCH>/<USER>/<CASE_DIR>/realization-%d/iter-0/
+
+NUM_REALIZATIONS    1
+--MAX_RUNTIME         18000
+--MIN_REALIZATIONS    1
+--MAX_SUBMIT          1
+QUEUE_SYSTEM LOCAL
+
+FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)
+
+"""
+
+def test_export_connection_status(testdata_folder: Path) -> None:
+    subprocess.call(  # nosec
+        ["ert", "test_run", "config.ert"],
+        cwd=testdata_folder / "webviz_examples",
+    )

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -20,7 +20,7 @@ FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parq
     with open(ert_config_file, "w") as file:
         file.write(ert_config)
 
-    subprocess.check_output( # nosec
+    subprocess.check_output(  # nosec
         ["ert", "test_run", ert_config_file], stderr=subprocess.STDOUT
     )
 

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None:
 
-    runpath = f"{testdata_folder}/reek_history_match/realization-0/iter-0/"
+    runpath = f"{testdata_folder}/reek_history_match/realization-0/iter-0"
     ert_config = f"""
 ECLBASE     something\n
 RUNPATH     {runpath}\n
@@ -20,9 +20,11 @@ FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parq
     with open(ert_config_file, "w") as file:
         file.write(ert_config)
 
-    subprocess.call(["ert", "test_run", ert_config_file])  # nosec
+    subprocess.check_output(
+        ["ert", "test_run", ert_config_file], stderr=subprocess.STDOUT
+    )  # nosec
 
-    output_file = Path(f"{runpath}output.parquet")
+    output_file = Path(f"{runpath}/output.parquet")
     assert output_file.exists()
 
     df = pd.read_parquet(output_file)

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -10,6 +10,7 @@ from pathlib import Path
 # FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=output.parquet)
 # """
 
+
 def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None:
 
     ert_config = f"""
@@ -24,6 +25,4 @@ FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parq
     with open(ert_config_file, "w") as file:
         file.write(ert_config)
 
-    subprocess.call(  # nosec
-        ["ert", "test_run", ert_config_file]
-    )
+    subprocess.call(["ert", "test_run", ert_config_file])  # nosec

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -20,9 +20,9 @@ FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parq
     with open(ert_config_file, "w") as file:
         file.write(ert_config)
 
-    subprocess.check_output(
+    subprocess.check_output( # nosec
         ["ert", "test_run", ert_config_file], stderr=subprocess.STDOUT
-    )  # nosec
+    )
 
     output_file = Path(f"{runpath}/output.parquet")
     assert output_file.exists()

--- a/tests/unit_tests/plugin_tests/test_well_completions.py
+++ b/tests/unit_tests/plugin_tests/test_well_completions.py
@@ -153,8 +153,6 @@ def test_merge_compdat_and_connstatus():
         }
     )
     df_result = merge_compdat_and_connstatus(df_compdat, df_connstatus)
-    print(df_output)
-    print(df_result)
     assert_frame_equal(
         df_result, df_output, check_like=True
     )  # Ignore order of rows and columns

--- a/tests/unit_tests/plugin_tests/test_well_completions.py
+++ b/tests/unit_tests/plugin_tests/test_well_completions.py
@@ -2,7 +2,10 @@ import pytest
 import pandas as pd
 from pandas._testing import assert_frame_equal
 
-from webviz_subsurface.plugins._well_completions import extract_stratigraphy, merge_compdat_and_connstatus
+from webviz_subsurface.plugins._well_completions import (
+    extract_stratigraphy,
+    merge_compdat_and_connstatus,
+)
 from webviz_subsurface._datainput.well_completions import remove_invalid_colors
 
 
@@ -92,6 +95,7 @@ def test_extract_stratigraphy_errors():
     with pytest.raises(ValueError):
         extract_stratigraphy(layer_zone_mapping, stratigraphy, {}, [])
 
+
 def test_merge_compdat_and_connstatus():
     """Tests the functionality of the merge_compdat_and_connstatus function.
 
@@ -104,34 +108,42 @@ def test_merge_compdat_and_connstatus():
     in df_connstatus, but not REAL 1. We don't mix compdat and connstatus data
     for the same well
     """
-    df_compdat = pd.DataFrame(data={
-        "DATE": ["2021-01-01", "2021-05-01", "2021-01-01", "2021-01-01"],
-        "REAL": [0, 0, 0, 1],
-        "WELL": ["A1", "A1", "A2", "A1"],
-        "I": [1, 1, 1, 1],
-        "J": [1, 1, 1, 1],
-        "K1": [1, 1, 1, 1],
-        "OP/SH": ["SHUT", "OPEN", "OPEN", "OPEN"],
-        "KH": [100, 100, 10, 100]
-    })
-    df_connstatus = pd.DataFrame(data={
-        "DATE": ["2021-03-01", "2021-08-01"],
-        "REAL": [0, 0],
-        "WELL": ["A1", "A1"],
-        "I": [1,1],
-        "J": [1,1],
-        "K1": [1,1],
-        "OP/SH": ["OPEN", "SHUT"],
-    })
-    df_output = pd.DataFrame(data={
-        "DATE": ["2021-03-01", "2021-08-01", "2021-01-01"],
-        "REAL": [0, 0, 0],
-        "WELL": ["A1", "A1", "A2"],
-        "I": [1, 1, 1],
-        "J": [1, 1, 1],
-        "K1": [1, 1, 1],
-        "OP/SH": ["OPEN", "SHUT", "OPEN"],
-        "KH": [100, 100, 10]
-    })
+    df_compdat = pd.DataFrame(
+        data={
+            "DATE": ["2021-01-01", "2021-05-01", "2021-01-01", "2021-01-01"],
+            "REAL": [0, 0, 0, 1],
+            "WELL": ["A1", "A1", "A2", "A1"],
+            "I": [1, 1, 1, 1],
+            "J": [1, 1, 1, 1],
+            "K1": [1, 1, 1, 1],
+            "OP/SH": ["SHUT", "OPEN", "OPEN", "OPEN"],
+            "KH": [100, 100, 10, 100],
+        }
+    )
+    df_connstatus = pd.DataFrame(
+        data={
+            "DATE": ["2021-03-01", "2021-08-01"],
+            "REAL": [0, 0],
+            "WELL": ["A1", "A1"],
+            "I": [1, 1],
+            "J": [1, 1],
+            "K1": [1, 1],
+            "OP/SH": ["OPEN", "SHUT"],
+        }
+    )
+    df_output = pd.DataFrame(
+        data={
+            "DATE": ["2021-03-01", "2021-08-01", "2021-01-01"],
+            "REAL": [0, 0, 0],
+            "WELL": ["A1", "A1", "A2"],
+            "I": [1, 1, 1],
+            "J": [1, 1, 1],
+            "K1": [1, 1, 1],
+            "OP/SH": ["OPEN", "SHUT", "OPEN"],
+            "KH": [100, 100, 10],
+        }
+    )
     df_result = merge_compdat_and_connstatus(df_compdat, df_connstatus)
-    assert_frame_equal(df_result, df_output, check_like=True) #Ignore order of rows and columns
+    assert_frame_equal(
+        df_result, df_output, check_like=True
+    )  # Ignore order of rows and columns

--- a/tests/unit_tests/plugin_tests/test_well_completions.py
+++ b/tests/unit_tests/plugin_tests/test_well_completions.py
@@ -1,5 +1,6 @@
 import pytest
 import pandas as pd
+import numpy as np
 from pandas._testing import assert_frame_equal
 
 from webviz_subsurface.plugins._well_completions import (
@@ -100,50 +101,60 @@ def test_merge_compdat_and_connstatus():
     """Tests the functionality of the merge_compdat_and_connstatus function.
 
     The following functionality is covered:
-    - The two first rows of df_compdat is replaced with the two first from
-    df_connstatus, except for the KH (which is only available in df_compdat)
-    - The A2 well is not available in df_connstatus and will be taken as is
+    * The two first rows of df_compdat is replaced with the two first from
+    df_connstatus, except for the KH (which is only available in df_compdat).
+    KH is taken from the first of the two compdat rows
+    * The A2 well is not available in df_connstatus and will be taken as is
     from df_compdat
-    - the last row in df_compdat (WELL: A1, REAL:1) is ignored because A1 is
+    * the fourth row in df_compdat (WELL: A1, REAL:1) is ignored because A1 is
     in df_connstatus, but not REAL 1. We don't mix compdat and connstatus data
     for the same well
+    * The fourth row in df_compdat has KH=Nan. This will be 0 in the output
     """
     df_compdat = pd.DataFrame(
         data={
-            "DATE": ["2021-01-01", "2021-05-01", "2021-01-01", "2021-01-01"],
-            "REAL": [0, 0, 0, 1],
-            "WELL": ["A1", "A1", "A2", "A1"],
-            "I": [1, 1, 1, 1],
-            "J": [1, 1, 1, 1],
-            "K1": [1, 1, 1, 1],
-            "OP/SH": ["SHUT", "OPEN", "OPEN", "OPEN"],
-            "KH": [100, 100, 10, 100],
+            "DATE": [
+                "2021-01-01",
+                "2021-05-01",
+                "2021-01-01",
+                "2021-01-01",
+                "2022-01-01",
+            ],
+            "REAL": [0, 0, 0, 1, 0],
+            "WELL": ["A1", "A1", "A2", "A1", "A3"],
+            "I": [1, 1, 1, 1, 1],
+            "J": [1, 1, 1, 1, 1],
+            "K1": [1, 1, 1, 1, 1],
+            "OP/SH": ["SHUT", "OPEN", "OPEN", "OPEN", "OPEN"],
+            "KH": [100, 1000, 10, 100, np.nan],
         }
     )
     df_connstatus = pd.DataFrame(
         data={
-            "DATE": ["2021-03-01", "2021-08-01"],
-            "REAL": [0, 0],
-            "WELL": ["A1", "A1"],
-            "I": [1, 1],
-            "J": [1, 1],
-            "K1": [1, 1],
-            "OP/SH": ["OPEN", "SHUT"],
-        }
-    )
-    df_output = pd.DataFrame(
-        data={
             "DATE": ["2021-03-01", "2021-08-01", "2021-01-01"],
             "REAL": [0, 0, 0],
-            "WELL": ["A1", "A1", "A2"],
+            "WELL": ["A1", "A1", "A3"],
             "I": [1, 1, 1],
             "J": [1, 1, 1],
             "K1": [1, 1, 1],
             "OP/SH": ["OPEN", "SHUT", "OPEN"],
-            "KH": [100, 100, 10],
+        }
+    )
+    df_output = pd.DataFrame(
+        data={
+            "DATE": ["2021-03-01", "2021-08-01", "2021-01-01", "2021-01-01"],
+            "REAL": [0, 0, 0, 0],
+            "WELL": ["A1", "A1", "A3", "A2"],
+            "I": [1, 1, 1, 1],
+            "J": [1, 1, 1, 1],
+            "K1": [1, 1, 1, 1],
+            "OP/SH": ["OPEN", "SHUT", "OPEN", "OPEN"],
+            "KH": [100.0, 100.0, 0.0, 10.0],
         }
     )
     df_result = merge_compdat_and_connstatus(df_compdat, df_connstatus)
+    print(df_output)
+    print(df_result)
     assert_frame_equal(
         df_result, df_output, check_like=True
     )  # Ignore order of rows and columns

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -123,8 +123,8 @@ def get_ecl_unit_system(ensemble_path: str) -> Optional[str]:
 
 
 def get_real_from_filename(filename: str) -> int:
-    """
-    Description
+    """Reads the realization number from the filepath. This will work
+    if one of the parent folders for the file is on the
     """
     for item in filename.split("/"):
         if item.startswith("realization-"):
@@ -135,8 +135,13 @@ def read_connection_status(
     ensemble_path: str,
     connection_status_file: str
 ) -> Optional[pd.DataFrame]:
-    """
-    Description
+    """Reads parquet file with connection status data from the scratch disk.
+    Merges together files from all realizations, does some fixing of the column
+    data types, and returns it as a pandas dataframe.
+
+    The connection status data is extracted from the CPI data, which is 0 if the
+    connection is SHUT and >0 if the connection is OPEN. This is independent of
+    the status of the well.
     """
     files = glob.glob(f"{ensemble_path}/{connection_status_file}")
     if not files:
@@ -150,6 +155,7 @@ def read_connection_status(
         df = pd.concat([df, df_real])
     df.I = pd.to_numeric(df.I)
     df.J = pd.to_numeric(df.J)
-    df.K = pd.to_numeric(df.K)
+    df["K1"] = pd.to_numeric(df.K)
+    df = df.drop(["K"], axis=1)
     df.DATE = pd.to_datetime(df.DATE).dt.date
     return df

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -131,9 +131,9 @@ def get_real_from_filename(filename: str) -> int:
             return int(item.split("-")[1])
     raise ValueError(f"Realization number not found for {filename}")
 
+
 def read_connection_status(
-    ensemble_path: str,
-    connection_status_file: str
+    ensemble_path: str, connection_status_file: str
 ) -> Optional[pd.DataFrame]:
     """Reads parquet file with connection status data from the scratch disk.
     Merges together files from all realizations, does some fixing of the column

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -148,7 +148,7 @@ def read_connection_status(
         return None
 
     df = pd.DataFrame()
-    for filename in glob.glob(f"{ensemble_path}/{connection_status_file}"):
+    for filename in files:
         df_real = pd.read_parquet(filename)
         real = get_real_from_filename(filename)
         df_real["REAL"] = real

--- a/webviz_subsurface/ert_jobs/config_jobs/EXPORT_CONNECTION_STATUS
+++ b/webviz_subsurface/ert_jobs/config_jobs/EXPORT_CONNECTION_STATUS
@@ -1,0 +1,5 @@
+EXECUTABLE export_connection_status
+
+ARGLIST "--input" <INPUT> --output <OUTPUT>
+
+MIN_ARG 2

--- a/webviz_subsurface/ert_jobs/config_jobs/EXPORT_CONNECTION_STATUS
+++ b/webviz_subsurface/ert_jobs/config_jobs/EXPORT_CONNECTION_STATUS
@@ -1,5 +1,5 @@
 EXECUTABLE export_connection_status
 
-ARGLIST -i <INPUT> -o <OUTPUT>
+ARGLIST <INPUT> <OUTPUT>
 
 MIN_ARG 2

--- a/webviz_subsurface/ert_jobs/config_jobs/EXPORT_CONNECTION_STATUS
+++ b/webviz_subsurface/ert_jobs/config_jobs/EXPORT_CONNECTION_STATUS
@@ -1,5 +1,5 @@
 EXECUTABLE export_connection_status
 
-ARGLIST "--input" <INPUT> --output <OUTPUT>
+ARGLIST -i <INPUT> -o <OUTPUT>
 
 MIN_ARG 2

--- a/webviz_subsurface/ert_jobs/export_connection_status.py
+++ b/webviz_subsurface/ert_jobs/export_connection_status.py
@@ -19,7 +19,7 @@ Export connection status data on sparse form from CPI summary data.
 """
 
 
-def get_parser() -> argparse.ArgumentParser:
+def _get_parser() -> argparse.ArgumentParser:
     """Setup parser for command line options"""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -40,7 +40,7 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_status_changes(df_conn: pd.DataFrame, cpi_column: str) -> List[Tuple[Any, str]]:
+def _get_status_changes(df_conn: pd.DataFrame, cpi_column: str) -> List[Tuple[Any, str]]:
     """Extracts the status history of a single connection as a list of tuples
     on the form (date, status)
     """
@@ -56,7 +56,7 @@ def get_status_changes(df_conn: pd.DataFrame, cpi_column: str) -> List[Tuple[Any
     return status_changes
 
 
-def extract_connection_status(filename: str) -> pd.DataFrame:
+def _extract_connection_status(filename: str) -> pd.DataFrame:
     """Exctracts connection status history for each compdat connection that
     is included in the summary data on the form CPI:WELL,I,J,K.
 
@@ -82,7 +82,7 @@ def extract_connection_status(filename: str) -> pd.DataFrame:
         coord = colsplit[2].split(",")
         i, j, k = coord[0], coord[1], coord[2]
 
-        status_changes = get_status_changes(smry[["DATE", col]], col)
+        status_changes = _get_status_changes(smry[["DATE", col]], col)
         for date, status in status_changes:
             df.loc[df.shape[0]] = [date, well, i, j, k, status]
 
@@ -91,10 +91,10 @@ def extract_connection_status(filename: str) -> pd.DataFrame:
 
 def main() -> None:
     """Entry point from command line"""
-    parser = get_parser()
+    parser = _get_parser()
     args = parser.parse_args()
 
-    df = extract_connection_status(args.input)
+    df = _extract_connection_status(args.input)
     df.to_parquet(args.output, index=False)
 
 

--- a/webviz_subsurface/ert_jobs/export_connection_status.py
+++ b/webviz_subsurface/ert_jobs/export_connection_status.py
@@ -40,7 +40,9 @@ def _get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _get_status_changes(df_conn: pd.DataFrame, cpi_column: str) -> List[Tuple[Any, str]]:
+def _get_status_changes(
+    df_conn: pd.DataFrame, cpi_column: str
+) -> List[Tuple[Any, str]]:
     """Extracts the status history of a single connection as a list of tuples
     on the form (date, status)
     """

--- a/webviz_subsurface/ert_jobs/export_connection_status.py
+++ b/webviz_subsurface/ert_jobs/export_connection_status.py
@@ -15,10 +15,10 @@ from pathlib import Path
 
 import pandas as pd
 
-DESCRIPTION = """
+DESCRIPTION: str = """
 Export connection status data on sparse form from CPI summary data.
 """
-CATEGORY = "utility.eclipse"
+CATEGORY: str = "utility.eclipse"
 EXAMPLES: str = """
 Extracts connection status history from summary parquet file by running
 this in the ert workflow:

--- a/webviz_subsurface/ert_jobs/export_connection_status.py
+++ b/webviz_subsurface/ert_jobs/export_connection_status.py
@@ -40,7 +40,7 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def get_status_changes(df_conn: pd.DataFrame, cpi_column: str) -> list:
+def get_status_changes(df_conn: pd.DataFrame, cpi_column: str) -> List[Tuple[Any, str]]:
     """Extracts the status history of a single connection as a list of tuples
     on the form (date, status)
     """

--- a/webviz_subsurface/ert_jobs/export_connection_status.py
+++ b/webviz_subsurface/ert_jobs/export_connection_status.py
@@ -11,6 +11,7 @@ The output data set is very sparse compared to the CPI summary data.
 import argparse
 import re
 from typing import List, Tuple, Any
+from pathlib import Path
 
 import pandas as pd
 
@@ -28,14 +29,16 @@ def _get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-i",
         "--input",
+        type=Path,
         help="Input file",
-        default="share/results/tables/summary.parquet",
+        default=Path("share/results/tables") / "summary.parquet",
     )
     parser.add_argument(
         "-o",
         "--output",
+        type=Path,
         help="Output file",
-        default="share/results/tables/connection_status.parquet",
+        default=Path("share/results/tables") / "connection_status.parquet",
     )
     return parser
 

--- a/webviz_subsurface/ert_jobs/export_connection_status.py
+++ b/webviz_subsurface/ert_jobs/export_connection_status.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Exctracts connection status history for each compdat connection that
+is included in the summary data on the form CPI:WELL,I,J,K. One line is
+added to the export every time a connection changes status. It is OPEN when
+CPI>0 and SHUT when CPI=0. The earliest date for any connection will be OPEN,
+i.e a cell can not be SHUT before it has been OPEN. This means that any cells
+that are always SHUT will be excluded.
+
+The output data set is very sparse compared to the CPI summary data.
+"""
+import argparse
+import re
+from typing import List, Tuple, Any
+
+import pandas as pd
+
+DESCRIPTION = """
+Export connection status data on sparse form from CPI summary data.
+"""
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Setup parser for command line options"""
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=DESCRIPTION,
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        help="Input file",
+        default="share/results/tables/summary.parquet",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file",
+        default="share/results/tables/connection_status.parquet",
+    )
+    return parser
+
+
+def get_status_changes(df_conn: pd.DataFrame, cpi_column: str) -> list:
+    """Extracts the status history of a single connection as a list of tuples
+    on the form (date, status)
+    """
+    status_changes = []
+    prev_value = 0
+    for _, row in df_conn.sort_values(by="DATE").iterrows():
+        value = row[cpi_column]
+        if value > 0 and prev_value == 0:
+            status_changes.append((row.DATE, "OPEN"))
+        elif prev_value > 0 and value == 0:
+            status_changes.append((row.DATE, "SHUT"))
+        prev_value = value
+    return status_changes
+
+
+def extract_connection_status(filename: str) -> pd.DataFrame:
+    """Exctracts connection status history for each compdat connection that
+    is included in the summary data on the form CPI:WELL,I,J,K.
+
+    From the CPI time series it is possible to extract the status of the connection
+    because it is 0 when the connection is SHUT and >0 when the connection is open.
+
+    The output from this function is one row for every time a connection changes
+    status. The earliest date for any connection will be OPEN, i.e a cell can not
+    be SHUT before it has been OPEN. This means that any cells that are always SHUT
+    will not be included in the export.
+    """
+    smry = pd.read_parquet(filename)
+    cpi_columns = [
+        col
+        for col in smry.columns
+        if re.match("^CPI:[A-Z0-9_-]{1,8}:[0-9]+,[0-9]+,[0-9]+$", col)
+    ]
+    df = pd.DataFrame(columns=["DATE", "WELL", "I", "J", "K", "OP/SH"])
+
+    for col in cpi_columns:
+        colsplit = col.split(":")
+        well = colsplit[1]
+        coord = colsplit[2].split(",")
+        i, j, k = coord[0], coord[1], coord[2]
+
+        status_changes = get_status_changes(smry[["DATE", col]], col)
+        for date, status in status_changes:
+            df.loc[df.shape[0]] = [date, well, i, j, k, status]
+
+    return df
+
+
+def main() -> None:
+    """Entry point from command line"""
+    parser = get_parser()
+    args = parser.parse_args()
+
+    df = extract_connection_status(args.input)
+    df.to_parquet(args.output, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/webviz_subsurface/ert_jobs/export_connection_status.py
+++ b/webviz_subsurface/ert_jobs/export_connection_status.py
@@ -18,6 +18,14 @@ import pandas as pd
 DESCRIPTION = """
 Export connection status data on sparse form from CPI summary data.
 """
+CATEGORY = "utility.eclipse"
+EXAMPLES: str = """
+Extracts connection status history from summary parquet file by running
+this in the ert workflow:
+
+    FORWARD_MODEL EXPORT_CONNECTION_STATUS(<INPUT>=share/results/tables/summary.parquet, <OUTPUT>=share/results/tables/connection_status.parquet)
+
+"""  # noqa
 
 
 def _get_parser() -> argparse.ArgumentParser:

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -26,10 +26,8 @@ except ModuleNotFoundError:
         return decorator
 
 
-@hook_implementation
-@plugin_response(
-    plugin_name="webviz-subsurface"
-)  # pylint: disable=no-value-for-parameter
+@hook_implementation  # pylint: disable=no-value-for-parameter
+@plugin_response(plugin_name="webviz-subsurface")
 def installable_jobs() -> dict:
     resource_directory = Path(
         resource_filename("webviz_subsurface", "ert_jobs/config_jobs")

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -1,20 +1,25 @@
+from typing import Callable
 from pathlib import Path
 from pkg_resources import resource_filename
 
 try:
     from ert_shared.plugins.plugin_manager import (
         hook_implementation,
-    )  # pylint: disable=import-error
+    )
+    # pylint: disable=import-error
     from ert_shared.plugins.plugin_response import (
         plugin_response,
-    )  # pylint: disable=import-error
+    )
+    # pylint: disable=import-error
 except ModuleNotFoundError:
     # ert is not installed - use dummy/transparent function decorators.
-    def hook_implementation(func):
+    def hook_implementation(func: Callable) -> Callable:
         return func
 
-    def plugin_response(plugin_name):  # pylint: disable=unused-argument
-        def decorator(func):
+    def plugin_response(
+        plugin_name: str,
+    ) -> Callable:  # pylint: disable=unused-argument
+        def decorator(func: Callable) -> Callable:
             return func
 
         return decorator
@@ -22,7 +27,7 @@ except ModuleNotFoundError:
 
 @hook_implementation
 @plugin_response(plugin_name="webviz-subsurface")
-def installable_jobs():
+def installable_jobs() -> dict:
     resource_directory = Path(
         resource_filename("webviz_subsurface", "ert_jobs/config_jobs")
     )

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -5,14 +5,11 @@ from pkg_resources import resource_filename
 try:
     from ert_shared.plugins.plugin_manager import (
         hook_implementation,
-    )
+    )  # pylint: disable=import-error
 
-    # pylint: disable=import-error
     from ert_shared.plugins.plugin_response import (
         plugin_response,
-    )
-
-    # pylint: disable=import-error
+    )  # pylint: disable=import-error
 except ModuleNotFoundError:
     # ert is not installed - use dummy/transparent function decorators.
     def hook_implementation(func: Callable) -> Callable:
@@ -20,7 +17,8 @@ except ModuleNotFoundError:
 
     def plugin_response(
         plugin_name: str,
-    ) -> Callable:  # pylint: disable=unused-argument
+    ) -> Callable:
+        # pylint: disable=unused-argument
         def decorator(func: Callable) -> Callable:
             return func
 
@@ -30,6 +28,7 @@ except ModuleNotFoundError:
 @hook_implementation
 @plugin_response(plugin_name="webviz-subsurface")
 def installable_jobs() -> dict:
+    # pylint: disable=no-value-for-parameter
     resource_directory = Path(
         resource_filename("webviz_subsurface", "ert_jobs/config_jobs")
     )

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -6,10 +6,12 @@ try:
     from ert_shared.plugins.plugin_manager import (
         hook_implementation,
     )
+
     # pylint: disable=import-error
     from ert_shared.plugins.plugin_response import (
         plugin_response,
     )
+
     # pylint: disable=import-error
 except ModuleNotFoundError:
     # ert is not installed - use dummy/transparent function decorators.

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -52,7 +52,9 @@ def _get_module_variable_if_exists(
 
 
 @hook_implementation
-@plugin_response(plugin_name="webviz_subsurface")
+@plugin_response(  # pylint: disable=no-value-for-parameter
+    plugin_name="webviz-subsurface"
+)
 def job_documentation(job_name: str) -> Optional[dict]:
     webviz_subsurface_jobs = set(installable_jobs().keys())
     if job_name not in webviz_subsurface_jobs:

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -20,7 +20,6 @@ except ModuleNotFoundError:
         plugin_name: str,
     ) -> Callable:
         # pylint: disable=unused-argument
-        # pylint: disable=no-value-for-parameter
         def decorator(func: Callable) -> Callable:
             return func
 
@@ -28,9 +27,10 @@ except ModuleNotFoundError:
 
 
 @hook_implementation
-@plugin_response(plugin_name="webviz-subsurface")
+@plugin_response(
+    plugin_name="webviz-subsurface"
+)  # pylint: disable=no-value-for-parameter
 def installable_jobs() -> dict:
-    # pylint: disable=no-value-for-parameter
     resource_directory = Path(
         resource_filename("webviz_subsurface", "ert_jobs/config_jobs")
     )

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from pkg_resources import resource_filename
+
+try:
+    from ert_shared.plugins.plugin_manager import hook_implementation
+    from ert_shared.plugins.plugin_response import plugin_response
+except ModuleNotFoundError:
+    # ert is not installed - use dummy/transparent function decorators.
+    def hook_implementation(func):
+        return func
+
+    def plugin_response(plugin_name):  # pylint: disable=unused-argument
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+@hook_implementation
+@plugin_response(plugin_name="webviz-subsurface")
+def installable_jobs():
+    resource_directory = Path(
+        resource_filename("webviz_subsurface", "ert_jobs/config_jobs")
+    )
+    return {
+        "EXPORT_CONNECTION_STATUS": str(resource_directory / "EXPORT_CONNECTION_STATUS")
+    }

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from pkg_resources import resource_filename
 
 try:
-# pylint: disable=import-error
+    # pylint: disable=import-error
     from ert_shared.plugins.plugin_manager import (
         hook_implementation,
     )
@@ -20,6 +20,7 @@ except ModuleNotFoundError:
         plugin_name: str,
     ) -> Callable:
         # pylint: disable=unused-argument
+        # pylint: disable=no-value-for-parameter
         def decorator(func: Callable) -> Callable:
             return func
 

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -2,8 +2,12 @@ from pathlib import Path
 from pkg_resources import resource_filename
 
 try:
-    from ert_shared.plugins.plugin_manager import hook_implementation # pylint: disable=import-error
-    from ert_shared.plugins.plugin_response import plugin_response # pylint: disable=import-error
+    from ert_shared.plugins.plugin_manager import (
+        hook_implementation,
+    )  # pylint: disable=import-error
+    from ert_shared.plugins.plugin_response import (
+        plugin_response,
+    )  # pylint: disable=import-error
 except ModuleNotFoundError:
     # ert is not installed - use dummy/transparent function decorators.
     def hook_implementation(func):

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -26,8 +26,10 @@ except ModuleNotFoundError:
         return decorator
 
 
-@hook_implementation  # pylint: disable=no-value-for-parameter
-@plugin_response(plugin_name="webviz-subsurface")
+@hook_implementation
+@plugin_response(
+    plugin_name="webviz-subsurface"
+)  # pylint: disable=no-value-for-parameter
 def installable_jobs() -> dict:
     resource_directory = Path(
         resource_filename("webviz_subsurface", "ert_jobs/config_jobs")

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -27,9 +27,9 @@ except ModuleNotFoundError:
 
 
 @hook_implementation
-@plugin_response(
+@plugin_response(  # pylint: disable=no-value-for-parameter
     plugin_name="webviz-subsurface"
-)  # pylint: disable=no-value-for-parameter
+)
 def installable_jobs() -> dict:
     resource_directory = Path(
         resource_filename("webviz_subsurface", "ert_jobs/config_jobs")

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from pkg_resources import resource_filename
 
 try:
-    from ert_shared.plugins.plugin_manager import hook_implementation
-    from ert_shared.plugins.plugin_response import plugin_response
+    from ert_shared.plugins.plugin_manager import hook_implementation # pylint: disable=import-error
+    from ert_shared.plugins.plugin_response import plugin_response # pylint: disable=import-error
 except ModuleNotFoundError:
     # ert is not installed - use dummy/transparent function decorators.
     def hook_implementation(func):

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -3,13 +3,14 @@ from pathlib import Path
 from pkg_resources import resource_filename
 
 try:
+# pylint: disable=import-error
     from ert_shared.plugins.plugin_manager import (
         hook_implementation,
-    )  # pylint: disable=import-error
+    )
 
     from ert_shared.plugins.plugin_response import (
         plugin_response,
-    )  # pylint: disable=import-error
+    )
 except ModuleNotFoundError:
     # ert is not installed - use dummy/transparent function decorators.
     def hook_implementation(func: Callable) -> Callable:

--- a/webviz_subsurface/plugins/_well_completions.py
+++ b/webviz_subsurface/plugins/_well_completions.py
@@ -141,28 +141,28 @@ class WellCompletions(WebvizPluginABC):
     {
         "version" : "0.1",
         "wells" : [
-        {
-            "alias" : {
-                "eclipse" : "OP_1"
+            {
+                "alias" : {
+                    "eclipse" : "OP_1"
+                },
+                "attributes" : {
+                    "mlt_singlebranch" : "mlt",
+                    "structure" : "East",
+                    "welltype" : "producer"
+                },
+                "name" : "OP_1"
             },
-            "attributes" : {
-                "mlt_singlebranch" : "mlt",
-                "structure" : "East",
-                "welltype" : "producer"
+            {
+                "alias" : {
+                    "eclipse" : "GI_1"
+                },
+                "attributes" : {
+                    "mlt_singlebranch" : "singlebranch",
+                    "structure" : "West",
+                    "welltype" : "gas injector"
+                },
+                "name" : "GI_1"
             },
-            "name" : "OP_1"
-        },
-        {
-            "alias" : {
-                "eclipse" : "GI_1"
-            },
-            "attributes" : {
-                "mlt_singlebranch" : "singlebranch",
-                "structure" : "West",
-                "welltype" : "gas injector"
-            },
-            "name" : "GI_1"
-        },
         ]
     }
     ```

--- a/webviz_subsurface/plugins/_well_completions.py
+++ b/webviz_subsurface/plugins/_well_completions.py
@@ -66,8 +66,7 @@ class WellCompletions(WebvizPluginABC):
     This file can be exported from the ERT workflow by a forward model: `EXPORT_CONNECTION_STATUS`,
     which will be distributed somehow. This forward model uses the CPI summary data to create
     a connection status history: for each connection cell there is one line for each time the
-    connection is opened or closed. This data is very sparse compared to the CPI data. This export
-    has the logic that
+    connection is opened or closed. This data is very sparse compared to the CPI data.
 
     **Zone layer mapping**
 


### PR DESCRIPTION
This PR solves the problem of incomplete compdat OPEN/SHUT history coming from `ecl2df`. There is various problems with `ecl2df `exporting the connection history: it is not picking up lumps of connections being closed by WELOPEN and it could never pick up completions closed with ACTIONS. For history, all the information would be in the schedule file, and it could in theory be solved in ecl2df, but not for predictions with f.ex ACTIONS.

This PR allows the user to pass to the plugin a connection status table, exported by an ERT workflow (EXPORT_CONNECTION_STATUS) for each realization. This data is extracted from the CPI summary data. The data is stored in `.parquet` format and has the following columns: WELL, I, J, K, OP/SH (similar to the ecl2df compdat export: https://equinor.github.io/ecl2df/usage/compdat.html). For each connection, there is one line for every time the connection status changes. It can only be OPEN or SHUT.

If this data is not passed to the plugin, the connection history is taken from the compdat export as before. So it's also possible to improve the compdat export from `ecl2df `and use that  (should be sufficient for history runs).