### PR TITLE
Bugfix property calculation in mean table `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#765](https://github.com/equinor/webviz-subsurface/pull/765) - Use correct inline/xline ranges for axes in `SegyViewer` z-slice graph.
-
+- [#782](https://github.com/equinor/webviz-subsurface/pull/782) - Fixed an issue in `VolumetricAnalysis` when calculating property columns on grouped selections.
 
 ## [0.2.5] - 2021-09-03
 ### Added

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
@@ -188,15 +188,16 @@ def distribution_controllers(
         if not selections["update"]:
             raise PreventUpdate
 
-        table_groups = ["ENSEMBLE", "REAL"]
+        table_groups = (
+            ["ENSEMBLE", "REAL"]
+            if selections["Table type"] == "Statistics table"
+            else ["ENSEMBLE"]
+        )
         if selections["Group by"] is not None:
             table_groups.extend(
                 [x for x in selections["Group by"] if x not in table_groups]
             )
-        dframe = volumemodel.get_df(
-            filters=selections["filters"],
-            groups=table_groups,
-        )
+        dframe = volumemodel.get_df(filters=selections["filters"], groups=table_groups)
 
         return make_table_wrapper_children(
             dframe=dframe,


### PR DESCRIPTION
Bugfix in `VolumetricAnalysis` do not split data per realization before taking mean for property columns when `Mean table` is selected. Property columns should be computed on the grouped volumetric data.

Bug was introduced in  #724 
