### PR TITLE
Updates for `pylint=2.10.2`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MESSAGES CONTROL]
 
-disable = bad-continuation, missing-docstring, duplicate-code, logging-fstring-interpolation
+disable = bad-continuation, missing-docstring, duplicate-code, logging-fstring-interpolation, unspecified-encoding
 
 [DESIGN]
 

--- a/webviz_subsurface/_utils/simulation_timeseries.py
+++ b/webviz_subsurface/_utils/simulation_timeseries.py
@@ -344,7 +344,7 @@ def check_and_format_observations(obsfile: Path) -> dict:
             raise TypeError(
                 "The observation file's smry section must be formatted as a list of dictionaries."
             )
-        observations = dict()
+        observations: dict = {}
 
         # pylint: disable=too-many-nested-blocks
         for item in obslist:

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -1114,7 +1114,7 @@ def filter_and_aggregate_vectors(
 @CACHE.memoize(timeout=CACHE.TIMEOUT)
 def get_nodes(groupby: str, fipdesc: pd.DataFrame, fip: str, filters: dict) -> dict:
     df = fipdesc[fipdesc["FIP"] == fip]
-    nodes: dict = dict()
+    nodes: dict = {}
     for node, dfn in df.groupby("NODE"):
         node_inc = True
         node_subgroups = []


### PR DESCRIPTION
Adding exception for encoding in pylint. Investigate further whether `utf-8` should be enforced (separate issue #740 )

---

### Contributor checklist

- [X] :tada: This PR closes #738 .