### PR TITLE
Ignore mypy warning for optional variable in `numpy==1.21`

### DIFF
--- a/webviz_subsurface/_models/surface_leaflet_model.py
+++ b/webviz_subsurface/_models/surface_leaflet_model.py
@@ -73,7 +73,7 @@ class SurfaceLeafletModel:
     ) -> np.ndarray:
         surface = self.surface.copy()
         if clip_min or clip_max:
-            np.ma.clip(surface.values, clip_min, clip_max, out=surface.values)
+            np.ma.clip(surface.values, clip_min, clip_max, out=surface.values)  # type: ignore
         if unrotate:
             surface.unrotate()
         surface.fill(np.nan)


### PR DESCRIPTION
Mypy does not identify that either `a_min` or `a_max` can be optional in [numpy.ma.clip.](https://numpy.org/doc/stable/reference/generated/numpy.ma.clip.html)


---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
