### PR TITLE
Added parameter filter to ParameterAnalysis

### DIFF
--- a/webviz_subsurface/plugins/_parameter_analysis/models/simulation_timeseries_model.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/models/simulation_timeseries_model.py
@@ -173,7 +173,7 @@ class SimulationTimeSeriesModel:
 
     @CACHE.memoize(timeout=CACHE.TIMEOUT)
     def add_realization_traces(
-        self, ensemble: str, vector: str, real_filter: pd.Series = None
+        self, ensemble: str, vector: str, real_filter: Optional[list] = None
     ) -> list:
         """Renders line trace for each realization, includes history line if present"""
         dataframe = self._dataframe[self._dataframe["ENSEMBLE"] == ensemble]

--- a/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/parameter_analysis.py
@@ -7,6 +7,7 @@ from webviz_config import WebvizSettings
 
 from webviz_subsurface._models import EnsembleSetModel
 from webviz_subsurface._models import caching_ensemble_set_model_factory
+from webviz_subsurface._components.parameter_filter import ParameterFilter
 from .views import main_view
 from .models import ParametersModel, SimulationTimeSeriesModel
 from .controllers import (
@@ -125,6 +126,10 @@ slow for large models.
             else:
                 self.vmodel = None
 
+        self._parameter_filter = ParameterFilter(
+            app, self.uuid("parameter-filter"), self.pmodel.dataframe
+        )
+
         self.set_callbacks(app)
 
     @property
@@ -133,6 +138,7 @@ slow for large models.
             get_uuid=self.uuid,
             vectormodel=self.vmodel,
             parametermodel=self.pmodel,
+            parameterfilter_layout=self._parameter_filter.layout,
             theme=self.theme,
         )
 

--- a/webviz_subsurface/plugins/_parameter_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/views/main_view.py
@@ -1,7 +1,5 @@
 from typing import Callable
-
 import dash_html_components as html
-import dash_core_components as dcc
 from webviz_config import WebvizConfigTheme
 
 import webviz_core_components as wcc
@@ -14,33 +12,36 @@ def main_view(
     get_uuid: Callable,
     vectormodel: SimulationTimeSeriesModel,
     parametermodel: ParametersModel,
+    parameterfilter_layout: html.Div,
     theme: WebvizConfigTheme,
-) -> dcc.Tabs:
+) -> wcc.Tabs:
     tabs = [
         wcc.Tab(
             label="Parameter distributions",
+            value="tab-1",
             children=parameter_qc_view(
                 get_uuid=get_uuid, parametermodel=parametermodel
             ),
         )
     ]
+
     if vectormodel is not None:
         tabs.append(
             wcc.Tab(
                 label="Parameters impact on simulation profiles",
+                value="tab-2",
                 children=parameter_response_view(
                     get_uuid=get_uuid,
                     parametermodel=parametermodel,
+                    parameterfilter_layout=parameterfilter_layout,
                     vectormodel=vectormodel,
                     theme=theme,
                 ),
             )
         )
 
