### PR TITLE
Use `pd.all()` in documented way

### DIFF
--- a/webviz_subsurface/_components/tornado/_tornado_data.py
+++ b/webviz_subsurface/_components/tornado/_tornado_data.py
@@ -33,7 +33,9 @@ class TornadoData:
             raise KeyError("No sensitivities found in tornado input")
 
         for sens_name, sens_name_df in dframe.groupby("SENSNAME"):
-            if sens_name_df["SENSTYPE"].all() not in ["scalar", "mc"]:
+            if not any(
+                (sens_name_df["SENSTYPE"] == st).all() for st in ["scalar", "mc"]
+            ):
                 raise ValueError(
                     f"Sensitivity {sens_name} is not of type 'mc' or 'scalar"
                 )
@@ -87,7 +89,7 @@ class TornadoData:
                 continue
 
             # If `SENSTYPE` is scalar get the mean for each `SENSCASE`
-            if sens_name_df["SENSTYPE"].all() == "scalar":
+            if (sens_name_df["SENSTYPE"] == "scalar").all():
                 for sens_case, sens_case_df in sens_name_df.groupby(["SENSCASE"]):
                     avg_per_sensitivity.append(
                         {
@@ -101,7 +103,7 @@ class TornadoData:
                         }
                     )
             # If `SENSTYPE` is monte carlo get p10, p90
-            elif sens_name_df["SENSTYPE"].all() == "mc":
+            elif (sens_name_df["SENSTYPE"] == "mc").all():
 
                 # Calculate p90(low) and p10(high)
                 p90 = sens_name_df["VALUE"].quantile(0.10)


### PR DESCRIPTION
After `pandas==1.3` that was released three days ago, CI on Python 3.7-3.8 has started to consistently fail (Python 3.6 succeeds due to recent version of Pandas not being installed on that Python version).

According to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.all.html it looks like `all()` returns a boolean by itself, and the pattern `df["somecolumn"].all() == x` does not seem to be documented on that page. But apparently it worked for `pandas < 1.3`? :thinking: 

I checked for other occurrences by doing `grep -rnw './webviz-subsurface' -e '.all()'` giving only matches for the file `_tornado_data.py`.