### PR TITLE
Bugfix TornadoPlot when no sensitivities have impact

### DIFF
--- a/webviz_subsurface/_components/tornado/_tornado_bar_chart.py
+++ b/webviz_subsurface/_components/tornado/_tornado_bar_chart.py
@@ -60,7 +60,11 @@ class TornadoBarChart:
                 df["sensname"] = sensname
                 df["case"] = case
                 dfs.append(df)
-        return pd.concat(dfs)
+        return (
+            pd.concat(dfs)
+            if dfs
+            else pd.DataFrame(columns=["REAL", "sensname", "case"])
+        )
 
     @property
     def figure_height(self) -> Optional[int]:
@@ -202,7 +206,7 @@ class TornadoBarChart:
                 "xaxis": {
                     "title": self._scale,
                     "range": self.range,
-                    "autorange": self._show_scatter,
+                    "autorange": self._show_scatter or self._tornadotable.empty,
                     "showgrid": False,
                     "zeroline": False,
                     "linecolor": "black",

--- a/webviz_subsurface/_components/tornado/tornado_widget.py
+++ b/webviz_subsurface/_components/tornado/tornado_widget.py
@@ -419,7 +419,7 @@ class TornadoWidget:
                 client_height * 0.59
                 if "Fit all bars in figure" in plot_options
                 and client_height is not None
-                else 100 * len(tornado_data.tornadotable["sensname"].unique())
+                else max(100 * len(tornado_data.tornadotable["sensname"].unique()), 200)
             )
             tornado_figure = TornadoBarChart(
                 tornado_data=tornado_data,


### PR DESCRIPTION
PR to fix bug when no sensitivities have impact on a response and the "Remove sensitivities with no impact" is active.
This resulted in error before. Now an empty plot with only the refrence line is drawn.

---

### Contributor checklist

- [x] :tada: This PR closes #702 
