### PR TITLE
Store `xtgeo.RegularSurface` as bytestream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#755](https://github.com/equinor/webviz-subsurface/pull/755) - Updated existing and added new tests for the Drogon dataset.
 
+### Changed
+- [#761](https://github.com/equinor/webviz-subsurface/pull/761) - Store `xtgeo.RegularSurface` as bytestream instead of serializing to `json`.
+
 ## [0.2.5] - 2021-09-03
 ### Added
 - [#733](https://github.com/equinor/webviz-subsurface/pull/733) - Added plugin to visualize well logs from files using [videx-welllog](https://github.com/equinor/videx-wellog).


### PR DESCRIPTION
Store xtgeo.RegularSurface as bytestream instead of serializing to json for increased performance.

Note that older portable applications will not work with this change.