-    return html.Div(
-        id=get_uuid("layout"),
-        children=wcc.Tabs(
-            style={"width": "100%"},
-            children=tabs,
-        ),
+    return wcc.Tabs(
+        value="tab-1" if vectormodel is None else "tab-2",
+        style={"width": "100%"},
+        children=tabs,
     )

--- a/webviz_subsurface/plugins/_parameter_analysis/views/parameter_qc_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/views/parameter_qc_view.py
@@ -55,14 +55,15 @@ def parameter_qc_view(
     get_uuid: Callable, parametermodel: ParametersModel
 ) -> wcc.FlexBox:
     return wcc.FlexBox(
-        style={"margin": "20px"},
         children=[
             wcc.FlexColumn(
-                wcc.Frame(
+                flex=1,
+                children=wcc.Frame(
+                    style={"height": "80vh"},
                     children=selector_view(
                         get_uuid=get_uuid, parametermodel=parametermodel
                     ),
-                )
+                ),
             ),
             wcc.FlexColumn(
                 flex=4,
@@ -84,7 +85,8 @@ def parameter_qc_view(
                             value="distribution",
                         ),
                         html.Div(
-                            style={"height": "75vh"}, id=get_uuid("property-qc-wrapper")
+                            style={"height": "75vh", "margin-top": "20px"},
+                            id=get_uuid("property-qc-wrapper"),
                         ),
                     ],
                 ),

--- a/webviz_subsurface/plugins/_parameter_analysis/views/parameter_response_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/views/parameter_response_view.py
@@ -67,26 +67,21 @@ def selector_view(
                 ],
             ),
             wcc.Selectors(
-                label=[
-                    "Filters ",
-                    html.Span(
-                        "(for correlations)",
-                        style={
-                            "float": "right",
-                            "margin-top": "10px",
-                            "fontSize": "13px",
-                            "font-weight": "normal",
-                        },
-                    ),
-                ],
+                label="Filters",
                 children=[
+                    wcc.Checklist(
+                        id=get_uuid("display-paramfilter"),
+                        options=[{"label": "Show parameter filter", "value": "Show"}],
+                        value=[],
+                    ),
                     filter_vector_selector(
                         get_uuid=get_uuid, vectormodel=vectormodel, tab="response"
-                    )
+                    ),
                 ],
             ),
             wcc.Selectors(
                 label="Options",
+                open_details=False,
                 children=[
                     plot_options(get_uuid=get_uuid, tab="response"),
                     color_selector(
@@ -108,13 +103,14 @@ def selector_view(
 def parameter_response_view(
     get_uuid: Callable,
     parametermodel: ParametersModel,
+    parameterfilter_layout: html.Div,
     vectormodel: SimulationTimeSeriesModel,
     theme: WebvizConfigTheme,
 ) -> wcc.FlexBox:
     return wcc.FlexBox(
-        style={"margin": "20px"},
         children=[
             wcc.FlexColumn(
+                flex=1,
                 children=selector_view(
                     get_uuid=get_uuid,
                     parametermodel=parametermodel,
@@ -123,58 +119,72 @@ def parameter_response_view(
                 ),
             ),
             wcc.FlexColumn(
-                flex=2,
-                style={"height": "80vh"},
-                children=[
-                    wcc.Frame(
-                        style={"height": "38.5vh"},
-                        color="white",
-                        highlight=False,
-                        children=timeseries_view(get_uuid=get_uuid),
-                    ),
-                    wcc.Frame(
-                        style={"height": "38.5vh"},
-                        color="white",
-                        highlight=False,
-                        children=[
-                            wcc.Graph(
-                                id=get_uuid("vector-vs-param-scatter"),
-                                config={"displayModeBar": False},
-                                style={"height": "38vh"},
-                            )
-                        ],
-                    ),
-                ],
-            ),
-            wcc.FlexColumn(
-                flex=2,
-                style={"height": "80vh"},
-                children=[
-                    wcc.Frame(
-                        color="white",
-                        highlight=False,
-                        style={"height": "38.5vh"},
-                        children=[
-                            wcc.Graph(
-                                config={"displayModeBar": False},
-                                style={"height": "38vh"},
-                                id=get_uuid("vector-corr-graph"),
+                flex=4,
+                children=wcc.FlexBox(
+                    children=[
+                        wcc.FlexColumn(
+                            flex=2,
+                            children=[
+                                wcc.Frame(
+                                    style={"height": "38.5vh"},
+                                    color="white",
+                                    highlight=False,
+                                    children=timeseries_view(get_uuid=get_uuid),
+                                ),
+                                wcc.Frame(
+                                    style={"height": "38.5vh"},
+                                    color="white",
+                                    highlight=False,
+                                    children=[
+                                        wcc.Graph(
+                                            id=get_uuid("vector-vs-param-scatter"),
+                                            config={"displayModeBar": False},
+                                            style={"height": "38vh"},
+                                        )
+                                    ],
+                                ),
+                            ],
+                        ),
+                        wcc.FlexColumn(
+                            flex=2,
+                            children=[
+                                wcc.Frame(
+                                    color="white",
+                                    highlight=False,
+                                    style={"height": "38.5vh"},
+                                    children=[
+                                        wcc.Graph(
+                                            config={"displayModeBar": False},
+                                            style={"height": "38vh"},
+                                            id=get_uuid("vector-corr-graph"),
+                                        ),
+                                    ],
+                                ),
+                                wcc.Frame(
+                                    color="white",
+                                    highlight=False,
+                                    style={"height": "38.5vh"},
+                                    children=[
+                                        wcc.Graph(
+                                            config={"displayModeBar": False},
+                                            style={"height": "38vh"},
+                                            id=get_uuid("param-corr-graph"),
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                        wcc.FlexColumn(
+                            id=get_uuid("param-filter-wrapper"),
+                            style={"display": "none"},
+                            flex=1,
+                            children=wcc.Frame(
+                                style={"height": "80vh"},
+                                children=parameterfilter_layout,
                             ),
-                        ],
-                    ),
-                    wcc.Frame(
-                        color="white",
-                        highlight=False,
-                        style={"height": "38.5vh"},
-                        children=[
-                            wcc.Graph(
-                                config={"displayModeBar": False},
-                                style={"height": "38vh"},
-                                id=get_uuid("param-corr-graph"),
-                            ),
-                        ],
-                    ),
-                ],
+                        ),
+                    ],
+                ),
             ),
         ],
     )

--- a/webviz_subsurface/plugins/_parameter_analysis/views/selector_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/views/selector_view.py
@@ -29,7 +29,7 @@ def ensemble_selector(
             clearable=False,
         )
     )
-    return html.Div(style={"width": "90%"}, children=children)
+    return html.Div(children)
 
 
 def vector_selector(
@@ -41,7 +41,7 @@ def vector_selector(
         else list(vectormodel.vector_groups.keys())[0]
     )
     return html.Div(
-        style={"width": "90%"},
+        style={"margin": "10px 0px"},
         children=[
             html.Span(wcc.Label("Vector type")),
             html.Div(
@@ -150,6 +150,7 @@ def date_selector(
 ) -> html.Div:
     dates = vectormodel.dates
     return html.Div(
+        style={"margin": "10px 0px"},
         children=[
             html.Div(
                 style={"display": "inline-flex"},
@@ -192,7 +193,7 @@ def filter_parameter(
     value: Union[str, float] = None,
 ) -> html.Div:
     return html.Div(
-        style={"margin-top": "10px", "width": "90%"},
+        style={"margin-top": "10px"},
         children=[
             wcc.Label("Select parameters"),
             html.Div(
@@ -225,11 +226,11 @@ def make_filter(
     value: Union[str, float] = None,
     open_details: bool = False,
 ) -> wcc.Selectors:
-    return wcc.Selectors(
-        label=vtype,
+    return html.Details(
         open=open_details,
         children=[
-            wcc.SelectWithLabel(
+            html.Summary(vtype),
+            wcc.Select(
                 id={
                     "id": get_uuid("vitem-filter"),
                     "tab": tab,
@@ -253,7 +254,7 @@ def filter_vector_selector(
     open_details: bool = False,
 ) -> html.Div:
     return html.Div(
-        style={"width": "90%"},
+        style={"margin-top": "10px"},
         children=[
             wcc.Dropdown(
                 label="Vector type",
@@ -268,6 +269,7 @@ def filter_vector_selector(
                 multi=True,
             ),
             html.Div(
+                style={"margin-top": "10px"},
                 children=[
                     make_filter(
                         get_uuid=get_uuid,
@@ -298,7 +300,7 @@ def color_selector(
     height: Optional[float] = None,
 ):
     return html.Div(
-        style={"width": "90%", "margin-top": "5px"},
+        style={"margin-top": "5px"},
         children=[
             wcc.Label("Colors"),
             wcc.Graph(
@@ -316,7 +318,7 @@ def color_selector(
 
 def color_opacity_selector(get_uuid: Callable, tab: str, value: float):
     return html.Div(
-        style={"width": "90%", "margin-top": "5px"},
+        style={"margin-top": "5px"},
         children=[
             "Opacity:",
             dcc.Input(


### PR DESCRIPTION
This PR addresses issue #722, and implements the  `ParameterFilter` component to the "Parameters impact on simulation profiles" tab of the `ParameterAnalysis` plugin.
- Added checkbox to be able to display/hide the ParameterFilter component 
- Added realization filter to filter data used for the figures and correlations.
- Added return of empty figures if there is no data left after filtering.

Also included in the PR:
- minor layout fixes to adjust some margins etc. after the wcc layout components was implemented
- set tab "Parameters impact on simulation profiles" as selected tab, if smry data is available, to make it more visible for users looking through the Reek examples.

![image](https://user-images.githubusercontent.com/61694854/129486097-d5f13e93-de4a-4a1a-ba14-d8befb4de9a7.png)

*Insert a description of your pull request (PR) here, and check off the boxes below when they are done.*

---


### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
