### PR TITLE
Layout change Ensemble comparison tab `VolumetricAnalysis`

### DIFF
--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from dash import html, dcc, dash_table
 import plotly.graph_objects as go
 import webviz_core_components as wcc
@@ -38,11 +39,12 @@ def comparison_main_layout(uuid: str) -> html.Div:
 
 
 def comparison_qc_plots_layout(
-    fig_diff_vs_real: go.Figure,
+    fig_diff_vs_real: Optional[go.Figure],
     fig_corr: go.Figure,
     fig_diff_vs_response: go.Figure,
     barfig: go.Figure,
 ) -> html.Div:
+    real_plot = fig_diff_vs_real is not None
     return html.Div(
         children=[
             html.Div(
@@ -51,21 +53,23 @@ def comparison_qc_plots_layout(
                     style={"height": "22vh"},
                     figure=fig_diff_vs_real,
                 )
+                if real_plot
+                else [],
             ),
             wcc.FlexBox(
-                style={"height": "32vh"},
+                style={"height": "32vh" if real_plot else "54vh"},
                 children=[
                     wcc.FlexColumn(
                         children=wcc.Graph(
                             config={"displayModeBar": False},
-                            style={"height": "31vh"},
+                            style={"height": "31vh" if real_plot else "53vh"},
                             figure=fig_diff_vs_response,
                         )
                     ),
                     wcc.FlexColumn(
                         children=wcc.Graph(
                             config={"displayModeBar": False},
-                            style={"height": "31vh"},
+                            style={"height": "31vh" if real_plot else "53vh"},
                             figure=fig_corr,
                         )
                     ),
@@ -152,6 +156,14 @@ def comparison_selections(
                         selector_label="value2",
                         value=elements[1] if compare_on == "SOURCE" else elements[-1],
                         elements=elements,
+                    ),
+                    html.Div(
+                        f"Difference = {compare_on.capitalize()} B - {compare_on.capitalize()} A",
+                        style={
+                            "font-size": "15px",
+                            "margin-top": "5px",
+                            "color": "#007079",
+                        },
                     ),
                     response_selector(volumemodel, uuid, tab),
                     group_by_selector(volumemodel, uuid, tab),


### PR DESCRIPTION
For ensembles it doesn't make sense to compare on realization level like it does for sources. 

This PR removes the realization vs diff plot from the layout and removes the option of grouping on realization level for the `Ensemble comparison` tab in `VolumetricAnalysis`.

Edit to the not released #777

| Source comparison layout | Ensemble comparison layout |
| -----------------------------|---------------------------------|
|![image](https://user-images.githubusercontent.com/61694854/134563503-cbab6229-2ac4-4ee4-9336-7a0a168be381.png) | ![image](https://user-images.githubusercontent.com/61694854/134563541-afce17c3-25d3-42e4-8b1d-63a0c76a9bea.png) |

