### PR TITLE
Added fipfile QC tab to VolumetricAnalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Added
+- [#783](https://github.com/equinor/webviz-subsurface/pull/783) - `VolumetricAnalysis` - added tab with Fipfile QC for inspection of which `FIPNUM's` and `REGION∕ZONE's` that have been combined in order to get comparable volumes between dynamic and static sources. This tab is only available if a fipfile is given as input.
 - [#777](https://github.com/equinor/webviz-subsurface/pull/777) - `VolumetricAnalysis` - added tabs with `Source comparison` and `Ensemble comparison` as QC tools for quick identification of where and why volumetric changes occur across sources (e.g. static vs dynamic) or ensembles (e.g. model revisions or ahm iterations).
 - [#709](https://github.com/equinor/webviz-subsurface/pull/709) - Added `VectorCalculator` component in `ReservoirSimulationTimeSeries` plugin for calculation and graphing of custom simulation time series vectors.
 - [#773](https://github.com/equinor/webviz-subsurface/pull/773) - `VolumetricAnalysis` - added functionality of easy switching bewteen `FIPNUM` and `REGION/ZONE` filter for cases where each fipnum belongs to a unique region and zone.

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/__init__.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/__init__.py
@@ -3,3 +3,4 @@ from .selections_controllers import selections_controllers
 from .layout_controllers import layout_controllers
 from .export_data_controllers import export_data_controllers
 from .comparison_controllers import comparison_controllers
+from .fipfile_qc_controller import fipfile_qc_controller

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/fipfile_qc_controller.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/fipfile_qc_controller.py
@@ -1,0 +1,117 @@
+from typing import Callable
+
+import pandas as pd
+from dash import Dash, html, Input, Output
+from dash.exceptions import PreventUpdate
+import plotly.express as px
+import plotly.graph_objects as go
+import webviz_core_components as wcc
+from ..utils.table_and_figure_utils import create_table_columns, create_data_table
+
+
+def fipfile_qc_controller(
+    app: Dash,
+    get_uuid: Callable,
+    disjoint_set_df: pd.DataFrame,
+) -> None:
+    @app.callback(
+        Output(get_uuid("main-fipqc"), "children"),
+        Input(get_uuid("selections"), "data"),
+        Input(get_uuid("page-selected"), "data"),
+        Input({"id": get_uuid("main-fipqc"), "element": "display-option"}, "value"),
+    )
+    def _update_page_fipfileqc(
+        selections: dict, page_selected: str, display_option: str
+    ) -> html.Div:
+
+        if page_selected != "fipqc":
+            raise PreventUpdate
+
+        df = disjoint_set_df[["SET", "FIPNUM", "REGION", "ZONE", "REGZONE"]]
+
+        group_table = True
+        if "fipqc" in selections:
+            selections = selections[page_selected]
+            if not selections["update"]:
+                raise PreventUpdate
+
+            for filt, values in selections["filters"].items():
+                df = df.loc[df[filt].isin(values)]
+            group_table = selections["Group table"]
+
+        if group_table and display_option == "table":
+            df["FIPNUM"] = df["FIPNUM"].astype(str)
+            df = df.groupby(["SET"]).agg(lambda x: ", ".join(set(x))).reset_index()
+
+        df = df.sort_values(by=["SET"])
+
+        if display_option == "table":
+            return html.Div(
+                children=create_data_table(
+                    columns=create_table_columns(df.columns),
+                    data=df.to_dict("records"),
+                    height="88vh",
+                    table_id={"table_id": "disjointset-info"},
+                    style_cell_conditional=[
+                        {"if": {"column_id": ["SET", "FIPNUM"]}, "width": "10%"},
+                        {"if": {"column_id": ["ZONE", "REGION"]}, "width": "20%"},
+                    ],
+                    style_cell={
+                        "whiteSpace": "normal",
+                        "textAlign": "left",
+                        "height": "auto",
+                    },
+                ),
+            )
+
+        df["FIPNUM"] = df["FIPNUM"].astype(str)
+        return html.Div(
+            [
+                create_heatmap(df=df, y="ZONE", x="REGION"),
+                create_heatmap(df=df, y="ZONE", x="FIPNUM"),
+                create_heatmap(df=df, y="REGION", x="FIPNUM"),
+            ]
+        )
+
+
+def create_heatmap(df: pd.DataFrame, y: str, x: str) -> wcc.Graph:
+    """Create heatmap"""
+    unique_y = df[y].unique()
+    unique_x = sorted(df[x].unique(), key=int if x == "FIPNUM" else None)
+    data = []
+    for y_elm in unique_y:
+        set_list = []
+        for x_elm in unique_x:
+            set_idx = df.loc[(df[y] == y_elm) & (df[x] == x_elm), "SET"]
+            set_list.append(set_idx.iloc[0] if not set_idx.empty else None)
+        data.append(set_list)
+
+    return wcc.Graph(
+        config={"displayModeBar": False},
+        style={"height": "28vh"},
+        figure=go.Figure(
+            data=go.Heatmap(
+                z=data,
+                x=unique_x,
+                y=unique_y,
+                colorscale=(
+                    px.colors.qualitative.Safe
+                    + px.colors.qualitative.T10
+                    + px.colors.qualitative.Set1
+                ),
+                showscale=False,
+                hovertemplate="SET: %{z} <br>"
+                + f"{x}: %{{x}} <br>"
+                + f"{y}: %{{y}} <extra></extra>",
+            )
+        )
+        .update_layout(
+            margin={"l": 20, "r": 20, "t": 20, "b": 20}, plot_bgcolor="white"
+        )
+        .update_xaxes(title_text=x, tickangle=45, ticks="outside", **axis_variables())
+        .update_yaxes(title_text=y, **axis_variables()),
+    )
+
+
+def axis_variables() -> dict:
+    return {"showline": True, "linewidth": 2, "linecolor": "black", "mirror": True}

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -283,9 +283,9 @@ def selections_controllers(
 
         output = {}
         for selector in ["SOURCE", "ENSEMBLE", "SENSNAME"]:
-            options = [x["value"] for x in page_filter_settings[selector]["options"]]
             if selector not in page_filter_settings:
                 continue
+            options = [x["value"] for x in page_filter_settings[selector]["options"]]
             multi = selector in selected_data
             selector_is_multi = page_filter_settings[selector]["multi"]
             if not multi and selector_is_multi:
@@ -357,6 +357,8 @@ def selections_controllers(
         real_filter_id: list,
     ) -> tuple:
         """Callback that updates the selected relization info and text"""
+        if selected_tab == "fipqc":
+            raise PreventUpdate
 
         index = [x["tab"] for x in reals_ids].index(selected_tab)
         real_list = [int(real) for real in reals[index]]
@@ -425,6 +427,9 @@ def selections_controllers(
         input_ids: list,
         wrapper_ids: list,
     ) -> list:
+        if selected_tab == "fipqc":
+            raise PreventUpdate
+
         reals = volumemodel.realizations
         prev_selection = (
             selections[selected_page]["filters"].get("REAL", [])

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/fipfile_qc_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/fipfile_qc_layout.py
@@ -1,0 +1,83 @@
+from typing import List
+
+import pandas as pd
+from dash import html
+import webviz_core_components as wcc
+
+
+def fipfile_qc_main_layout(uuid: str) -> wcc.Frame:
+    return wcc.Frame(
+        color="white",
+        highlight=False,
+        style={"height": "91vh"},
+        children=[
+            html.Div(
+                style={"margin-bottom": "20px"},
+                children=wcc.RadioItems(
+                    vertical=False,
+                    id={"id": uuid, "element": "display-option"},
+                    options=[
+                        {
+                            "label": "QC plots",
+                            "value": "plots",
+                        },
+                        {"label": "Table", "value": "table"},
+                    ],
+                    value="plots",
+                ),
+            ),
+            html.Div(id=uuid),
+        ],
+    )
+
+
+def fipfile_qc_selections(
+    uuid: str,
+    tab: str,
+) -> wcc.Selectors:
+    return wcc.Selectors(
+        label="TABLE COTROLS",
+        open_details=True,
+        children=wcc.Checklist(
+            id={"id": uuid, "tab": tab, "selector": "Group table"},
+            options=[
+                {"label": "Group table on set", "value": "grouped"},
+            ],
+            value=["grouped"],
+        ),
+    )
+
+
+def fipfile_qc_filters(
+    uuid: str, tab: str, disjoint_set_df: pd.DataFrame
+) -> wcc.Selectors:
+    return wcc.Selectors(
+        label="FILTERS",
+        open_details=True,
+        children=filter_dropdowns(
+            uuid=uuid,
+            tab=tab,
+            disjoint_set_df=disjoint_set_df,
+        ),
+    )
+
+
+def filter_dropdowns(uuid: str, disjoint_set_df: pd.DataFrame, tab: str) -> html.Div:
+    dropdowns: List[html.Div] = []
+    for selector in ["REGION", "ZONE", "FIPNUM", "SET"]:
+        elements = list(disjoint_set_df[selector].unique())
+        if selector == "FIPNUM":
+            elements = sorted(elements, key=int)
+        dropdowns.append(
+            html.Div(
+                children=wcc.SelectWithLabel(
+                    label=selector.lower().capitalize(),
+                    id={"id": uuid, "tab": tab, "selector": selector, "type": "fipqc"},
+                    options=[{"label": i, "value": i} for i in elements],
+                    value=elements,
+                    multi=True,
+                    size=min(15, len(elements)),
+                ),
+            )
+        )
+    return html.Div(dropdowns)

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -1,5 +1,6 @@
-from typing import Callable
+from typing import Callable, Optional
 
+import pandas as pd
 from dash import html, dcc
 import webviz_core_components as wcc
 from webviz_config import WebvizConfigTheme
@@ -10,12 +11,18 @@ from .selections_view import selections_layout, table_selections_layout
 from .tornado_selections_view import tornado_selections_layout
 from .comparison_layout import comparison_main_layout, comparison_selections
 from .tornado_layout import tornado_main_layout
+from .fipfile_qc_layout import (
+    fipfile_qc_filters,
+    fipfile_qc_main_layout,
+    fipfile_qc_selections,
+)
 
 
 def main_view(
     get_uuid: Callable,
     volumemodel: InplaceVolumesModel,
     theme: WebvizConfigTheme,
+    disjoint_set_df: Optional[pd.DataFrame] = None,
 ) -> dcc.Tabs:
 
     tabs = []
@@ -141,6 +148,25 @@ def main_view(
                 ),
             )
         )
+    if disjoint_set_df is not None:
+        tabs.append(
+            wcc.Tab(
+                label="Fipfile QC",
+                value="fipqc",
+                children=tab_view_layout(
+                    main_layout=fipfile_qc_main_layout(get_uuid("main-fipqc")),
+                    sidebar_layout=[
+                        fipfile_qc_selections(uuid=get_uuid("selections"), tab="fipqc"),
+                        fipfile_qc_filters(
+                            uuid=get_uuid("filters"),
+                            tab="fipqc",
+                            disjoint_set_df=disjoint_set_df,
+                        ),
+                    ],
+                ),
+            )
+        )
+
     initial_tab = "voldist"
     if volumemodel.volume_type == "mixed":
         initial_tab = "src-comp"

--- a/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
@@ -21,6 +21,7 @@ from .controllers import (
     layout_controllers,
     export_data_controllers,
     comparison_controllers,
+    fipfile_qc_controller,
 )
 
 
@@ -199,7 +200,10 @@ reek_test_data/aggregated_data/parameters.csv)
             children=[
                 clientside_stores(get_uuid=self.uuid),
                 main_view(
-                    get_uuid=self.uuid, volumemodel=self.volmodel, theme=self.theme
+                    get_uuid=self.uuid,
+                    volumemodel=self.volmodel,
+                    theme=self.theme,
+                    disjoint_set_df=self.disjoint_set_df,
                 ),
             ],
         )
@@ -207,14 +211,14 @@ reek_test_data/aggregated_data/parameters.csv)
     def set_callbacks(self, app: Dash) -> None:
         selections_controllers(app=app, get_uuid=self.uuid, volumemodel=self.volmodel)
         distribution_controllers(
-            app=app,
-            get_uuid=self.uuid,
-            volumemodel=self.volmodel,
-            theme=self.theme,
+            app=app, get_uuid=self.uuid, volumemodel=self.volmodel, theme=self.theme
         )
         comparison_controllers(app=app, get_uuid=self.uuid, volumemodel=self.volmodel)
         layout_controllers(app=app, get_uuid=self.uuid)
         export_data_controllers(app=app, get_uuid=self.uuid)
+        fipfile_qc_controller(
+            app=app, get_uuid=self.uuid, disjoint_set_df=self.disjoint_set_df
+        )
 
     def add_webvizstore(self) -> List[Tuple[Callable, list]]:
         store_functions = []


### PR DESCRIPTION
PR which adds a Fipfile QC tab to VolumetricAnalysis.
This tab will only appear if users inputs a fipfile.

When comparing static and dynamic volumes the fipfile is used to guide which fipnums and regions/zones to sum over to get comparables volumes. If the user makes this file manually errors can occur. This tab presents a way of QC'ing the mapping between fipnum vs zone/region and to see what data are grouped together by the fipmapper (SETs).
- this is done in both a visual manner using heatmaps and by table form 

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
