### PR TITLE
Added Tables tab in `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#723](https://github.com/equinor/webviz-subsurface/pull/723) - Added custom option to allow free selection of responses shown in the tornadoplots in `VolumetricAnalysis`
 - [#717](https://github.com/equinor/webviz-subsurface/pull/717) - Keep zoom state in `ReservoirSimulationTimeseries` (inc `Regional` and `OneByOne`) and `RelativePermeability` plugins using `uirevision`.
 
+### Changed
+- [#724](https://github.com/equinor/webviz-subsurface/pull/724) - Seperated out Tables as a new tab to `VolumetricAnalysis`
+
 ## [0.2.4] - 2021-07-13
 
 ### Added

--- a/webviz_subsurface/_assets/css/inplace_volumes.css
+++ b/webviz_subsurface/_assets/css/inplace_volumes.css
@@ -2,50 +2,13 @@
     background-color: #E8E8E8;
     width: 100%;
     display: block;
-    padding: 0 20px;
-    margin-top: 5px;
     margin-left: auto;
     font-size: 12px;
+    height: 30px;
+    line-height:30px;
 }
 
 
 .webviz-inplace-vol-btn:hover {
     box-shadow: 0px 0px 3px 0.5px lightgrey;
-}
-
-
-.webviz-inplace-vol-details-main {
-    cursor: pointer;
-    color: #ff1243;
-    border-bottom-style: solid;
-    border-width: thin;
-    border-color: #ff1243;
-    font-weight: bold;
-    font-size: 20px;
-    margin-bottom: 15px;
-} 
-
-
-.webviz-inplace-vol-plotselect {
-    cursor: pointer;
-    color: #555;
-    margin-top: 10px;
-    margin-bottom: 10px;
-    background-color: rgb(232, 232, 232);    
-    border-radius: 4px;
-    border: 1px solid #bbb;    
-
-}
-
-.webviz-inplace-vol-plotselect:hover {
-    box-shadow: 0px 0px 3px 0.5px lightgrey;
-}
-
-.webviz-inplace-vol-framed {
-    border-radius: 5px;
-    background-color: white;
-    margin: 10px;
-    padding: 15px;
-    position: relative;
-    box-shadow: 0px 0px 4px 0.5px lightgrey;
 }

--- a/webviz_subsurface/_components/tornado/_tornado_bar_chart.py
+++ b/webviz_subsurface/_components/tornado/_tornado_bar_chart.py
@@ -256,7 +256,7 @@ class TornadoBarChart:
         return _layout
 
     @property
-    def figure(self) -> Dict:
+    def figure(self) -> go.Figure:
         data = self.data
 
         fig = go.Figure({"data": data, "layout": self.layout})

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
@@ -91,20 +91,3 @@ def layout_controllers(app: dash.Dash, get_uuid: Callable) -> None:
             else:
                 styles.append({"display": "none"})
         return styles
-
-    @app.callback(
-        Output(
-            {
-                "id": get_uuid("selections"),
-                "tab": "voldist",
-                "element": "table_response_group_wrapper",
-            },
-            "style",
-        ),
-        Input(
-            {"id": get_uuid("selections"), "tab": "voldist", "selector": "sync_table"},
-            "value",
-        ),
-    )
-    def _show_hide_table_response_group_controls(sync_table: list) -> dict:
-        return {"display": "none"} if sync_table else {"display": "block"}

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -208,11 +208,8 @@ def selections_controllers(
         Output(
             {"id": get_uuid("filters"), "tab": ALL, "element": "real_text"}, "children"
         ),
-        Input({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "value"),
         Input(get_uuid("page-selected"), "data"),
-        Input(
-            {"id": get_uuid("main-voldist"), "element": "plot-table-select"}, "value"
-        ),
+        Input({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "value"),
         Input({"id": get_uuid("filters"), "tab": ALL, "component_type": ALL}, "value"),
         State({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "id"),
         State(get_uuid("tabs"), "value"),
@@ -223,9 +220,8 @@ def selections_controllers(
         State({"id": get_uuid("filters"), "tab": ALL, "element": "real_text"}, "id"),
     )
     def _update_filter_options(
+        _selected_page: str,
         selectors: list,
-        selected_page: str,
-        plot_table_select: str,
         reals: list,
         selector_ids: list,
         selected_tab: str,
@@ -255,20 +251,8 @@ def selections_controllers(
                 page_selections[x]
                 for x in ["Color by", "Subplots", "X Response", "Y Response"]
             ]
-            table_groups = (
-                page_selections["Group by"]
-                if page_selections["Group by"] is not None
-                else []
-            )
-
-            if selected_page == "1p1t" and not page_selections["sync_table"]:
-                selected_data.extend(table_groups)
-            if (
-                selected_page == "custom"
-                and plot_table_select == "table"
-                and not page_selections["sync_table"]
-            ):
-                selected_data = table_groups
+        if selected_tab == "table" and page_selections["Group by"] is not None:
+            selected_data = page_selections["Group by"]
 
         output = {}
         for selector in ["SOURCE", "ENSEMBLE"]:

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/distribution_main_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/distribution_main_layout.py
@@ -30,6 +30,16 @@ def distributions_main_layout(uuid: str, volumemodel: InplaceVolumesModel) -> ht
     )
 
 
+def table_main_layout(uuid: str) -> html.Div:
+    return wcc.Frame(
+        id={"id": uuid, "wrapper": "table", "page": "table"},
+        color="white",
+        highlight=False,
+        style={"height": "91vh"},
+        children=[],
+    )
+
+
 def convergence_plot_layout(uuid: str) -> html.Div:
     return wcc.Frame(
         color="white",

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -6,8 +6,8 @@ import webviz_core_components as wcc
 from webviz_config import WebvizConfigTheme
 from webviz_subsurface._models import InplaceVolumesModel
 from .filter_view import filter_layout
-from .distribution_main_layout import distributions_main_layout
-from .selections_view import selections_layout
+from .distribution_main_layout import distributions_main_layout, table_main_layout
+from .selections_view import selections_layout, table_selections_layout
 from .tornado_selections_view import tornado_selections_layout
 from .tornado_layout import tornado_main_layout
 
@@ -45,7 +45,32 @@ def main_view(
             ),
         )
     ]
-
+    tabs.append(
+        wcc.Tab(
+            label="Tables",
+            value="table",
+            children=tab_view_layout(
+                main_layout=table_main_layout(
+                    uuid=get_uuid("main-table"),
+                ),
+                sidebar_layout=[
+                    table_selections_layout(
+                        uuid=get_uuid("selections"),
+                        tab="table",
+                        volumemodel=volumemodel,
+                    )
+                ]
+                + [
+                    filter_layout(
+                        open_details=True,
+                        uuid=get_uuid("filters"),
+                        tab="table",
+                        volumemodel=volumemodel,
+                    ),
+                ],
+            ),
+        )
+    )
     if volumemodel.sensrun:
         tabs.append(
             wcc.Tab(

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
@@ -17,12 +17,18 @@ def selections_layout(
     )
     return html.Div(
         children=[
-            button(uuid=uuid, title="1 plot / 1 table", page_id="1p1t"),
-            button(uuid=uuid, title=f"Plots per {selectors}", page_id="per_zr"),
-            button(uuid=uuid, title="Convergence plot mean/p10/p90", page_id="conv"),
-            button(uuid=uuid, title="Custom plotting", page_id="custom"),
+            html.Div(
+                style={"margin-bottom": "20px"},
+                children=[
+                    button(uuid=uuid, title="1 plot / 1 table", page_id="1p1t"),
+                    button(uuid=uuid, title=f"Plots per {selectors}", page_id="per_zr"),
+                    button(
+                        uuid=uuid, title="Convergence plot mean/p10/p90", page_id="conv"
+                    ),
+                    button(uuid=uuid, title="Custom plotting", page_id="custom"),
+                ],
+            ),
             plot_selections_layout(uuid, volumemodel, tab),
-            table_selections_layout(uuid, volumemodel, tab),
             settings_layout(uuid, theme, tab),
         ]
     )
@@ -42,7 +48,7 @@ def button(
 
 def plot_selections_layout(
     uuid: str, volumemodel: InplaceVolumesModel, tab: str
-) -> html.Details:
+) -> wcc.Selectors:
     return wcc.Selectors(
         label="PLOT CONTROLS",
         open_details=True,
@@ -52,13 +58,12 @@ def plot_selections_layout(
 
 def table_selections_layout(
     uuid: str, volumemodel: InplaceVolumesModel, tab: str
-) -> html.Details:
+) -> wcc.Selectors:
     responses = volumemodel.volume_columns + volumemodel.property_columns
     return wcc.Selectors(
         label="TABLE CONTROLS",
         open_details=True,
         children=[
-            table_sync_option(uuid, tab),
             wcc.Dropdown(
                 label="Table type",
                 id={"id": uuid, "tab": tab, "selector": "Table type"},
@@ -66,43 +71,30 @@ def table_selections_layout(
                     {"label": elm, "value": elm}
                     for elm in ["Statistics table", "Mean table"]
                 ],
-                value="Statistics table",
+                value="Mean table",
                 clearable=False,
             ),
-            html.Div(
+            wcc.Dropdown(
+                label="Group by",
+                id={"id": uuid, "tab": tab, "selector": "Group by"},
+                options=[{"label": elm, "value": elm} for elm in volumemodel.selectors],
+                value=None,
+                multi=True,
+                clearable=False,
+            ),
+            wcc.SelectWithLabel(
+                label="Responses",
                 id={
                     "id": uuid,
                     "tab": tab,
-                    "element": "table_response_group_wrapper",
+                    "selector": "table_responses",
                 },
-                style={"display": "None"},
-                children=[
-                    wcc.Dropdown(
-                        label="Group by",
-                        id={"id": uuid, "tab": tab, "selector": "Group by"},
-                        options=[
-                            {"label": elm, "value": elm}
-                            for elm in volumemodel.selectors
-                        ],
-                        value=None,
-                        multi=True,
-                        clearable=False,
-                    ),
-                    wcc.SelectWithLabel(
-                        label="Responses",
-                        id={
-                            "id": uuid,
-                            "tab": tab,
-                            "selector": "table_responses",
-                        },
-                        options=[{"label": i, "value": i} for i in responses],
-                        value=responses,
-                        size=min(
-                            20,
-                            len(responses),
-                        ),
-                    ),
-                ],
+                options=[{"label": i, "value": i} for i in responses],
+                value=responses,
+                size=min(
+                    20,
+                    len(responses),
+                ),
             ),
         ],
     )


### PR DESCRIPTION
This PR adds a "Tables" tab in `VolumetricAnalysis` for easy user access to custom table generation.  

Today the user has to turn off the "sync table with plot" option on the tables belonging to the plots in order to make custom tables. With this PR these tables are no longer customizable, but are kept as statistics tables similar to the old `InplaceVolumetrics` plugin. With this change a lot of logic can be removed from the code.

This PR also includes removal of unnecessary initial callback check in each page update callback.
