### PR TITLE
Added region/zone vs fipnum filter switch in `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 ### Added
 - [#709](https://github.com/equinor/webviz-subsurface/pull/709) - Added `VectorCalculator` component in `ReservoirSimulationTimeSeries` plugin for calculation and graphing of custom simulation time series vectors.
+- [#773](https://github.com/equinor/webviz-subsurface/pull/773) - `VolumetricAnalysis` - added functionality of easy switching bewteen `FIPNUM` and `REGION/ZONE` filter for cases where each fipnum belongs to a unique region and zone.
 - [#770](https://github.com/equinor/webviz-subsurface/pull/770) - Added support for dynamic volumetric files in `VolumetricAnalysis` and possibility of combining static and dynamic volumes on a comparable level. To trigger this behaviour a fipfile with `FIPNUM` to `REGION/ZONE` mapping information needs to be provided. Also added support for giving multiple files as input per source.
 - [#755](https://github.com/equinor/webviz-subsurface/pull/755) - Updated existing and added new tests for the Drogon dataset.
 

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -151,6 +151,14 @@ class InplaceVolumesModel:
         return [x for x in self.POSSIBLE_SELECTORS if x in self._dataframe]
 
     @property
+    def region_selectors(self) -> List[str]:
+        return [
+            x
+            for x in ["FIPNUM", "ZONE", "REGION", "SET", "LICENSE"]
+            if x in self.selectors
+        ]
+
+    @property
     def responses(self) -> List[str]:
         return self.volume_columns + self.property_columns
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -7,14 +7,17 @@ from webviz_subsurface._models import InplaceVolumesModel
 from ..utils.utils import create_range_string, update_relevant_components
 
 
-# pylint: disable=too-many-statements, too-many-locals, too-many-arguments
+# pylint: disable=too-many-statements,too-many-arguments
 def selections_controllers(
     app: Dash, get_uuid: Callable, volumemodel: InplaceVolumesModel
 ) -> None:
     @app.callback(
         Output(get_uuid("selections"), "data"),
         Input({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "value"),
-        Input({"id": get_uuid("filters"), "tab": ALL, "selector": ALL}, "value"),
+        Input(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": ALL},
+            "value",
+        ),
         Input(
             {"id": get_uuid("selections"), "tab": "voldist", "settings": "Colorscale"},
             "colorscale",
@@ -24,7 +27,9 @@ def selections_controllers(
         State(get_uuid("selections"), "data"),
         State(get_uuid("initial-load-info"), "data"),
         State({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "id"),
-        State({"id": get_uuid("filters"), "tab": ALL, "selector": ALL}, "id"),
+        State(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": ALL}, "id"
+        ),
     )
     def _update_selections(
         selectors: list,
@@ -217,33 +222,39 @@ def selections_controllers(
         )
 
     @app.callback(
-        Output({"id": get_uuid("filters"), "tab": ALL, "selector": ALL}, "multi"),
-        Output({"id": get_uuid("filters"), "tab": ALL, "selector": ALL}, "value"),
         Output(
-            {"id": get_uuid("filters"), "tab": ALL, "element": "real_text"}, "children"
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "undef"},
+            "multi",
+        ),
+        Output(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "undef"},
+            "value",
         ),
         Input(get_uuid("page-selected"), "data"),
         Input({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "value"),
-        Input({"id": get_uuid("filters"), "tab": ALL, "component_type": ALL}, "value"),
         State({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "id"),
         State(get_uuid("tabs"), "value"),
-        State({"id": get_uuid("filters"), "tab": ALL, "selector": ALL}, "options"),
-        State({"id": get_uuid("filters"), "tab": ALL, "selector": ALL}, "multi"),
-        State({"id": get_uuid("filters"), "tab": ALL, "selector": ALL}, "id"),
-        State({"id": get_uuid("filters"), "tab": ALL, "component_type": ALL}, "id"),
-        State({"id": get_uuid("filters"), "tab": ALL, "element": "real_text"}, "id"),
+        State(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "undef"},
+            "options",
+        ),
+        State(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "undef"},
+            "multi",
+        ),
+        State(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "undef"},
+            "id",
+        ),
     )
     def _update_filter_options(
         _selected_page: str,
         selectors: list,
-        reals: list,
         selector_ids: list,
         selected_tab: str,
         filter_options: list,
         filter_multi: list,
         filter_ids: list,
-        reals_ids: list,
-        real_string_ids: list,
     ) -> tuple:
 
         page_selections = {
@@ -289,18 +300,6 @@ def selections_controllers(
                 ]
             }
 
-        # realization
-        index = [x["tab"] for x in reals_ids].index(selected_tab)
-        real_list = [int(real) for real in reals[index]]
-
-        if reals_ids[index]["component_type"] == "range":
-            real_list = list(range(real_list[0], real_list[1] + 1))
-            text = f"{real_list[0]}-{real_list[-1]}"
-        else:
-            text = create_range_string(real_list)
-
-        output["REAL"] = {"values": real_list}
-
         return (
             update_relevant_components(
                 id_list=filter_ids,
@@ -320,6 +319,50 @@ def selections_controllers(
                         "conditions": {"tab": selected_tab, "selector": selector},
                     }
                     for selector, values in output.items()
+                ],
+            ),
+        )
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "REAL"},
+            "value",
+        ),
+        Output(
+            {"id": get_uuid("filters"), "tab": ALL, "element": "real_text"}, "children"
+        ),
+        Input({"id": get_uuid("filters"), "tab": ALL, "component_type": ALL}, "value"),
+        State(get_uuid("tabs"), "value"),
+        State({"id": get_uuid("filters"), "tab": ALL, "component_type": ALL}, "id"),
+        State({"id": get_uuid("filters"), "tab": ALL, "element": "real_text"}, "id"),
+        State(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "REAL"},
+            "id",
+        ),
+    )
+    def _update_realization_filter_and_text(
+        reals: list,
+        selected_tab: str,
+        reals_ids: list,
+        real_string_ids: list,
+        real_filter_id: list,
+    ) -> tuple:
+        """Callback that updates the selected relization info and text"""
+
+        index = [x["tab"] for x in reals_ids].index(selected_tab)
+        real_list = [int(real) for real in reals[index]]
+
+        if reals_ids[index]["component_type"] == "range":
+            real_list = list(range(real_list[0], real_list[1] + 1))
+            text = f"{real_list[0]}-{real_list[-1]}"
+        else:
+            text = create_range_string(real_list)
+
+        return (
+            update_relevant_components(
+                id_list=real_filter_id,
+                update_info=[
+                    {"new_value": real_list, "conditions": {"tab": selected_tab}}
                 ],
             ),
             update_relevant_components(
@@ -379,61 +422,40 @@ def selections_controllers(
             if selections is not None and selected_page in selections
             else None
         )
-
-        page_value = [
+        selected_component = [
             value
             for id_value, value in zip(input_ids, input_selectors)
             if id_value["tab"] == selected_tab
-        ]
+        ][0]
+        selected_reals = prev_selection if prev_selection is not None else reals
 
-        if page_value[0] == "range":
-            min_value = (
-                min(prev_selection) if prev_selection is not None else min(reals)
+        component = (
+            wcc.RangeSlider(
+                id={
+                    "id": get_uuid("filters"),
+                    "tab": selected_tab,
+                    "component_type": selected_component,
+                },
+                value=[min(selected_reals), max(selected_reals)],
+                min=min(reals),
+                max=max(reals),
+                marks={str(i): {"label": str(i)} for i in [min(reals), max(reals)]},
             )
-            max_value = (
-                max(prev_selection) if prev_selection is not None else max(reals)
+            if selected_component == "range"
+            else wcc.SelectWithLabel(
+                id={
+                    "id": get_uuid("filters"),
+                    "tab": selected_tab,
+                    "component_type": selected_component,
+                },
+                options=[{"label": i, "value": i} for i in reals],
+                value=selected_reals,
+                size=min(20, len(reals)),
             )
-            return update_relevant_components(
-                id_list=wrapper_ids,
-                update_info=[
-                    {
-                        "new_value": wcc.RangeSlider(
-                            id={
-                                "id": get_uuid("filters"),
-                                "tab": selected_tab,
-                                "component_type": page_value[0],
-                            },
-                            value=[min_value, max_value],
-                            min=min(reals),
-                            max=max(reals),
-                            marks={
-                                str(i): {"label": str(i)}
-                                for i in [min(reals), max(reals)]
-                            },
-                        ),
-                        "conditions": {"tab": selected_tab},
-                    }
-                ],
-            )
-
-        # if input_selector == "select"
+        )
         return update_relevant_components(
             id_list=wrapper_ids,
-            update_info=[
-                {
-                    "new_value": wcc.SelectWithLabel(
-                        id={
-                            "id": get_uuid("filters"),
-                            "tab": selected_tab,
-                            "component_type": page_value[0],
-                        },
-                        options=[{"label": i, "value": i} for i in reals],
-                        value=prev_selection if prev_selection is not None else reals,
-                        size=min(20, len(reals)),
-                    ),
-                    "conditions": {"tab": selected_tab},
-                }
-            ],
+            update_info=[{"new_value": component, "conditions": {"tab": selected_tab}}],
         )
 
     @app.callback(
@@ -487,4 +509,100 @@ def selections_controllers(
                 ],
             )
             for prop in ["options", "value", "disabled"]
+        )
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "region"},
+            "value",
+        ),
+        Output(
+            {"id": get_uuid("filters"), "wrapper": ALL, "tab": ALL, "type": "region"},
+            "style",
+        ),
+        Input(
+            {"id": get_uuid("filters"), "tab": ALL, "element": "region-selector"},
+            "value",
+        ),
+        State(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": "region"},
+            "id",
+        ),
+        State(get_uuid("tabs"), "value"),
+        State(get_uuid("page-selected"), "data"),
+        State(get_uuid("selections"), "data"),
+        State(
+            {"id": get_uuid("filters"), "wrapper": ALL, "tab": ALL, "type": "region"},
+            "id",
+        ),
+        State(
+            {"id": get_uuid("filters"), "tab": ALL, "element": "region-selector"},
+            "id",
+        ),
+        prevent_initial_call=True,
+    )
+    def update_region_filters(
+        selected_reg_filter: list,
+        reg_filter_ids: list,
+        selected_tab: str,
+        selected_page: str,
+        selections: dict,
+        wrapper_ids: list,
+        reg_select_ids: list,
+    ) -> tuple:
+        """
+        Callback to update the visible region filter between FIPNUM or ZONE/REGION.
+        When changing, the active selection will be used to set the new selection.
+        Note this callback will only be used for cases where each FIPNUM belongs to
+        a unique ZONE and REGION.
+        """
+        selected = [
+            value
+            for id_value, value in zip(reg_select_ids, selected_reg_filter)
+            if id_value["tab"] == selected_tab
+        ]
+
+        df = volumemodel.dataframe
+        filters = selections[selected_page]["filters"]
+
+        values = {}
+        if selected[0] != "fipnum":
+            values["FIPNUM"] = df["FIPNUM"].unique()
+            for elm in ["REGION", "ZONE"]:
+                values[elm] = df.loc[df["FIPNUM"].isin(filters["FIPNUM"])][elm].unique()
+
+        else:
+            values["REGION"] = df["REGION"].unique()
+            values["ZONE"] = df["ZONE"].unique()
+            mask = (df["REGION"].isin(filters["REGION"])) & (
+                df["ZONE"].isin(filters["ZONE"])
+            )
+            values["FIPNUM"] = df.loc[mask]["FIPNUM"].unique()
+
+        styles = {}
+        styles["FIPNUM"] = {"display": "none" if selected[0] != "fipnum" else "block"}
+        styles["REGION"] = {"display": "none" if selected[0] == "fipnum" else "block"}
+        styles["ZONE"] = {"display": "none" if selected[0] == "fipnum" else "block"}
+
+        return (
+            update_relevant_components(
+                id_list=reg_filter_ids,
+                update_info=[
+                    {
+                        "new_value": value,
+                        "conditions": {"selector": selector, "tab": selected_tab},
+                    }
+                    for selector, value in values.items()
+                ],
+            ),
+            update_relevant_components(
+                id_list=wrapper_ids,
+                update_info=[
+                    {
+                        "new_value": style,
+                        "conditions": {"wrapper": selector, "tab": selected_tab},
+                    }
+                    for selector, style in styles.items()
+                ],
+            ),
         )

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/filter_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/filter_view.py
@@ -10,7 +10,7 @@ def filter_layout(
     tab: str,
     volumemodel: InplaceVolumesModel,
     open_details: bool = True,
-    filters: Optional[list] = None,
+    hide_selectors: Optional[list] = None,
 ) -> wcc.Selectors:
     """Layout for selecting intersection data"""
     return wcc.Selectors(
@@ -18,7 +18,10 @@ def filter_layout(
         open_details=open_details,
         children=[
             filter_dropdowns(
-                uuid=uuid, tab=tab, volumemodel=volumemodel, filters=filters
+                uuid=uuid,
+                tab=tab,
+                volumemodel=volumemodel,
+                hide_selectors=hide_selectors,
             ),
             realization_filters(uuid=uuid, tab=tab, volumemodel=volumemodel),
         ],
@@ -29,30 +32,75 @@ def filter_dropdowns(
     uuid: str,
     volumemodel: InplaceVolumesModel,
     tab: str,
-    filters: Optional[list] = None,
+    hide_selectors: Optional[list] = None,
 ) -> html.Div:
     """Makes dropdowns for each selector"""
-    dropdowns: List[html.Div] = []
-    filters = filters if filters is not None else volumemodel.selectors
-    for selector in filters:
-        if selector == "REAL":
-            continue
-        elements = list(volumemodel.dataframe[selector].unique())
-
-        dropdowns.append(
-            html.Div(
-                style={"display": "inline" if len(elements) > 1 else "none"},
-                children=wcc.SelectWithLabel(
-                    label=selector.lower().capitalize(),
-                    id={"id": uuid, "tab": tab, "selector": selector},
-                    options=[{"label": i, "value": i} for i in elements],
-                    value=elements,
-                    multi=True,
-                    size=min(15, len(elements)),
-                ),
+    dropdowns_layout: List[html.Div] = []
+    hide_selectors = hide_selectors if hide_selectors is not None else []
+    selectors = [
+        x
+        for x in volumemodel.selectors
+        if x not in volumemodel.region_selectors + ["REAL"]
+    ]
+    for selector in selectors:
+        dropdowns_layout.append(
+            create_filter_select(
+                selector,
+                elements=list(volumemodel.dataframe[selector].unique()),
+                filter_type="undef",
+                uuid=uuid,
+                tab=tab,
+                hide=selector in hide_selectors,
             )
         )
-    return html.Div(dropdowns)
+    # Make region filters
+    dropdowns_layout.append(
+        html.Span("Region filters: ", style={"font-weight": "bold"})
+    )
+    if all(x in volumemodel.region_selectors for x in ["FIPNUM", "ZONE", "REGION"]):
+        dropdowns_layout.append(fipnum_vs_zone_region_switch(uuid, tab))
+
+    for selector in volumemodel.region_selectors:
+        dropdowns_layout.append(
+            create_filter_select(
+                selector,
+                elements=list(volumemodel.dataframe[selector].unique()),
+                filter_type="region",
+                uuid=uuid,
+                tab=tab,
+                hide=selector == "FIPNUM" and len(volumemodel.region_selectors) > 1,
+            )
+        )
+    return html.Div(dropdowns_layout)
+
+
+def create_filter_select(
+    selector: str, elements: list, uuid: str, tab: str, filter_type: str, hide: bool
+) -> html.Div:
+    return html.Div(
+        id={"id": uuid, "tab": tab, "wrapper": selector, "type": filter_type},
+        style={"display": "inline" if len(elements) > 1 and not hide else "none"},
+        children=wcc.SelectWithLabel(
+            label=selector.lower().capitalize(),
+            id={"id": uuid, "tab": tab, "selector": selector, "type": filter_type},
+            options=[{"label": i, "value": i} for i in elements],
+            value=elements,
+            multi=True,
+            size=min(15, len(elements)),
+        ),
+    )
+
+
+def fipnum_vs_zone_region_switch(uuid: str, tab: str) -> wcc.RadioItems:
+    return wcc.RadioItems(
+        id={"id": uuid, "tab": tab, "element": "region-selector"},
+        options=[
+            {"label": "Region∕Zone", "value": "regzone"},
+            {"label": "Fipnum", "value": "fipnum"},
+        ],
+        value="regzone",
+        vertical=False,
+    )
 
 
 def realization_filters(
@@ -100,7 +148,7 @@ def realization_filters(
             html.Div(
                 style={"display": "none"},
                 children=wcc.Select(
-                    id={"id": uuid, "tab": tab, "selector": "REAL"},
+                    id={"id": uuid, "tab": tab, "selector": "REAL", "type": "REAL"},
                     options=[{"label": i, "value": i} for i in reals],
                     value=reals,
                 ),

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -31,15 +31,13 @@ def main_view(
                         tab="voldist",
                         volumemodel=volumemodel,
                         theme=theme,
-                    )
-                ]
-                + [
+                    ),
                     filter_layout(
                         uuid=get_uuid("filters"),
                         tab="voldist",
                         volumemodel=volumemodel,
-                        filters=[x for x in volumemodel.selectors if x != "SENSTYPE"],
-                    )
+                        hide_selectors=["SENSTYPE"],
+                    ),
                 ],
             ),
         )
@@ -57,14 +55,13 @@ def main_view(
                         uuid=get_uuid("selections"),
                         tab="table",
                         volumemodel=volumemodel,
-                    )
-                ]
-                + [
+                    ),
                     filter_layout(
                         open_details=True,
                         uuid=get_uuid("filters"),
                         tab="table",
                         volumemodel=volumemodel,
+                        hide_selectors=["SENSTYPE"],
                     ),
                 ],
             ),
@@ -84,25 +81,13 @@ def main_view(
                             uuid=get_uuid("selections"),
                             tab="tornado",
                             volumemodel=volumemodel,
-                        )
-                    ]
-                    + [
+                        ),
                         filter_layout(
                             open_details=True,
                             uuid=get_uuid("filters"),
                             tab="tornado",
                             volumemodel=volumemodel,
-                            filters=[
-                                x
-                                for x in volumemodel.selectors
-                                if x
-                                not in [
-                                    "SENSCASE",
-                                    "SENSNAME",
-                                    "SENSTYPE",
-                                    "REAL",
-                                ]
-                            ],
+                            hide_selectors=["SENSCASE", "SENSNAME", "SENSTYPE"],
                         ),
                     ],
                 ),


### PR DESCRIPTION
PR which adds functionality of easy switching between `fipnum` or `region/zone` as filter if all three selectors are present in `VolumetricAnalysis` (this occurs in cases where each fipnum value belongs to an unique region and zone). 
- When the user switches between a fipnum or a region/zone filter, the current filter selection is used to set the new selection e.g. when a fipnum selection is made and the user switches to a region/zone filter the zones and regions containing those fipnums are selected.


| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/61694854/134050837-2ad268e4-b70e-4867-bebf-2b834ff39696.png)  | ![image](https://user-images.githubusercontent.com/61694854/134051342-43a9f751-f1dd-4657-8a75-274ea13523d4.png) |

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
