### PR TITLE
Added source and ensemble comparison to `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Added
+- [#777](https://github.com/equinor/webviz-subsurface/pull/777) - `VolumetricAnalysis` - added tabs with `Source comparison` and `Ensemble comparison` as QC tools for quick identification of where and why volumetric changes occur across sources (e.g. static vs dynamic) or ensembles (e.g. model revisions or ahm iterations).
 - [#709](https://github.com/equinor/webviz-subsurface/pull/709) - Added `VectorCalculator` component in `ReservoirSimulationTimeSeries` plugin for calculation and graphing of custom simulation time series vectors.
 - [#773](https://github.com/equinor/webviz-subsurface/pull/773) - `VolumetricAnalysis` - added functionality of easy switching bewteen `FIPNUM` and `REGION/ZONE` filter for cases where each fipnum belongs to a unique region and zone.
 - [#770](https://github.com/equinor/webviz-subsurface/pull/770) - Added support for dynamic volumetric files in `VolumetricAnalysis` and possibility of combining static and dynamic volumes on a comparable level. To trigger this behaviour a fipfile with `FIPNUM` to `REGION/ZONE` mapping information needs to be provided. Also added support for giving multiple files as input per source.

--- a/webviz_subsurface/_figures/px_figure.py
+++ b/webviz_subsurface/_figures/px_figure.py
@@ -72,7 +72,9 @@ def update_xaxes(figure: go.Figure, plot_type: str, **kwargs: Any) -> go.Figure:
         linewidth=2,
         linecolor="black",
         mirror=True,
-        title=None if facet_col is not None else kwargs.get("x"),
+        title=None
+        if facet_col is not None or not isinstance(kwargs.get("x"), str)
+        else kwargs.get("x"),
         showticklabels=(data_frame[facet_col].nunique() <= 100)
         if facet_col is not None
         else None,

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -205,7 +205,7 @@ class InplaceVolumesModel:
         if all(col in self._dataframe for col in ["BULK", "PORV"]):
             self._property_columns.append("PORO")
         if all(col in self._dataframe for col in ["NET", "PORV"]):
-            self._property_columns.append("PORO (net)")
+            self._property_columns.append("PORO_NET")
         if all(col in self._dataframe for col in ["HCPV", "PORV"]):
             self._property_columns.append("SW")
 
@@ -226,7 +226,7 @@ class InplaceVolumesModel:
             dframe["NTG"] = dframe["NET"] / dframe["BULK"]
         if "PORO" in properties:
             if "NET" in dframe.columns:
-                dframe["PORO (net)"] = dframe["PORV"] / dframe["NET"]
+                dframe["PORO_NET"] = dframe["PORV"] / dframe["NET"]
             dframe["PORO"] = dframe["PORV"] / dframe["BULK"]
         if "SW" in properties:
             dframe["SW"] = 1 - (dframe["HCPV"] / dframe["PORV"])

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/__init__.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/__init__.py
@@ -2,3 +2,4 @@ from .distribution_controllers import distribution_controllers
 from .selections_controllers import selections_controllers
 from .layout_controllers import layout_controllers
 from .export_data_controllers import export_data_controllers
+from .comparison_controllers import comparison_controllers

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -1,0 +1,434 @@
+from typing import Callable, Union, Optional
+
+import numpy as np
+import pandas as pd
+from dash import html, Dash, callback_context, dash_table, Input, Output, State
+from dash.exceptions import PreventUpdate
+import plotly.express as px
+import plotly.graph_objects as go
+
+from webviz_subsurface._models import InplaceVolumesModel
+from webviz_subsurface._figures import create_figure
+from ..views.comparison_layout import (
+    comparison_qc_plots_layout,
+    comparison_table_layout,
+)
+from ..utils.table_and_figure_utils import (
+    add_correlation_line,
+    create_table_columns,
+    create_data_table,
+)
+from ..utils.utils import move_to_end_of_list
+
+# pylint: disable=too-many-locals
+def comparison_controllers(
+    app: Dash,
+    get_uuid: Callable,
+    volumemodel: InplaceVolumesModel,
+) -> None:
+    @app.callback(
+        Output({"id": get_uuid("main-src-comp"), "wrapper": "table"}, "children"),
+        Input(get_uuid("selections"), "data"),
+        Input({"id": get_uuid("main-src-comp"), "element": "display-option"}, "value"),
+        State(get_uuid("page-selected"), "data"),
+    )
+    def _update_page_src_comp(
+        selections: dict,
+        display_option: str,
+        page_selected: str,
+    ) -> html.Div:
+        ctx = callback_context.triggered[0]
+
+        if page_selected != "src-comp":
+            raise PreventUpdate
+
+        selections = selections[page_selected]
+        if not "display-option" in ctx["prop_id"]:
+            if not selections["update"]:
+                raise PreventUpdate
+
+        return comparison_callback(
+            compare_on="SOURCE",
+            volumemodel=volumemodel,
+            selections=selections,
+            display_option=display_option,
+        )
+
+    @app.callback(
+        Output({"id": get_uuid("main-ens-comp"), "wrapper": "table"}, "children"),
+        Input(get_uuid("selections"), "data"),
+        Input({"id": get_uuid("main-ens-comp"), "element": "display-option"}, "value"),
+        State(get_uuid("page-selected"), "data"),
+    )
+    def _update_page_ens_comp(
+        selections: dict,
+        display_option: str,
+        page_selected: str,
+    ) -> html.Div:
+        ctx = callback_context.triggered[0]
+
+        if page_selected != "ens-comp":
+            raise PreventUpdate
+
+        selections = selections[page_selected]
+        if not "display-option" in ctx["prop_id"]:
+            if not selections["update"]:
+                raise PreventUpdate
+
+        return comparison_callback(
+            compare_on="ENSEMBLE",
+            volumemodel=volumemodel,
+            selections=selections,
+            display_option=display_option,
+        )
+
+
+def comparison_callback(
+    compare_on: str,
+    volumemodel: InplaceVolumesModel,
+    selections: dict,
+    display_option: str,
+) -> html.Div:
+    if selections["value1"] == selections["value2"]:
+        return html.Div("Comparison between equal sources")
+
+    groupby = selections["Group by"] if selections["Group by"] is not None else []
+    hc_responses = ["STOIIP", "GIIP", "ASSOCIATEDGAS", "ASSOCIATEDOIL"]
+    # for hc responses and bo/bg the data should be grouped
+    # on fluid zone to avoid misinterpretations
+    if (
+        selections["Response"] in hc_responses + ["BO", "BG"]
+        and "FLUID_ZONE" not in groupby
+    ):
+        groupby.append("FLUID_ZONE")
+
+    if display_option == "multi-response table":
+        # select max one hc_response for a cleaner table
+        responses = [selections["Response"]] + [
+            col
+            for col in volumemodel.responses
+            if col not in hc_responses and col != selections["Response"]
+        ]
+        df = create_comparison_df(
+            volumemodel,
+            compare_on=compare_on,
+            selections=selections,
+            responses=responses,
+            abssort_on=f"{selections['Response']} diff (%)",
+            groups=groupby,
+        )
+        return comparison_table_layout(
+            table=create_comaprison_table(
+                tabletype=display_option,
+                df=df,
+                groupby=groupby,
+                selections=selections,
+                compare_on=compare_on,
+                volumemodel=volumemodel,
+            ),
+            table_type=display_option,
+            selections=selections,
+            filter_info="SOURCE" if compare_on != "SOURCE" else "ENSEMBLE",
+        )
+
+    diffdf_real = create_comparison_df(
+        volumemodel,
+        compare_on=compare_on,
+        selections=selections,
+        responses=[selections["Response"]],
+        groups=groupby + (["REAL"] if "REAL" not in groupby else []),
+        rename_diff_col=True,
+    )
+
+    if "REAL" not in groupby:
+        diffdf_group = create_comparison_df(
+            volumemodel,
+            compare_on=compare_on,
+            selections=selections,
+            responses=[selections["Response"]],
+            groups=groupby,
+            rename_diff_col=True,
+        )
+        # Add column with number of highlighted realizations
+        diffdf_group["💡 reals"] = diffdf_group.apply(
+            lambda row: find_higlighted_real_count(row, diffdf_real, groupby),
+            axis=1,
+        )
+
+    df = diffdf_group if "REAL" not in groupby else diffdf_real
+    if df.empty:
+        return html.Div("Only data with no volume present!")
+
+    if display_option == "single-response table":
+        return comparison_table_layout(
+            table=create_comaprison_table(
+                tabletype=display_option,
+                df=df,
+                groupby=groupby,
+                selections=selections,
+                use_si_format=selections["Response"] in volumemodel.volume_columns,
+                compare_on=compare_on,
+            ),
+            table_type=display_option,
+            selections=selections,
+            filter_info="SOURCE" if compare_on != "SOURCE" else "ENSEMBLE",
+        )
+
+    if display_option == "plots":
+        resp1 = f"{selections['Response']} {selections['value1']}"
+        resp2 = f"{selections['Response']} {selections['value2']}"
+
+        scatter_corr = create_scatterfig(
+            df=df, x=resp1, y=resp2, selections=selections, groupby=groupby
+        )
+        scatter_corr = add_correlation_line(
+            figure=scatter_corr, xy_min=df[resp1].min(), xy_max=df[resp1].max()
+        )
+        scatter_diff_vs_response = create_scatterfig(
+            df=df,
+            x=resp1,
+            y=selections["Diff mode"],
+            selections=selections,
+            groupby=groupby,
+            diff_mode=selections["Diff mode"],
+        )
+        scatter_diff_vs_real = create_scatterfig(
+            df=diffdf_real,
+            x="REAL",
+            y=selections["Diff mode"],
+            selections=selections,
+            groupby=groupby,
+            diff_mode=selections["Diff mode"],
+        )
+        barfig_non_highlighted = create_barfig(
+            df=df[df["highlighted"] == "yes"],
+            groupby=groupby,
+            diff_mode=selections["Diff mode"],
+            colorcol=resp1,
+        )
+
+    return comparison_qc_plots_layout(
+        scatter_diff_vs_real,
+        scatter_corr,
+        scatter_diff_vs_response,
+        barfig_non_highlighted,
+    )
+
+
+def create_comparison_df(
+    volumemodel: InplaceVolumesModel,
+    compare_on: str,
+    responses: list,
+    selections: dict,
+    groups: list,
+    abssort_on: str = "diff (%)",
+    rename_diff_col: bool = False,
+) -> pd.DataFrame:
+
+    value1, value2 = selections["value1"], selections["value2"]
+    resp = selections["Response"]
+    selections["filters"][compare_on] = [value1, value2]
+
+    groups = groups + ["SOURCE", "ENSEMBLE"]
+    df = volumemodel.get_df(selections["filters"], groups=groups)
+
+    df = df.loc[:, groups + responses].pivot_table(
+        columns=compare_on, index=[x for x in groups if x != compare_on]
+    )
+    responses = [x for x in responses if x in df]
+    for col in responses:
+        df[col, "diff"] = df[col][value2] - df[col][value1]
+        df[col, "diff (%)"] = ((df[col][value2] / df[col][value1]) - 1) * 100
+        df.loc[df[col]["diff"] == 0, (col, "diff (%)")] = 0
+    df = df[responses].replace([np.inf, -np.inf], np.nan).reset_index()
+
+    # remove rows where the selected response is nan
+    # can happen for properties where the volume columns are 0
+    df = df.loc[~((df[resp][value1].isna()) & (df[resp][value2].isna()))]
+    if selections["Remove zeros"]:
+        df = df.loc[~((df[resp]["diff"] == 0) & (df[resp][value1] == 0))]
+
+    df["highlighted"] = compute_highlighted_col(df, resp, value1, selections)
+    df.columns = df.columns.map(" ".join).str.strip(" ")
+
+    # remove columns where all values are nan and drop SOURCE/ENSMEBLE column
+    df = df.dropna(how="all", axis=1).drop(
+        columns=["SOURCE", "ENSEMBLE"], errors="ignore"
+    )
+
+    if rename_diff_col:
+        df = df.rename(columns={f"{resp} diff": "diff", f"{resp} diff (%)": "diff (%)"})
+    df = add_fluid_zone_column(df, selections["filters"])
+    return df.sort_values(by=[abssort_on], key=abs, ascending=False)
+
+
+def compute_highlighted_col(
+    df: pd.DataFrame, response: str, value1: str, selections: dict
+) -> list:
+    highlight_mask = (df[response][value1] > selections["Ignore <"]) & (
+        df[response]["diff (%)"].abs() < selections["Accept value"]
+    ) | (df[response][value1] <= selections["Ignore <"])
+    return np.where(highlight_mask, "no", "yes")
+
+
+def find_higlighted_real_count(
+    row: pd.Series, df_per_real: pd.DataFrame, groups: list
+) -> str:
+    query = " & ".join([f"{col}=='{row[col]}'" for col in groups])
+    result = df_per_real.query(query) if groups else df_per_real
+    return str(len(result[result["highlighted"] == "yes"]))
+
+
+def create_comaprison_table(
+    tabletype: str,
+    df: pd.DataFrame,
+    groupby: list,
+    selections: dict,
+    compare_on: str,
+    use_si_format: Optional[bool] = None,
+    volumemodel: Optional[InplaceVolumesModel] = None,
+) -> dash_table.DataTable:
+
+    diff_mode_percent = selections["Diff mode"] == "diff (%)"
+
+    if selections["Remove non-highlighted"]:
+        df = df.loc[df["highlighted"] == "yes"]
+        if df.empty:
+            return html.Div(
+                [
+                    html.Div("All data outside highlight criteria!"),
+                    html.Div(
+                        "To see the data turn off setting 'Display only highlighted data'"
+                    ),
+                ]
+            )
+
+    if tabletype == "multi-response table":
+        diff_cols = [x for x in df.columns if x.endswith(selections["Diff mode"])]
+        rename_dict = {x: x.split(" ")[0] for x in diff_cols}
+        df = df[groupby + diff_cols + ["highlighted"]].rename(columns=rename_dict)
+        df = add_fluid_zone_column(df, selections["filters"])
+
+        columns = create_table_columns(
+            columns=move_to_end_of_list("FLUID_ZONE", df.columns),
+            text_columns=groupby,
+            use_si_format=volumemodel.volume_columns
+            if volumemodel is not None and not diff_mode_percent
+            else None,
+            use_percentage=list(df.columns) if diff_mode_percent else None,
+        )
+    else:
+        columns = create_table_columns(
+            columns=move_to_end_of_list("FLUID_ZONE", df.columns),
+            text_columns=groupby,
+            use_si_format=list(df.columns) if use_si_format else None,
+            use_percentage=["diff (%)"],
+        )
+
+    return create_data_table(
+        selectors=groupby,
+        columns=columns,
+        height="80vh",
+        data=df.to_dict("records"),
+        table_id={"table_id": f"{compare_on}-comp-table"},
+        style_cell={"textAlign": "center"},
+        style_data_conditional=[
+            {
+                "if": {"filter_query": "{highlighted} = 'yes'"},
+                "backgroundColor": "rgb(230, 230, 230)",
+                "fontWeight": "bold",
+            },
+        ],
+        style_cell_conditional=[
+            {"if": {"column_id": "highlighted"}, "display": "None"}
+        ],
+    )
+
+
+def create_scatterfig(
+    df: pd.DataFrame,
+    x: str,
+    y: str,
+    selections: dict,
+    groupby: list,
+    diff_mode: Optional[str] = None,
+) -> go.Figure:
+
+    highlight_colors = {"yes": "#FF1243", "no": "#80B7BC"}
+    colorby = (
+        selections["Color by"]
+        if selections["Color by"] == "highlighted"
+        else groupby[0]
+    )
+    df[colorby] = df[colorby].astype(str)
+
+    fig = (
+        create_figure(
+            plot_type="scatter",
+            data_frame=df,
+            x=x,
+            y=y,
+            color_discrete_sequence=px.colors.qualitative.Dark2,
+            color_discrete_map=highlight_colors if colorby == "highlighted" else None,
+            color=colorby,
+            hover_data={col: True for col in groupby},
+        )
+        .update_traces(marker_size=10)
+        .update_layout(margin={"l": 20, "r": 20, "t": 20, "b": 20})
+    )
+    if diff_mode is not None:
+        fig.update_yaxes(range=find_diff_plot_range(df, diff_mode, selections))
+        if diff_mode == "diff (%)" and x == "REAL":
+            fig.add_hline(y=selections["Accept value"], line_dash="dot").add_hline(
+                y=-selections["Accept value"], line_dash="dot"
+            )
+    return fig
+
+
+def find_diff_plot_range(df: pd.DataFrame, diff_mode: str, selections: dict) -> list:
+    """
+    Find plot range for diff axis. If axis focus is selected
+    the range will center around the non-acepted data points.
+    An 10% extension is added to the axis
+    """
+    if selections["Axis focus"] and "yes" in df["highlighted"].values:
+        df = df[df["highlighted"] == "yes"]
+
+    low = min(df[diff_mode].min(), -selections["Accept value"])
+    high = max(df[diff_mode].max(), selections["Accept value"])
+    extend = (high - low) * 0.1
+    return [low - extend, high + extend]
+
+
+def create_barfig(
+    df: pd.DataFrame, groupby: list, diff_mode: str, colorcol: str
+) -> Union[None, go.Figure]:
+    if df.empty:
+        return None
+    return (
+        create_figure(
+            plot_type="bar",
+            data_frame=df,
+            x=df[[x for x in groupby if x != "FLUID_ZONE"]]
+            .astype(str)
+            .agg(" ".join, axis=1),
+            y=diff_mode,
+            color_continuous_scale="teal_r",
+            color=df[colorcol],
+            hover_data={col: True for col in groupby},
+            opacity=1,
+        )
+        .update_layout(
+            margin={"l": 20, "r": 20, "t": 5, "b": 5},
+            bargap=0.15,
+            paper_bgcolor="rgba(0,0,0,0)",
+        )
+        .update_xaxes(title_text=None, tickangle=45, ticks="outside")
+        .update_yaxes(zeroline=True, zerolinecolor="black")
+    )
+
+
+def add_fluid_zone_column(dframe: pd.DataFrame, filters: dict) -> pd.DataFrame:
+    if "FLUID_ZONE" not in dframe and "FLUID_ZONE" in filters:
+        dframe["FLUID_ZONE"] = (" + ").join(filters["FLUID_ZONE"])
+    return dframe

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
@@ -2,11 +2,10 @@ from typing import Callable, List, Optional
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 import numpy as np
-from dash import html, Dash, dash_table, no_update, Input, Output, State, ALL
+from dash import html, Dash, no_update, Input, Output, State, ALL
 from dash.exceptions import PreventUpdate
 import plotly.express as px
 import plotly.graph_objects as go
-import webviz_core_components as wcc
 from webviz_config import WebvizConfigTheme
 
 from webviz_subsurface._components.tornado._tornado_data import TornadoData
@@ -18,8 +17,12 @@ from webviz_subsurface._abbreviations.volume_terminology import (
     volume_unit,
 )
 from webviz_subsurface._figures import create_figure
-from ..utils.utils import update_relevant_components
-
+from ..utils.utils import update_relevant_components, move_to_end_of_list
+from ..utils.table_and_figure_utils import (
+    fluid_annotation,
+    create_data_table,
+    create_table_columns,
+)
 
 # pylint: disable=too-many-statements, too-many-branches
 def distribution_controllers(
@@ -460,12 +463,9 @@ def distribution_controllers(
                     html.Div(
                         style={"margin-top": "20px"},
                         children=create_data_table(
-                            volumemodel=volumemodel,
                             columns=tornado_table.columns
                             + create_table_columns(
-                                columns=["Reference"],
-                                format_columns=["Reference"],
-                                use_si_format=True,
+                                columns=["Reference"], use_si_format=["Reference"]
                             ),
                             data=table,
                             height="20vh",
@@ -522,7 +522,7 @@ def make_table_wrapper_children(
 
                 for idx, group in enumerate(groups):
                     data[group] = (
-                        name if isinstance(name, str) == 1 else list(name)[idx]
+                        name if not isinstance(name, tuple) else list(name)[idx]
                     )
                 if response in volumemodel.volume_columns:
                     data_volcols.append(data)
@@ -537,14 +537,13 @@ def make_table_wrapper_children(
                 html.Div(
                     style={"margin-top": "20px"},
                     children=create_data_table(
-                        volumemodel=volumemodel,
+                        selectors=volumemodel.selectors,
                         columns=create_table_columns(
-                            columns=[col]
-                            + [x for x in groups if x != "FLUID_ZONE"]
-                            + statcols
-                            + ["FLUID_ZONE"],
-                            format_columns=statcols,
-                            use_si_format=col == "Response",
+                            columns=move_to_end_of_list(
+                                "FLUID_ZONE", [col] + groups + statcols
+                            ),
+                            text_columns=[col] + groups,
+                            use_si_format=statcols if col == "Response" else None,
                         ),
                         data=data,
                         height=f"{view_height}vh",
@@ -574,126 +573,18 @@ def make_table_wrapper_children(
     if "FLUID_ZONE" not in dframe:
         dframe["FLUID_ZONE"] = (" + ").join(selections["filters"]["FLUID_ZONE"])
 
-    dframe = dframe[[x for x in dframe.columns if x != "FLUID_ZONE"] + ["FLUID_ZONE"]]
+    dframe = dframe[move_to_end_of_list("FLUID_ZONE", dframe.columns)]
     return html.Div(
+        style={"margin-top": "20px"},
         children=[
             create_data_table(
-                volumemodel=volumemodel,
+                selectors=volumemodel.selectors,
                 columns=create_table_columns(
-                    columns=dframe.columns,
-                    format_columns=dframe.columns,
-                    volumemodel=volumemodel,
+                    columns=dframe.columns, use_si_format=volumemodel.volume_columns
                 ),
                 data=dframe.iloc[::-1].to_dict("records"),
                 height=f"{view_height}vh",
                 table_id={"table_id": f"{page_selected}-meantable"},
             )
-        ]
-    )
-
-
-def create_table_columns(
-    columns: list,
-    volumemodel: Optional[InplaceVolumesModel] = None,
-    format_columns: Optional[list] = None,
-    use_si_format: Optional[bool] = None,
-) -> List[dict]:
-
-    format_columns = format_columns if format_columns is not None else []
-
-    table_columns = []
-    for col in columns:
-        data = {"id": col, "name": col}
-        if col in format_columns:
-            data.update(
-                {
-                    "type": "numeric",
-                    "format": {"locale": {"symbol": ["", ""]}, "specifier": "$.4s"}
-                    if use_si_format
-                    or volumemodel is not None
-                    and col in volumemodel.volume_columns
-                    else dash_table.Format.Format(precision=3),
-                }
-            )
-        table_columns.append(data)
-    return table_columns
-
-
-def create_data_table(
-    volumemodel: InplaceVolumesModel,
-    columns: list,
-    height: str,
-    data: List[dict],
-    table_id: dict,
-) -> dash_table.DataTable:
-
-    if not data:
-        return []
-
-    style_cell_conditional = [
-        {"if": {"column_id": c}, "textAlign": "left"}
-        for c in [x for x in volumemodel.selectors if x != "FLUID_ZONE"]
-        + ["Response", "Property", "Sensitivity"]
-    ]
-    style_cell_conditional.extend(
-        [
-            {"if": {"column_id": c}, "width": "10%"}
-            for c in volumemodel.selectors + ["Response", "Property", "Sensitivity"]
-        ]
-    )
-    style_data_conditional = fluid_table_style()
-
-    return wcc.WebvizPluginPlaceholder(
-        id={"request": "table_data", "table_id": table_id["table_id"]},
-        buttons=["expand", "download"],
-        children=dash_table.DataTable(
-            id=table_id,
-            sort_action="native",
-            sort_mode="multi",
-            filter_action="native",
-            columns=columns,
-            data=data,
-            style_as_list_view=True,
-            style_cell_conditional=style_cell_conditional,
-            style_data_conditional=style_data_conditional,
-            style_table={
-                "height": height,
-                "overflowY": "auto",
-            },
-        ),
-    )
-
-
-def fluid_table_style() -> list:
-    fluid_colors = {
-        "oil": "#007079",
-        "gas": "#FF1243",
-        "water": "#ADD8E6",
-    }
-    return [
-        {
-            "if": {
-                "filter_query": "{FLUID_ZONE} = " + f"'{fluid}'",
-                "column_id": "FLUID_ZONE",
-            },
-            "color": color,
-            "fontWeight": "bold",
-        }
-        for fluid, color in fluid_colors.items()
-    ]
-
-
-def fluid_annotation(selections: dict) -> dict:
-    fluid_text = (" + ").join(selections["filters"]["FLUID_ZONE"])
-    return dict(
-        visible=bool(selections["Fluid annotation"])
-        and selections["Subplots"] != "FLUID_ZONE",
-        x=1,
-        y=1,
-        xref="paper",
-        yref="paper",
-        showarrow=False,
-        text="Fluid zone<br>" + fluid_text,
-        font=dict(size=15, color="black"),
-        bgcolor="#E8E8E8",
+        ],
     )

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -606,3 +606,31 @@ def selections_controllers(
                 ],
             ),
         )
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("selections"), "tab": "src-comp", "selector": "Ignore <"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("selections"), "tab": "src-comp", "selector": "Response"},
+            "value",
+        ),
+    )
+    def _reset_ignore_value_source_comparison(_response_change: str) -> float:
+        """reset ignore value when new response is selected"""
+        return 0
+
+    @app.callback(
+        Output(
+            {"id": get_uuid("selections"), "tab": "ens-comp", "selector": "Ignore <"},
+            "value",
+        ),
+        Input(
+            {"id": get_uuid("selections"), "tab": "ens-comp", "selector": "Response"},
+            "value",
+        ),
+    )
+    def _reset_ignore_value_ens_comparison(_response_change: str) -> float:
+        """reset ignore value when new response is selected"""
+        return 0

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
@@ -1,0 +1,135 @@
+from typing import List, Optional, Union
+
+from dash import dash_table
+from dash.dash_table.Format import Format
+import plotly.graph_objects as go
+import webviz_core_components as wcc
+
+
+def create_table_columns(
+    columns: list,
+    text_columns: list = None,
+    use_si_format: Optional[list] = None,
+    use_percentage: Optional[list] = None,
+) -> List[dict]:
+
+    text_columns = text_columns if text_columns is not None else []
+    use_si_format = use_si_format if use_si_format is not None else []
+    use_percentage = use_percentage if use_percentage is not None else []
+
+    table_columns = []
+    for col in columns:
+        data = {"id": col, "name": col}
+        if col not in text_columns:
+            data["type"] = "numeric"
+            if col in use_percentage:
+                data["format"] = {"specifier": ".1f"}
+            elif col in use_si_format:
+                data["format"] = {"locale": {"symbol": ["", ""]}, "specifier": "$.4s"}
+            else:
+                data["format"] = Format(precision=3)
+        table_columns.append(data)
+    return table_columns
+
+
+def create_data_table(
+    columns: list,
+    height: str,
+    data: List[dict],
+    table_id: dict,
+    selectors: Optional[list] = None,
+    style_cell: Optional[dict] = None,
+    style_cell_conditional: Optional[list] = None,
+    style_data_conditional: Optional[list] = None,
+) -> Union[list, wcc.WebvizPluginPlaceholder]:
+
+    if not data:
+        return []
+
+    if selectors is None:
+        selectors = []
+    conditional_cell_style = [
+        {
+            "if": {"column_id": selectors + ["Response", "Property", "Sensitivity"]},
+            "width": "10%",
+            "textAlign": "left",
+        },
+        {"if": {"column_id": "FLUID_ZONE"}, "width": "10%", "textAlign": "right"},
+    ]
+    if style_cell_conditional is not None:
+        conditional_cell_style.extend(style_cell_conditional)
+
+    style_data_conditional = (
+        style_data_conditional if style_data_conditional is not None else []
+    )
+    style_data_conditional.extend(fluid_table_style())
+
+    return wcc.WebvizPluginPlaceholder(
+        id={"request": "table_data", "table_id": table_id["table_id"]},
+        buttons=["expand", "download"],
+        children=dash_table.DataTable(
+            id=table_id,
+            sort_action="native",
+            sort_mode="multi",
+            filter_action="native",
+            columns=columns,
+            data=data,
+            style_as_list_view=True,
+            style_cell=style_cell,
+            style_cell_conditional=conditional_cell_style,
+            style_data_conditional=style_data_conditional,
+            style_table={
+                "height": height,
+                "overflowY": "auto",
+            },
+        ),
+    )
+
+
+def fluid_table_style() -> list:
+    fluid_colors = {
+        "oil": "#007079",
+        "gas": "#FF1243",
+        "water": "#ADD8E6",
+    }
+    return [
+        {
+            "if": {
+                "filter_query": "{FLUID_ZONE} = " + f"'{fluid}'",
+                "column_id": "FLUID_ZONE",
+            },
+            "color": color,
+            "fontWeight": "bold",
+        }
+        for fluid, color in fluid_colors.items()
+    ]
+
+
+def fluid_annotation(selections: dict) -> dict:
+    fluid_text = (" + ").join(selections["filters"]["FLUID_ZONE"])
+    return dict(
+        visible=bool(selections["Fluid annotation"])
+        and selections["Subplots"] != "FLUID_ZONE",
+        x=1,
+        y=1,
+        xref="paper",
+        yref="paper",
+        showarrow=False,
+        text="Fluid zone<br>" + fluid_text,
+        font=dict(size=15, color="black"),
+        bgcolor="#E8E8E8",
+    )
+
+
+def add_correlation_line(figure: go.Figure, xy_min: float, xy_max: float) -> go.Figure:
+    return figure.add_shape(
+        type="line",
+        layer="below",
+        xref="x",
+        yref="y",
+        x0=xy_min,
+        y0=xy_min,
+        x1=xy_max,
+        y1=xy_max,
+        line=dict(color="black", width=2, dash="dash"),
+    )

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/utils.py
@@ -25,3 +25,7 @@ def update_relevant_components(id_list: list, update_info: List[dict]) -> list:
                 output_id_list[idx] = elm["new_value"]
                 break
     return output_id_list
+
+
+def move_to_end_of_list(element: str, list_of_elements: list) -> list:
+    return [x for x in list_of_elements if x != element] + [element]

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -1,0 +1,322 @@
+from dash import html, dcc, dash_table
+import plotly.graph_objects as go
+import webviz_core_components as wcc
+from webviz_subsurface._models import InplaceVolumesModel
+
+
+def comparison_main_layout(uuid: str) -> html.Div:
+    return wcc.Frame(
+        color="white",
+        highlight=False,
+        style={"height": "91vh"},
+        children=[
+            html.Div(
+                style={"margin-bottom": "20px"},
+                children=wcc.RadioItems(
+                    vertical=False,
+                    id={"id": uuid, "element": "display-option"},
+                    options=[
+                        {
+                            "label": "QC plots",
+                            "value": "plots",
+                        },
+                        {
+                            "label": "Difference table for selected response",
+                            "value": "single-response table",
+                        },
+                        {
+                            "label": "Difference table for multiple responses",
+                            "value": "multi-response table",
+                        },
+                    ],
+                    value="plots",
+                ),
+            ),
+            html.Div(id={"id": uuid, "wrapper": "table"}),
+        ],
+    )
+
+
+def comparison_qc_plots_layout(
+    fig_diff_vs_real: go.Figure,
+    fig_corr: go.Figure,
+    fig_diff_vs_response: go.Figure,
+    barfig: go.Figure,
+) -> html.Div:
+    return html.Div(
+        children=[
+            html.Div(
+                children=wcc.Graph(
+                    config={"displayModeBar": False},
+                    style={"height": "22vh"},
+                    figure=fig_diff_vs_real,
+                )
+            ),
+            wcc.FlexBox(
+                style={"height": "32vh"},
+                children=[
+                    wcc.FlexColumn(
+                        children=wcc.Graph(
+                            config={"displayModeBar": False},
+                            style={"height": "31vh"},
+                            figure=fig_diff_vs_response,
+                        )
+                    ),
+                    wcc.FlexColumn(
+                        children=wcc.Graph(
+                            config={"displayModeBar": False},
+                            style={"height": "31vh"},
+                            figure=fig_corr,
+                        )
+                    ),
+                ],
+            ),
+            wcc.Frame(
+                style={"height": "31vh"},
+                children=[
+                    wcc.Header("Highlighted data"),
+                    wcc.Graph(
+                        config={"displayModeBar": False},
+                        style={"height": "25vh"},
+                        figure=barfig,
+                    )
+                    if barfig is not None
+                    else html.Div("No data within highlight criteria"),
+                ],
+            ),
+        ]
+    )
+
+
+def comparison_table_layout(
+    table: dash_table, table_type: str, selections: dict, filter_info: str
+) -> html.Div:
+    if table_type == "single-response table":
+        header = f"Table showing differences for {selections['Response']}"
+    else:
+        diff_mode = "percent" if selections["Diff mode"] == "diff (%)" else "true value"
+        header = f"Table showing differences in {diff_mode} for multiple responses"
+
+    return html.Div(
+        children=[
+            wcc.Header(header),
+            html.Div(
+                style={"margin-bottom": "30px", "font-weight": "bold"},
+                children=[
+                    html.Div(f"From {selections['value1']} to {selections['value2']}"),
+                    html.Div(
+                        f"{filter_info.capitalize()} {selections['filters'][filter_info][0]}"
+                    ),
+                ],
+            ),
+            table,
+        ]
+    )
+
+
+def settings_layout(uuid: str, tab: str) -> wcc.Selectors:
+    return wcc.Selectors(
+        label="⚙️ SETTINGS",
+        open_details=False,
+        children=[
+            colorby_selector(uuid, tab),
+            axis_focus_selector(uuid, tab),
+            remove_zero_responses(uuid, tab),
+            remove_non_highlighted_data(uuid, tab),
+        ],
+    )
+
+
+def comparison_selections(
+    uuid: str, volumemodel: InplaceVolumesModel, tab: str, compare_on: str
+) -> html.Div:
+    elements = volumemodel.sources if compare_on == "SOURCE" else volumemodel.ensembles
+    return html.Div(
+        children=[
+            wcc.Selectors(
+                label="CONTROLS",
+                open_details=True,
+                children=[
+                    source_selector(
+                        uuid,
+                        tab,
+                        label=f"{compare_on.capitalize()} A",
+                        selector_label="value1",
+                        value=elements[0],
+                        elements=elements,
+                    ),
+                    source_selector(
+                        uuid,
+                        tab,
+                        label=f"{compare_on.capitalize()} B",
+                        selector_label="value2",
+                        value=elements[1] if compare_on == "SOURCE" else elements[-1],
+                        elements=elements,
+                    ),
+                    response_selector(volumemodel, uuid, tab),
+                    group_by_selector(volumemodel, uuid, tab),
+                    diff_mode_selector(uuid, tab),
+                    highlight_controls(uuid, tab),
+                ],
+            ),
+            settings_layout(uuid, tab),
+        ]
+    )
+
+
+def axis_focus_selector(uuid: str, tab: str) -> html.Div:
+    return wcc.Checklist(
+        id={"id": uuid, "tab": tab, "selector": "Axis focus"},
+        options=[{"label": "Focus diff plots on highlighted", "value": "focus"}],
+        value=["focus"],
+    )
+
+
+def remove_zero_responses(uuid: str, tab: str) -> html.Div:
+    return wcc.Checklist(
+        id={"id": uuid, "tab": tab, "selector": "Remove zeros"},
+        options=[{"label": "Remove data with no volume", "value": "remove"}],
+        value=["remove"],
+    )
+
+
+def remove_non_highlighted_data(uuid: str, tab: str) -> html.Div:
+    return wcc.Checklist(
+        id={"id": uuid, "tab": tab, "selector": "Remove non-highlighted"},
+        options=[
+            {"label": "Display only highlighted data in table", "value": "remove"}
+        ],
+        value=[],
+    )
+
+
+def diff_mode_selector(uuid: str, tab: str) -> html.Div:
+    return html.Div(
+        style={"margin-top": "10px"},
+        children=wcc.RadioItems(
+            label="Difference mode",
+            id={"id": uuid, "tab": tab, "selector": "Diff mode"},
+            options=[
+                {"label": "Percent", "value": "diff (%)"},
+                {"label": "True value", "value": "diff"},
+            ],
+            labelStyle={"display": "inline-flex", "margin-right": "5px"},
+            value="diff (%)",
+        ),
+    )
+
+
+def highlight_controls(uuid: str, tab: str) -> html.Div:
+    return html.Div(
+        style={"margin-top": "10px"},
+        children=[
+            html.Label("Data highlight criterias", className="webviz-underlined-label"),
+            html.Div(
+                children=[
+                    wcc.Label("Absolute diff (%) above:"),
+                    dcc.Input(
+                        id={"id": uuid, "tab": tab, "selector": "Accept value"},
+                        type="number",
+                        required=True,
+                        value=5,
+                        persistence=True,
+                        persistence_type="session",
+                    ),
+                ],
+            ),
+            html.Div(
+                children=[
+                    wcc.Label("Ignore response values below:"),
+                    dcc.Input(
+                        id={"id": uuid, "tab": tab, "selector": "Ignore <"},
+                        type="number",
+                        required=True,
+                        value=0,
+                        persistence=True,
+                        persistence_type="session",
+                        debounce=True,
+                    ),
+                ]
+            ),
+        ],
+    )
+
+
+def source_selector(
+    uuid: str,
+    tab: str,
+    label: str,
+    selector_label: str,
+    value: str,
+    elements: list,
+) -> wcc.Dropdown:
+
+    return wcc.Dropdown(
+        label=label,
+        id={"id": uuid, "tab": tab, "selector": selector_label},
+        options=[{"label": src, "value": src} for src in elements],
+        value=value,
+        clearable=False,
+    )
+
+
+def response_selector(
+    volumemodel: InplaceVolumesModel,
+    uuid: str,
+    tab: str,
+) -> html.Div:
+    return html.Div(
+        style={"margin-top": "10px"},
+        children=wcc.Dropdown(
+            id={
+                "id": uuid,
+                "tab": tab,
+                "selector": "Response",
+            },
+            label="Response",
+            options=[{"label": i, "value": i} for i in volumemodel.responses],
+            value=volumemodel.volume_columns[0],
+            clearable=False,
+        ),
+    )
+
+
+def colorby_selector(
+    uuid: str,
+    tab: str,
+) -> html.Div:
+    return html.Div(
+        style={"margin": "10px 0px"},
+        children=wcc.RadioItems(
+            label="Color plots on",
+            id={"id": uuid, "tab": tab, "selector": "Color by"},
+            options=[
+                {"label": "Highlighted", "value": "highlighted"},
+                {"label": "1st level of investigation", "value": "groups"},
+            ],
+            labelStyle={"display": "inline-flex", "margin-right": "5px"},
+            value="highlighted",
+        ),
+    )
+
+
+def group_by_selector(
+    volumemodel: InplaceVolumesModel, uuid: str, tab: str
+) -> html.Div:
+    available_selectors = [
+        x
+        for x in volumemodel.region_selectors + ["FACIES", "REAL", "FLUID_ZONE"]
+        if x in volumemodel.selectors and volumemodel.dataframe[x].nunique() > 1
+    ]
+    return html.Div(
+        style={"margin-top": "10px"},
+        children=wcc.Dropdown(
+            label="Investigate differences on level",
+            id={"id": uuid, "tab": tab, "selector": "Group by"},
+            options=[{"label": elm, "value": elm} for elm in available_selectors],
+            value=[],
+            placeholder="Total",
+            multi=True,
+            clearable=False,
+        ),
+    )

--- a/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
@@ -1,8 +1,8 @@
 from typing import List, Tuple, Callable, Optional
 from pathlib import Path
-
 import pandas as pd
-from dash import html, Dash
+import dash
+import dash_html_components as html
 from webviz_config import WebvizPluginABC
 from webviz_config import WebvizSettings
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
@@ -21,6 +21,7 @@ from .controllers import (
     selections_controllers,
     layout_controllers,
     export_data_controllers,
+    comparison_controllers,
 )
 
 
@@ -133,7 +134,7 @@ reek_test_data/aggregated_data/parameters.csv)
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        app: Dash,
+        app: dash.Dash,
         webviz_settings: WebvizSettings,
         csvfile_vol: Path = None,
         csvfile_parameters: Path = None,
@@ -143,9 +144,7 @@ reek_test_data/aggregated_data/parameters.csv)
         non_net_facies: Optional[List[str]] = None,
         fipfile: Path = None,
     ):
-
         super().__init__()
-
         WEBVIZ_ASSETS.add(
             Path(webviz_subsurface.__file__).parent
             / "_assets"
@@ -178,7 +177,7 @@ reek_test_data/aggregated_data/parameters.csv)
 
         else:
             raise ValueError(
-                'Incorrent arguments. Either provide a "csvfile" or "ensembles" and "volfiles"'
+                'Incorrent arguments. Either provide a "csvfile_vol" or "ensembles" and "volfiles"'
             )
 
         vcomb = VolumeValidatorAndCombinator(
@@ -201,18 +200,20 @@ reek_test_data/aggregated_data/parameters.csv)
             children=[
                 clientside_stores(get_uuid=self.uuid),
                 main_view(
-                    get_uuid=self.uuid,
-                    volumemodel=self.volmodel,
-                    theme=self.theme,
+                    get_uuid=self.uuid, volumemodel=self.volmodel, theme=self.theme
                 ),
             ],
         )
 
-    def set_callbacks(self, app: Dash) -> None:
+    def set_callbacks(self, app: dash.Dash) -> None:
         selections_controllers(app=app, get_uuid=self.uuid, volumemodel=self.volmodel)
         distribution_controllers(
-            app=app, get_uuid=self.uuid, volumemodel=self.volmodel, theme=self.theme
+            app=app,
+            get_uuid=self.uuid,
+            volumemodel=self.volmodel,
+            theme=self.theme,
         )
+        comparison_controllers(app=app, get_uuid=self.uuid, volumemodel=self.volmodel)
         layout_controllers(app=app, get_uuid=self.uuid)
         export_data_controllers(app=app, get_uuid=self.uuid)
 


### PR DESCRIPTION
PR which adds content to the `Source comparison` and `Ensemble comparison` tabs in `VolumetricAnalysis`.
These tabs are focused on computing differences between sources/ensembles, and is a tool for quick detection of where and why volumetric changes occur.

Both tabs have the same layout and functionality:
- Highlight data based on criteria to quickly detect where volumes changes occur
- Flexible selection of level of investigation
- Plots for visual inspection of correlation etc.
- Tables for looking at the differences for the selected response 
- Tables for looking at differences for multiple responses together to understand why volumes are changing

The` Source comparison` is useful for comparing volumes between:
- geogrid and upscaled grid from RMS. 
- static volumes and dynamic volumes 

The `Ensemble comparison` is useful for comparing volumes between:
- AHM iterations 
- Model revisions 

https://webviz-subsurface-review-tnatt.azurewebsites.net/volumetrics-analysis

![image](https://user-images.githubusercontent.com/61694854/134313052-124a8380-bfbc-4bd6-9600-2bfde8263a18.png)

