### PR TITLE
Bugfix sensitivity run detection `ParametersModel` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#761](https://github.com/equinor/webviz-subsurface/pull/761) - Store `xtgeo.RegularSurface` as bytestream instead of serializing to `json`.
 
 ### Fixed
+- [#794](https://github.com/equinor/webviz-subsurface/pull/794) - Fixed an issue in `VolumetricAnalysis` to prevent design matrix runs with only a single montecarlo sensitivity to be interpreted as a sensitivity run.
 - [#765](https://github.com/equinor/webviz-subsurface/pull/765) - Use correct inline/xline ranges for axes in `SegyViewer` z-slice graph.
 - [#782](https://github.com/equinor/webviz-subsurface/pull/782) - Fixed an issue in `VolumetricAnalysis` when calculating property columns on grouped selections.
 - [#791](https://github.com/equinor/webviz-subsurface/pull/791) - Ensure correct map bounds in `SurfaceViewerFMU` when switching between attributes with different geometry.

--- a/webviz_subsurface/_models/parameter_model.py
+++ b/webviz_subsurface/_models/parameter_model.py
@@ -117,7 +117,7 @@ class ParametersModel:
 
         return not all(
             (
-                (df["SENSNAME"].nunique() == 1 and df["SENSTYPE"].unique() != ["mc"])
+                (df["SENSNAME"].nunique() == 1 and df["SENSTYPE"].unique() == ["mc"])
                 for _, df in self.dataframe.groupby("ENSEMBLE")
             )
         )


### PR DESCRIPTION
Bugfix in the sensitivity run detection logic in `ParametersModel`. 
Desired behavior, if only ensembles with single montecarlo sensitivities the run should not be flagged as a sensitivity run.
