### PR TITLE
Added ERT forward model to convert from .UNSMRY to Arrow file format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#669](https://github.com/equinor/webviz-subsurface/pull/669) - New generic plugin to visualize tornado plots from a csv file of responses.
+- [#685](https://github.com/equinor/webviz-subsurface/pull/685) - Added ERT forward model to convert from `.UNSMRY` to Arrow IPC file format (`.arrow`)
 
 ### Changed
 - [#681](https://github.com/equinor/webviz-subsurface/pull/681) - `VolumetricAnalysis` upgrades - added page with tornadoplots to `VolumetricAnalysis`, automatic computation of volumes

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "ert": ["webviz_subsurface_jobs = webviz_subsurface.ert_jobs.jobs"],
         "console_scripts": [
             "export_connection_status=webviz_subsurface.ert_jobs.export_connection_status:main",
+            "smry2arrow=webviz_subsurface.ert_jobs.smry2arrow:main",
         ],
     },
     install_requires=[

--- a/tests/integration_tests/test_ert_jobs.py
+++ b/tests/integration_tests/test_ert_jobs.py
@@ -1,13 +1,31 @@
 import subprocess  # nosec
 from pathlib import Path
+import json
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.feather as feather
+
+
+def _create_minimal_ert_config_file(tmp_path: Path, forward_model_string: str) -> Path:
+    runpath = tmp_path / Path("output")
+    ert_config_file = tmp_path / "config.ert"
+
+    ert_config_file.write_text(
+        f"""
+ECLBASE          something
+RUNPATH          {runpath}
+NUM_REALIZATIONS 1
+QUEUE_OPTION     LSF MAX_RUNNING 1
+QUEUE_SYSTEM     LOCAL
+FORWARD_MODEL    {forward_model_string}
+"""
+    )
+
+    return ert_config_file
 
 
 def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None:
-
-    runpath = tmp_path / Path("output")
-    ert_config_file = tmp_path / "config.ert"
 
     input_file = (
         testdata_folder
@@ -20,22 +38,69 @@ def test_export_connection_status(testdata_folder: Path, tmp_path: Path) -> None
     ).resolve()
     assert input_file.exists()
 
-    output_file = runpath / "output.parquet"
+    output_file = tmp_path / "output.parquet"
 
-    ert_config_file.write_text(
-        f"""
-ECLBASE          something
-RUNPATH          {runpath}
-NUM_REALIZATIONS 1
-QUEUE_OPTION     LSF MAX_RUNNING 1
-QUEUE_SYSTEM     LOCAL
-FORWARD_MODEL    EXPORT_CONNECTION_STATUS(<INPUT>={input_file}, <OUTPUT>={output_file})
-"""
+    ert_config_file = _create_minimal_ert_config_file(
+        tmp_path,
+        f"EXPORT_CONNECTION_STATUS(<INPUT>={input_file}, <OUTPUT>={output_file})",
     )
 
     subprocess.check_output(["ert", "test_run", ert_config_file], cwd=tmp_path)  # nosec
-
     assert output_file.exists()
 
     df = pd.read_parquet(output_file)
     assert list(df.columns) == ["DATE", "WELL", "I", "J", "K", "OP/SH"]
+
+
+def test_smry2arrow(testdata_folder: Path, tmp_path: Path) -> None:
+
+    input_file = (
+        testdata_folder
+        / "reek_history_match"
+        / "realization-0"
+        / "iter-0"
+        / "eclipse"
+        / "model"
+        / "5_R001_REEK-0.UNSMRY"
+    ).resolve()
+    assert input_file.exists()
+
+    output_file = tmp_path / "output.arrow"
+
+    ert_config_file = _create_minimal_ert_config_file(
+        tmp_path, f"SMRY2ARROW(<INPUT>={input_file}, <OUTPUT>={output_file})"
+    )
+
+    subprocess.check_output(["ert", "test_run", ert_config_file], cwd=tmp_path)  # nosec
+    assert output_file.exists()
+
+    table = feather.read_table(output_file)
+    assert table.shape == (291, 471)
+
+    sample_date = table["DATE"][0]
+    assert sample_date.type == pa.timestamp("ms")
+
+    schema = table.schema
+    field = schema.field("FOPT")
+    field_meta = json.loads(field.metadata[b"smry_meta"])
+    assert field.type == pa.float32()
+    assert field_meta["unit"] == "SM3"
+    assert field_meta["is_total"] == True
+    assert field_meta["is_rate"] == False
+    assert field_meta["is_historical"] == False
+
+    field = schema.field("FOPR")
+    field_meta = json.loads(field.metadata[b"smry_meta"])
+    assert field.type == pa.float32()
+    assert field_meta["unit"] == "SM3/DAY"
+    assert field_meta["is_total"] == False
+    assert field_meta["is_rate"] == True
+    assert field_meta["is_historical"] == False
+
+    field = schema.field("FOPTH")
+    field_meta = json.loads(field.metadata[b"smry_meta"])
+    assert field.type == pa.float32()
+    assert field_meta["unit"] == "SM3"
+    assert field_meta["is_total"] == True
+    assert field_meta["is_rate"] == False
+    assert field_meta["is_historical"] == True

--- a/webviz_subsurface/ert_jobs/config_jobs/SMRY2ARROW
+++ b/webviz_subsurface/ert_jobs/config_jobs/SMRY2ARROW
@@ -1,0 +1,5 @@
+EXECUTABLE smry2arrow
+
+ARGLIST <INPUT> <OUTPUT>
+
+MIN_ARG 2

--- a/webviz_subsurface/ert_jobs/jobs.py
+++ b/webviz_subsurface/ert_jobs/jobs.py
@@ -36,7 +36,10 @@ def installable_jobs() -> dict:
         resource_filename("webviz_subsurface", "ert_jobs/config_jobs")
     )
     return {
-        "EXPORT_CONNECTION_STATUS": str(resource_directory / "EXPORT_CONNECTION_STATUS")
+        "EXPORT_CONNECTION_STATUS": str(
+            resource_directory / "EXPORT_CONNECTION_STATUS"
+        ),
+        "SMRY2ARROW": str(resource_directory / "SMRY2ARROW"),
     }
 
 

--- a/webviz_subsurface/ert_jobs/smry2arrow.py
+++ b/webviz_subsurface/ert_jobs/smry2arrow.py
@@ -93,7 +93,6 @@ def _load_smry_into_table(smry_filename: str) -> pa.Table:
     # For now, we go via a set to prune out duplicate entries being returned by EclSumKeyWordVector,
     # see: https://github.com/equinor/ecl/issues/816#issuecomment-865881283
     column_names: List[str] = list(set(EclSumKeyWordVector(eclsum, add_keywords=True)))
-    # column_names = eclsum.keys()
 
     # Exclude CPI columns from export
     org_col_count = len(column_names)

--- a/webviz_subsurface/ert_jobs/smry2arrow.py
+++ b/webviz_subsurface/ert_jobs/smry2arrow.py
@@ -90,8 +90,6 @@ def _load_smry_into_table(smry_filename: str) -> pa.Table:
 
     eclsum = EclSum(smry_filename, include_restart=False, lazy_load=False)
 
-    # Unclear what the difference between these two is, but it seems that
-    # EclSum.pandas_frame() internally uses EclSumKeyWordVector
     # For now, we go via a set to prune out duplicate entries being returned by EclSumKeyWordVector,
     # see: https://github.com/equinor/ecl/issues/816#issuecomment-865881283
     column_names: List[str] = list(set(EclSumKeyWordVector(eclsum, add_keywords=True)))

--- a/webviz_subsurface/ert_jobs/smry2arrow.py
+++ b/webviz_subsurface/ert_jobs/smry2arrow.py
@@ -27,7 +27,7 @@ this in the ert workflow:
 
     FORWARD_MODEL SMRY2ARROW(<INPUT>=eclipse/model/SOME.UNSMRY, <OUTPUT>=share/results/tables/unsmry.arrow)
 
-"""  # noqa
+"""
 
 
 def _get_parser() -> argparse.ArgumentParser:

--- a/webviz_subsurface/ert_jobs/smry2arrow.py
+++ b/webviz_subsurface/ert_jobs/smry2arrow.py
@@ -50,7 +50,8 @@ def _get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-# TODO(Sigurd) This function should be shared with export_connection_status.py
+# This logic is copied from well_connection_status.py.
+# Should be refactored so that the two modules share a common implementation.
 def _is_cpi_column(column_name: str) -> bool:
     return bool(re.match("^CPI:[A-Z0-9_-]{1,8}:[0-9]+,[0-9]+,[0-9]+$", column_name))
 

--- a/webviz_subsurface/ert_jobs/smry2arrow.py
+++ b/webviz_subsurface/ert_jobs/smry2arrow.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+"""Convert UNSMRY file to Apache Arrow IPC file format (also known as Feather V2)
+"""
+
+from typing import List, Iterable, Dict
+import argparse
+import re
+from pathlib import Path
+import logging
+import json
+import time
+
+from ecl.summary import EclSum, EclSumKeyWordVector
+import pyarrow as pa
+import pyarrow.feather as feather
+
+logger = logging.getLogger(__name__)
+
+
+DESCRIPTION: str = """
+Convert UNSMRY file to Apache Arrow IPC file format (also known as Feather V2)
+"""
+CATEGORY: str = "utility.eclipse"
+EXAMPLES: str = """
+Convert and output summary data in SOME.UNSMRY file to an Arrow IPC file named unsmry.arrow
+this in the ert workflow:
+
+    FORWARD_MODEL SMRY2ARROW(<INPUT>=eclipse/model/SOME.UNSMRY, <OUTPUT>=share/results/tables/unsmry.arrow)
+
+"""  # noqa
+
+
+def _get_parser() -> argparse.ArgumentParser:
+    """Setup parser for command line options"""
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=DESCRIPTION,
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="Input file",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        help="Output file",
+        default=Path() / "share" / "results" / "tables" / "unsmry.arrow",
+    )
+    return parser
+
+
+# TODO(Sigurd) This function should be shared with export_connection_status.py
+def _is_cpi_column(column_name: str) -> bool:
+    return bool(re.match("^CPI:[A-Z0-9_-]{1,8}:[0-9]+,[0-9]+,[0-9]+$", column_name))
+
+
+def _create_smry_meta_dict(
+    eclsum: EclSum, column_names: Iterable[str]
+) -> Dict[str, dict]:
+    """Builds dictionary containing metadata for all the specified summary columns"""
+    smry_meta = {}
+
+    for col_name in column_names:
+        col_meta = {}
+        col_meta["unit"] = eclsum.unit(col_name)
+        col_meta["is_total"] = eclsum.is_total(col_name)
+        col_meta["is_rate"] = eclsum.is_rate(col_name)
+        col_meta["is_historical"] = eclsum.smspec_node(col_name).is_historical()
+        col_meta["keyword"] = eclsum.smspec_node(col_name).keyword
+        col_meta["wgname"] = eclsum.smspec_node(col_name).wgname
+
+        num = eclsum.smspec_node(col_name).get_num()
+        if num is not None:
+            col_meta["get_num"] = num
+
+        smry_meta[col_name] = col_meta
+
+    return smry_meta
+
+
+def _load_smry_into_table(smry_filename: str) -> pa.Table:
+    """
+    Reads data from SMRY file into PyArrow Table.
+    DATE column is stored as an Arrow timetamp with ms resolution, timestamp[ms]
+    All numeric columns will be stored as 32 bit float
+    Summary meta data will be attached per field/column of the table's schema under the
+    'smry_meta' key
+    """
+
+    eclsum = EclSum(smry_filename, include_restart=False, lazy_load=False)
+
+    # Unclear what the difference between these two is, but it seems that
+    # EclSum.pandas_frame() internally uses EclSumKeyWordVector
+    # For now, we go via a set to prune out duplicate entries being returned by EclSumKeyWordVector,
+    # see: https://github.com/equinor/ecl/issues/816#issuecomment-865881283
+    column_names: List[str] = list(set(EclSumKeyWordVector(eclsum, add_keywords=True)))
+    # column_names = eclsum.keys()
+
+    # Exclude CPI columns from export
+    org_col_count = len(column_names)
+    column_names = [colname for colname in column_names if not _is_cpi_column(colname)]
+    if len(column_names) != org_col_count:
+        logger.info(
+            f"Excluding {org_col_count - len(column_names)} CPI columns from export"
+        )
+
+    # Fetch the dates as a numpy array with ms resolution
+    np_dates_ms = eclsum.numpy_dates
+
+    smry_meta_dict = _create_smry_meta_dict(eclsum, column_names)
+
+    # Datatypes to use for DATE column and all the numeric columns
+    dt_timestamp_ms = pa.timestamp("ms")
+    dt_float32 = pa.float32()
+
+    # Build schema for the table
+    field_list: List[pa.Field] = []
+    field_list.append(pa.field("DATE", dt_timestamp_ms))
+    for colname in column_names:
+        field_metadata = {b"smry_meta": json.dumps(smry_meta_dict[colname])}
+        field_list.append(pa.field(colname, dt_float32, metadata=field_metadata))
+
+    schema = pa.schema(field_list)
+
+    # Now extract all the summary vectors one by one
+    # We do this through EclSum.numpy_vector() instead of EclSum.pandas_frame() since
+    # the latter throws an exception if the SMRY data has timestamps beyond 2262,
+    # see: https://github.com/equinor/ecl/issues/802
+    column_arrays = [np_dates_ms]
+
+    for colname in column_names:
+        colvector = eclsum.numpy_vector(colname)
+        column_arrays.append(colvector)
+
+    table = pa.table(column_arrays, schema=schema)
+
+    return table
+
+
+def smry2arrow(smry_filename: Path, arrow_filename: Path) -> None:
+    start_s = time.perf_counter()
+
+    logger.debug(f"Reading SMRY data from: {smry_filename}")
+    table: pa.Table = _load_smry_into_table(str(smry_filename))
+    read_s = time.perf_counter() - start_s
+
+    # Writing here is done through the feather import, but could also be done using
+    # pa.RecordBatchFileWriter.write_table() with a few pa.ipc.IpcWriteOptions().
+    # It is convenient to use feather since it has ready configured defaults and the
+    # actual file format is the same (https://arrow.apache.org/docs/python/feather.html)
+    logger.debug(f"Writing {table.shape} arrow file to: {arrow_filename}")
+    feather.write_feather(table, dest=arrow_filename)
+
+    logger.debug(
+        f"Conversion took: {(time.perf_counter() - start_s):.2f}s (read={read_s:.2f}s)"
+    )
+
+
+def main() -> None:
+    """Entry point from command line"""
+    parser = _get_parser()
+    args = parser.parse_args()
+
+    smry2arrow(args.input, args.output)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    main()


### PR DESCRIPTION
This PR adds an ERT forward model that can converts `.UNSMRY` files to Apache Arrow IPC file format.
The Arrow IPC file format is a columnar data format optimized for table-like datasets, see https://arrow.apache.org/docs/format/Columnar.html#ipc-file-format
This file format is also known as `Feather` version 2, see https://arrow.apache.org/docs/python/feather.html

The ERT job imports data from an `.UNSMRY` file and writes output to an `.arrow` file in the above format.

The following data types are used in the exported data
- `DATE` column is stored as an Arrow timetamp with millisecond resolution `timestamp[ms]`
- All numeric columns will be stored as 32 bit floats
- Summary meta data will be attached to each field/column in the exported table's schema under the
'smry_meta' key

Currently `CPI` columns in the summary data wil be excluded from the exported `.arrow` file.

---

### Contributor checklist

- [x] :tada: This PR closes #673
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
