### PR TITLE
Preserve uirevision in timeseries and relperm plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [#723](https://github.com/equinor/webviz-subsurface/pull/723) - Added custom option to allow free selection of responses shown in the tornadoplots in `VolumetricAnalysis`
+- [#717](https://github.com/equinor/webviz-subsurface/pull/717) - Keep zoom state in `ReservoirSimulationTimeseries` (inc `Regional` and `OneByOne`) and `RelativePermeability` plugins using `uirevision`.
 
 ## [0.2.4] - 2021-07-13
 

--- a/webviz_subsurface/plugins/_relative_permeability.py
+++ b/webviz_subsurface/plugins/_relative_permeability.py
@@ -886,7 +886,12 @@ def plot_layout(nplots, curves, sataxis, color_by, linlog, theme):
     )
     layout = {}
     layout.update(theme)
-    layout.update({"hovermode": "closest"})
+    layout.update(
+        {
+            "hovermode": "closest",
+            "uirevision": f"sa:{sataxis}_{linlog}_curves:{'_'.join(sorted(curves))}",
+        }
+    )
     # create subplots
     layout.update(
         {

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -810,6 +810,21 @@ folder, to avoid risk of not extracting the right data.
                     for trace in add_observation_trace(self.observations.get(vector)):
                         fig.add_trace(trace, i + 1, 1)
 
+            # Remove linked x-axis for histograms
+            # Keep uirevision (e.g. zoom) for unchanged data.
+            fig.update_xaxes(uirevision="locked")  # Time axis state kept
+            for i, vector in enumerate(vectors, start=1):
+                if "Histogram" in trace_options:
+                    fig.update_xaxes(
+                        row=i,
+                        col=2,
+                        matches=None,
+                        showticklabels=True,
+                        uirevision=vector,
+                    )
+                    fig.update_yaxes(row=i, col=2, uirevision=vector)
+                fig.update_yaxes(row=i, col=1, uirevision=vector)
+
             fig = fig.to_dict()
             fig["layout"].update(
                 barmode="overlay",
@@ -817,18 +832,6 @@ folder, to avoid risk of not extracting the right data.
                 bargroupgap=0.2,
             )
             fig["layout"] = self.theme.create_themed_layout(fig["layout"])
-
-            if "Histogram" in trace_options:
-                # Remove linked x-axis for histograms
-                if "xaxis2" in fig["layout"]:
-                    fig["layout"]["xaxis2"]["matches"] = None
-                    fig["layout"]["xaxis2"]["showticklabels"] = True
-                if "xaxis4" in fig["layout"]:
-                    fig["layout"]["xaxis4"]["matches"] = None
-                    fig["layout"]["xaxis4"]["showticklabels"] = True
-                if "xaxis6" in fig["layout"]:
-                    fig["layout"]["xaxis6"]["matches"] = None
-                    fig["layout"]["xaxis6"]["showticklabels"] = True
             return fig
 
         @app.callback(

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -611,8 +611,10 @@ folder, to avoid risk of not extracting the right data.
                     ""
                     if get_unit(self.smry_meta, vector) is None
                     else f" [{get_unit(self.smry_meta, vector)}]"
-                )
+                ),
+                "uirevision": vector,
             }
+            figure["layout"]["xaxis"] = {"uirevision": "locked"}
             figure["layout"]["legend"] = {
                 "orientation": "h",
                 # "traceorder": "reversed",

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -734,7 +734,7 @@ folder, to avoid risk of not extracting the right data.
                     "title": make_title(self.smry_meta, ref_vector, vector, mode),
                     "showgrid": False,
                 },
-                "xaxis": {"showgrid": False},
+                "xaxis": {"showgrid": False, "uirevision": "locked"},
                 "height": 450,
             }
             if mode == "rec":


### PR DESCRIPTION
Introduces `uirevision` to keep zoom state in more plugins where it felt natural. 

There is a risk that some users are not familiar with plotly zoom and how to revert it to initial state, but it is fairly easy (either double click in plot or use the plot toolbar)

Replaces the test in #701 

---

### Contributor checklist

- [X] :tada: This PR closes #706 .
- [X] :scroll: I have broken down my PR into implementation of `uirevision` in the following plugins:
   - [X] `ReservoirSimulationTimeSeries`
   - [X] `ReservoirSimulationTimeSeriesRegional`
   - [X] `ReservoirSimulationTimeSeriesOneByOne`
   - [X] `RelativePermeability`
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
