### PR TITLE
Bugfixes `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#761](https://github.com/equinor/webviz-subsurface/pull/761) - Store `xtgeo.RegularSurface` as bytestream instead of serializing to `json`.
 
 ### Fixed
+- [#802](https://github.com/equinor/webviz-subsurface/pull/802) - Removed `BO` or `BG` as response options for the tornados in `VolumetricAnalysis`, selecting them caused an error.
 - [#794](https://github.com/equinor/webviz-subsurface/pull/794) - Fixed an issue in `VolumetricAnalysis` to prevent design matrix runs with only a single montecarlo sensitivity to be interpreted as a sensitivity run.
 - [#765](https://github.com/equinor/webviz-subsurface/pull/765) - Use correct inline/xline ranges for axes in `SegyViewer` z-slice graph.
 - [#782](https://github.com/equinor/webviz-subsurface/pull/782) - Fixed an issue in `VolumetricAnalysis` when calculating property columns on grouped selections.

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -94,7 +94,12 @@ def comparison_callback(
     if selections["value1"] == selections["value2"]:
         return html.Div("Comparison between equal sources")
 
+    # Handle None in highlight criteria input
+    for key in ["Accept value", "Ignore <"]:
+        selections[key] = selections[key] if selections[key] is not None else 0
+
     groupby = selections["Group by"] if selections["Group by"] is not None else []
+    group_on_fluid = "FLUID_ZONE" in groupby
     hc_responses = ["STOIIP", "GIIP", "ASSOCIATEDGAS", "ASSOCIATEDOIL"]
     # for hc responses and bo/bg the data should be grouped
     # on fluid zone to avoid misinterpretations
@@ -210,7 +215,9 @@ def comparison_callback(
         )
         barfig_non_highlighted = create_barfig(
             df=df[df["highlighted"] == "yes"],
-            groupby=groupby,
+            groupby=groupby
+            if group_on_fluid
+            else [x for x in groupby if x != "FLUID_ZONE"],
             diff_mode=selections["Diff mode"],
             colorcol=resp1,
         )
@@ -417,9 +424,7 @@ def create_barfig(
         create_figure(
             plot_type="bar",
             data_frame=df,
-            x=df[[x for x in groupby if x != "FLUID_ZONE"]]
-            .astype(str)
-            .agg(" ".join, axis=1),
+            x=df[groupby].astype(str).agg(" ".join, axis=1) if groupby else ["Total"],
             y=diff_mode,
             color_continuous_scale="teal_r",
             color=df[colorcol],

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -494,8 +494,9 @@ def selections_controllers(
     def _update_tornado_selections_from_mode(mode: str, selector_ids: list) -> tuple:
         settings = {}
         if mode == "custom":
+            responses = [x for x in volumemodel.responses if x not in ["BO", "BG"]]
             settings["Response left"] = settings["Response right"] = {
-                "options": [{"label": i, "value": i} for i in volumemodel.responses],
+                "options": [{"label": i, "value": i} for i in responses],
                 "disabled": False,
             }
         else:

--- a/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
@@ -195,7 +195,7 @@ class VolumeValidatorAndCombinator:
             return [x for x in regcols if (df[x] == 1).all()]
         return ["SET"]
 
-    def drop_total_columns(self):
+    def drop_total_columns(self) -> None:
         """Drop columns with "TOTAL" if both static and dynamic volumes in input"""
         total_columns = [col for col in self.dframe if col.endswith("_TOTAL")]
         if total_columns:
@@ -205,7 +205,7 @@ class VolumeValidatorAndCombinator:
             )
             self.dframe.drop(columns=total_columns, inplace=True)
 
-    def drop_rows_with_totals_from_selectors(self):
+    def drop_rows_with_totals_from_selectors(self) -> None:
         """Drop rows containing total volumes ("Totals") if present"""
         for sel in [col for col in self.VALID_STATIC_SELECTORS if col in self.dframe]:
             self.dframe = self.dframe.loc[self.dframe[sel] != "Totals"]


### PR DESCRIPTION
PR with small bugfixes for `VolumetricAnalysis`:

Comparison pages:
1. Handle None in the Input components by setting a default value of 0
2. Fix issue to avoid data from the different FLUID_ZONEs stacking upon eachother in the barfigure
3. Use "Total" as label in the barfigure if no "level of investigation" has been selected

Other:
1. Removed "BO" and "BG" as option in tornado as they will cause error if multiple FLUID_ZONEs exists
2. Print out "valid static columns" for the user if the volume type most likely is static but contains either custom columns or not standard column names. 
3. Remove TOTAL columns if both static and dynamic volumes have been given as input to avoid misleading comparison (they often represent different things)
4. Remove rows with total volumes from selectors if they are present to avoid doubling of volumes #800

Most issues are bugfixes on non-released code, except removing "BO" and "BG" from the tornados . I'll add a changelog for this.

