### PR TITLE
Support eclipse volumes in `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Added
+- [#770](https://github.com/equinor/webviz-subsurface/pull/770) - Added support for dynamic volumetric files in `VolumetricAnalysis` and possibility of combining static and dynamic volumes on a comparable level. To trigger this behaviour a fipfile with `FIPNUM` to `REGION/ZONE` mapping information needs to be provided. Also added support for giving multiple files as input per source.
 - [#755](https://github.com/equinor/webviz-subsurface/pull/755) - Updated existing and added new tests for the Drogon dataset.
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         "defusedxml>=0.6.0",
         "ecl2df>=0.13.0; sys_platform=='linux'",
         "fmu-ensemble>=1.2.3",
+        "fmu-tools>=1.8",
         "opm>=2020.10.1; sys_platform=='linux'",
         "pandas>=1.1.5",
         "pillow>=6.1",

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/distribution_main_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/distribution_main_layout.py
@@ -115,15 +115,19 @@ def one_plot_one_table_layout(uuid: str) -> html.Div:
 def plots_per_zone_region_layout(
     uuid: str, volumemodel: InplaceVolumesModel
 ) -> html.Div:
-    selectors = [x for x in ["ZONE", "REGION", "FACIES"] if x in volumemodel.selectors]
-    height = max(88 / len(selectors), 25)
+    selectors = [
+        x
+        for x in ["ZONE", "REGION", "FACIES", "FIPNUM", "SET"]
+        if x in volumemodel.selectors
+    ]
+    height = "42vh" if len(selectors) < 3 else "25vh"
     layout = []
     for selector in selectors:
         layout.append(
             wcc.Frame(
                 color="white",
                 highlight=False,
-                style={"height": f"{height}vh"},
+                style={"height": height},
                 children=wcc.FlexBox(
                     children=[
                         html.Div(
@@ -136,7 +140,7 @@ def plots_per_zone_region_layout(
                                     "page": "per_zr",
                                 },
                                 config={"displayModeBar": False},
-                                style={"height": f"{height}vh"},
+                                style={"height": height},
                             ),
                         ),
                         html.Div(
@@ -149,7 +153,7 @@ def plots_per_zone_region_layout(
                                     "page": "per_zr",
                                 },
                                 config={"displayModeBar": False},
-                                style={"height": f"{height}vh"},
+                                style={"height": height},
                             ),
                         ),
                     ]

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
@@ -11,9 +11,12 @@ def selections_layout(
     theme: WebvizConfigTheme,
     tab: str,
 ) -> html.Div:
-    """Layout for selecting intersection data"""
     selectors = "/".join(
-        [x.lower() for x in ["ZONE", "REGION", "FACIES"] if x in volumemodel.selectors]
+        [
+            x.lower()
+            for x in ["ZONE", "REGION", "FACIES", "FIPNUM", "SET"]
+            if x in volumemodel.selectors
+        ]
     )
     return html.Div(
         children=[
@@ -29,7 +32,7 @@ def selections_layout(
                 ],
             ),
             plot_selections_layout(uuid, volumemodel, tab),
-            settings_layout(uuid, theme, tab),
+            settings_layout(volumemodel, uuid, theme, tab),
         ]
     )
 
@@ -145,14 +148,16 @@ def plot_selector_dropdowns(
     return dropdowns
 
 
-def settings_layout(uuid: str, theme: WebvizConfigTheme, tab: str) -> wcc.Selectors:
+def settings_layout(
+    volumemodel: InplaceVolumesModel, uuid: str, theme: WebvizConfigTheme, tab: str
+) -> wcc.Selectors:
 
     theme_colors = theme.plotly_theme.get("layout", {}).get("colorway", [])
     return wcc.Selectors(
         label="⚙️ SETTINGS",
         open_details=False,
         children=[
-            remove_fluid_annotation(uuid=uuid, tab=tab),
+            remove_fluid_annotation(volumemodel, uuid=uuid, tab=tab),
             subplot_xaxis_range(uuid=uuid, tab=tab),
             histogram_options(uuid=uuid, tab=tab),
             html.Span("Colors", style={"font-weight": "bold"}),
@@ -197,13 +202,18 @@ def table_sync_option(uuid: str, tab: str) -> html.Div:
     )
 
 
-def remove_fluid_annotation(uuid: str, tab: str) -> html.Div:
+def remove_fluid_annotation(
+    volumemodel: InplaceVolumesModel, uuid: str, tab: str
+) -> html.Div:
     return html.Div(
-        style={"margin-bottom": "10px"},
+        style={
+            "margin-bottom": "10px",
+            "display": "none" if volumemodel.volume_type == "dynamic" else "block",
+        },
         children=wcc.Checklist(
             id={"id": uuid, "tab": tab, "selector": "Fluid annotation"},
             options=[{"label": "Show fluid annotation", "value": "Show"}],
-            value=["Show"],
+            value=["Show"] if volumemodel.volume_type != "dynamic" else [],
         ),
     )
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
@@ -1,0 +1,190 @@
+from typing import List, Dict
+from pathlib import Path
+import warnings
+import pandas as pd
+from fmu.tools.fipmapper import fipmapper
+
+
+class VolumeValidatorAndCombinator:
+    """
+    Class to validate volumetric dataframes based on their type (static/dynamic),
+    and to ensure correct format of combined volumetric dataframe before initialization
+    of an InplaceVolumesModel instance. A best guess of each source's volume are made based
+    on available columns. Only common columns between the different volumetric sources are kept.
+
+    If the input contains both dynamic and static sources and a fipfile with FIPNUM to
+    REGION∕ZONE mapping information is provided, the FipMapper from fmu.tools are utilized to
+    create sets that are comparable in volumes. The volumes in the reulting dataframe will be
+    combined per set. Only region selectors FIPNUM/REGION∕ZONE which are unique whithin each set
+    are kept in the resulting dataframe, if none meets the criteria SET is used.
+
+    Static dataframes must follow a strict format to fit the data processing steps of the
+    InplaceVolumesModel instance. If custom columns found the source is set as dynamic to
+    avoid this processing.
+    Dynamic dataframes must contain a FIPNUM column but custom columns are allowed.
+    """
+
+    ENSEMBLE_COLUMNS = ["ENSEMBLE", "REAL", "SOURCE"]
+    VALID_STATIC_SELECTORS = ["ZONE", "REGION", "FACIES", "LICENSE"]
+    VALID_STATIC_RESPONSES = [
+        "BULK",
+        "NET",
+        "PORV",
+        "HCPV",
+        "GIIP",
+        "STOIIP",
+        "ASSOCIATEDOIL",
+        "ASSOCIATEDGAS",
+    ]
+    FLUID_TYPES = ["TOTAL", "GAS", "OIL"]
+
+    def __init__(self, volumes_table: pd.DataFrame, fipfile: Path = None):
+
+        self.volume_sources: Dict[str, List[str]] = {
+            "static": [],
+            "dynamic": [],
+            "unknown": [],
+        }
+        self.disjoint_set_df = (
+            fipmapper.FipMapper(yamlfile=fipfile).disjoint_sets() if fipfile else None
+        )
+        self.dframe = self.validate_and_combine_sources(volumes_table)
+        self.volume_type = self.set_volumetric_type()
+
+    @property
+    def possible_static_columns(self) -> list:
+        possible_static_columns = self.VALID_STATIC_SELECTORS + self.ENSEMBLE_COLUMNS
+        for fluid in self.FLUID_TYPES:
+            possible_static_columns.extend(
+                [f"{col}_{fluid}" for col in self.VALID_STATIC_RESPONSES]
+            )
+        return possible_static_columns
+
+    def pore_to_porv_mapping(self, dframe: pd.DataFrame) -> pd.DataFrame:
+        """Rename PORE columns to PORV (PORE will be deprecated..)"""
+        return dframe.rename(
+            columns={f"PORE_{fluid}": f"PORV_{fluid}" for fluid in self.FLUID_TYPES},
+            errors="ignore",
+        )
+
+    def validate_and_combine_sources(self, volumes_table: pd.DataFrame) -> pd.DataFrame:
+        """
+        Validate columns for each volumetric source and combine them. Only common columns
+        are kept. If a fipfile is provided volumes are summed per disjoint_set.
+        """
+        dfs = []
+        all_columns = set()
+        for source, voldf in volumes_table.groupby("SOURCE"):
+            voldf = voldf.dropna(axis=1, how="all")
+            voldf = self.pore_to_porv_mapping(voldf)
+            volume_type = self.find_volume_type(voldf.columns, source)
+            self.volume_sources[volume_type].append(source)
+            all_columns.update(voldf.columns)
+            dfs.append(voldf)
+
+        dframe = (
+            pd.concat(dfs, join="inner", ignore_index=True)
+            if self.disjoint_set_df is None
+            else self.create_set_dframe(volume_dfs=dfs)
+        )
+
+        missing_columns = [col for col in all_columns if col not in dframe]
+        if missing_columns:
+            warnings.warn(
+                f"Skipping volumetric columns: {missing_columns} as they are not present in all "
+                "volumetric sources"
+            )
+        return dframe
+
+    def set_volumetric_type(self) -> str:
+        """Return volumetric type based on available volume sources"""
+        if self.volume_sources["static"] and (
+            self.volume_sources["dynamic"] or self.volume_sources["unknown"]
+        ):
+            if self.volume_sources["dynamic"] and self.disjoint_set_df is None:
+                raise ValueError(
+                    "A fipfile must be provided to map FIPNUMS to REGION/ZONE when both static "
+                    "and dynamic volume sources are given as input. "
+                    f"Static sources: {self.volume_sources['static']} "
+                    f"Dynamic sources: {self.volume_sources['dynamic']}"
+                )
+            return "mixed"
+        return "static" if self.volume_sources["static"] else "dynamic"
+
+    def find_volume_type(self, columns: list, source: str) -> str:
+        """Return volume type (stativ/dynamic) based on columns and validate"""
+        static_selectors_present = any(
+            col in self.VALID_STATIC_SELECTORS for col in columns
+        )
+        non_static_columns = [
+            col for col in columns if col not in self.possible_static_columns
+        ]
+        # Guess volume type based on columns
+        if "FIPNUM" in columns:
+            return "dynamic"
+
+        if not non_static_columns:
+            if not static_selectors_present:
+                raise ValueError(
+                    f"Static volume source {source} provided with no valid selectors. "
+                    f"One of {self.VALID_STATIC_SELECTORS} must be provided."
+                )
+            return "static"
+
+        if static_selectors_present:
+            warnings.warn(
+                f"The volumetric source {source} is considered a dynamic source due "
+                f"to the presence of columns: {non_static_columns}. "
+                "If this is a static source remove these columns from the input to "
+                "trigger correct plugin mode."
+            )
+            return "unknown"
+
+        raise ValueError(
+            f"Volume source {source} provided with no valid selectors. "
+            f"One of {self.VALID_STATIC_SELECTORS + ['FIPNUM']} must be provided."
+        )
+
+    def create_set_dframe(self, volume_dfs: List[pd.DataFrame]) -> pd.DataFrame:
+        """Sum Eclipse and RMS volumetrics over the common disjoints sets."""
+        region_selectors = self.find_region_selectors()
+        set_data_list = []
+        for set_idx, df in self.disjoint_set_df.groupby(["SET"]):
+            for voldf in volume_dfs:
+                source = voldf["SOURCE"].unique()[0]
+                if "FIPNUM" in voldf.columns:
+                    filtered_df = voldf[voldf["FIPNUM"].isin(df["FIPNUM"].unique())]
+                elif "ZONE" in voldf.columns and "REGION" in voldf.columns:
+                    filtered_df = voldf[
+                        (voldf["REGION"].isin(df["REGION"].unique()))
+                        & (voldf["ZONE"].isin(df["ZONE"].unique()))
+                    ]
+                else:
+                    raise ValueError(
+                        f"Fipfile is provided but volumetric source {source} is missing "
+                        "ZONE/REGION or FIPNUM definition."
+                    )
+                set_df = (
+                    filtered_df.groupby(["ENSEMBLE", "REAL"])
+                    .sum()
+                    .reset_index()
+                    .drop(labels=["FIPNUM", "REGION", "ZONE"], errors="ignore")
+                )
+                for col in region_selectors:
+                    set_df[col] = df[col].iloc[0] if col != "SET" else set_idx
+                set_df["SOURCE"] = source
+                set_data_list.append(set_df)
+
+        dframe = pd.concat(set_data_list, join="inner", ignore_index=True)
+        if "FIPNUM" in dframe:
+            dframe = dframe.sort_values(by=["FIPNUM"])
+        return dframe
+
+    def find_region_selectors(self) -> list:
+        """Return region selectors that has a unique value
+        per set. If none is found SET is used"""
+        df = self.disjoint_set_df.groupby(["SET"]).nunique()
+        regcols = ["FIPNUM", "REGION", "ZONE"]
+        if any((df[x] == 1).all() for x in regcols):
+            return [x for x in regcols if (df[x] == 1).all()]
+        return ["SET"]


### PR DESCRIPTION
Up until now the VolumetricAnalysis plugin has only supported static input. This PR fixes that issue.


The PR includes:

- Automatic detection of what fluid_type the different volumetric files are (static vs dynamic)
  - if only dynamic files are given as input, no processing is performed in the InplaceVolumesModel (e.g. removal of column fluid suffixes and computation of properties from the volumetric data)
- Validation of the static volume files as they must fit a strict format to be fit for the input processing done in the InplaceVolumesModel.
- Utilization of the FipMapper from fmu.tools for creating sets of FIPNUM's and REGION∕ZONE's that are comparable
in volumes, and combining volumes per set. To trigger this behaviour a fipfile with FIPNUM to REGION∕ZONE mapping information needs to be provided.

Also included in the PR:
- Support for giving more than one csv as input to the different volumetric sources (files under each source are merged on common columns). 
```yaml
volfiles:
    geogrid:
        - geogrid_oil.csv
        - geogrid_gas.csv
```

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
