### PR TITLE
Update required dash version to 1.20.0 due to dcc 1.16.0 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         ],
     },
     install_requires=[
-        "dash>=1.11",
+        "dash>=1.20.0",
         "dash_bootstrap_components>=0.10.3",
         "dash-daq>=0.5.0",
         "defusedxml>=0.6.0",


### PR DESCRIPTION
clientside_stores in _volumetric_analysis plugin utilize dcc.Download. Component requires dash-core-components 1.16.0, which is included in dash 1.20.0