### PR TITLE
Filter on OK in `ensemble_table_provider_factory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#717](https://github.com/equinor/webviz-subsurface/pull/717) - Keep zoom state in `ReservoirSimulationTimeseries` (inc `Regional` and `OneByOne`) and `RelativePermeability` plugins using `uirevision`.
 - [#707](https://github.com/equinor/webviz-subsurface/pull/707) - Generalized and improved some plot functions in  `PropertyStatistics`, `ParameterAnalysis` and `VolumetricAnalysis`. Replaced histogram with distribution plot in `PropertyStatistics`.
 
+### Fixed
+- [#747](https://github.com/equinor/webviz-subsurface/pull/747) - Added missing realization filter on `OK` file in `EnsembleTableProviderFactory`.
+
 ## [0.2.4] - 2021-07-13
 
 ### Added

--- a/webviz_subsurface/_providers/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider_factory.py
@@ -318,7 +318,7 @@ class EnsembleTableProviderFactory(WebvizFactory):
         if key in self._scratch_ensemble_cache:
             return pickle.loads(self._scratch_ensemble_cache[key])  # nosec
 
-        scratch_ensemble = ScratchEnsemble(ens_name, ens_path)
+        scratch_ensemble = ScratchEnsemble(ens_name, ens_path).filter("OK")
         self._scratch_ensemble_cache[key] = pickle.dumps(
             scratch_ensemble, pickle.HIGHEST_PROTOCOL
         )


### PR DESCRIPTION
We should agree on how far out in the factory code the filter option should be exposed. 
Right now, I added to only the innermost function wrapping the call to `ScratchEnsemble` and then defaulting the filter to `OK`, but could maybe be use cases where the filter is not wanted, and where the option of no filter (by setting `filter_file = None` ) is useful?

---

### Contributor checklist

- [X] :tada: This PR closes #745 .
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
