### PR TITLE
Ensure map bounds are updated when switching attribute in `SurfaceViewerFMU`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#765](https://github.com/equinor/webviz-subsurface/pull/765) - Use correct inline/xline ranges for axes in `SegyViewer` z-slice graph.
 - [#782](https://github.com/equinor/webviz-subsurface/pull/782) - Fixed an issue in `VolumetricAnalysis` when calculating property columns on grouped selections.
+- [#791](https://github.com/equinor/webviz-subsurface/pull/791) - Ensure correct map bounds in `SurfaceViewerFMU` when switching between attributes with different geometry.
 
 ## [0.2.5] - 2021-09-03
 ### Added

--- a/webviz_subsurface/plugins/_surface_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_surface_viewer_fmu.py
@@ -397,7 +397,7 @@ attribute_settings:
                                     unitScale={},
                                     autoScaleMap=True,
                                     minZoom=-19,
-                                    updateMode="update",
+                                    updateMode="replace",
                                     mouseCoords={"position": "bottomright"},
                                     colorBar={"position": "bottomleft"},
                                     switch={
@@ -418,7 +418,7 @@ attribute_settings:
                                     unitScale={},
                                     autoScaleMap=True,
                                     minZoom=-19,
-                                    updateMode="update",
+                                    updateMode="replace",
                                     mouseCoords={"position": "bottomright"},
                                     colorBar={"position": "bottomleft"},
                                     switch={
@@ -439,7 +439,7 @@ attribute_settings:
                                     unitScale={},
                                     autoScaleMap=True,
                                     minZoom=-19,
-                                    updateMode="update",
+                                    updateMode="replace",
                                     mouseCoords={"position": "bottomright"},
                                     colorBar={"position": "bottomleft"},
                                     switch={


### PR DESCRIPTION
When switching between attributes with different geometry the map bounds are not updated. There seems to be an issue using `updateMode="update"`. 
Switching to `updateMode="replace"` fixes the issue.


### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
