### PR TITLE
Prevent mixing volumes from different sensitivities in `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#755](https://github.com/equinor/webviz-subsurface/pull/755) - Updated existing and added new tests for the Drogon dataset.
 
 ### Changed
+- [#788](https://github.com/equinor/webviz-subsurface/pull/788) - Prevent mixing volumes from different sensitivities in `VolumetricAnalysis` by not allowing to select more than one sensitivity as a filter unless SENSNAME has been grouped on by the user.
 - [#760](https://github.com/equinor/webviz-subsurface/pull/760) - Updated to `Dash 2.0`.
 - [#761](https://github.com/equinor/webviz-subsurface/pull/761) - Store `xtgeo.RegularSurface` as bytestream instead of serializing to `json`.
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -278,15 +278,24 @@ def selections_controllers(
             ]
         if selected_tab == "table" and page_selections["Group by"] is not None:
             selected_data = page_selections["Group by"]
+        if selected_tab == "tornado":
+            selected_data = ["SENSNAME"]
 
         output = {}
-        for selector in ["SOURCE", "ENSEMBLE"]:
+        for selector in ["SOURCE", "ENSEMBLE", "SENSNAME"]:
+            options = [x["value"] for x in page_filter_settings[selector]["options"]]
+            if selector not in page_filter_settings:
+                continue
             multi = selector in selected_data
             selector_is_multi = page_filter_settings[selector]["multi"]
             if not multi and selector_is_multi:
-                values = [page_filter_settings[selector]["options"][0]["value"]]
+                values = [
+                    "rms_seed"
+                    if selector == "SENSNAME" and "rms_seed" in options
+                    else options[0]
+                ]
             elif multi and not selector_is_multi:
-                values = [x["value"] for x in page_filter_settings[selector]["options"]]
+                values = options
             else:
                 multi = values = no_update
             output[selector] = {"multi": multi, "values": values}


### PR DESCRIPTION
User request.
Handle SENSNAME in same manner as SOURCE/ENSEMBLE by not allowing more than one SENSNAME to be selected as filter if the user has not grouped on this column. This is to avoid misleading statistical numbers.

The standard name for the SENSNAME with "base case" simulations is "rms_seed", this is used as default if present when SENSNAME has not been grouped on.

