### PR TITLE
Fix CI deploy from forks

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -88,6 +88,7 @@ jobs:
     - name: 🐳 Build Docker example image
       run: |
         pip install webviz-config-equinor
+        export SOURCE_URL_WEBVIZ_SUBSURFACE=https://github.com/$GITHUB_REPOSITORY
         export GIT_POINTER_WEBVIZ_SUBSURFACE=$GITHUB_REF
         webviz build ./webviz-subsurface-testdata/webviz_examples/webviz-full-demo.yml --portable ./example_subsurface_app --theme equinor
         rm -rf ./webviz-subsurface-testdata


### PR DESCRIPTION
The CI Docker build works for `upstream` CI since the `Source_URL` in `setup.py` corresponds to that repository https://github.com/equinor/webviz-subsurface/blob/36cd2f5535888d84fc45e394c56ab3b31473f662/setup.py#L96
In order to also work for CI in forks we should override the source URL (i.e. the repository URL) from the `setup.py` according to:
https://github.com/equinor/webviz-config/blob/master/CONTRIBUTING.md#make-your-plugin-project-available