### PR TITLE
Runtime improvement in GroupTree plugin

### DIFF
--- a/webviz_subsurface/plugins/_group_tree/group_tree.py
+++ b/webviz_subsurface/plugins/_group_tree/group_tree.py
@@ -80,7 +80,7 @@ class GroupTree(WebvizPluginABC):
                     ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                     for ens in ensembles
                 },
-                time_index = "monthly"
+                time_index="monthly",
             )
         )
         smry = self.emodel.get_or_load_smry_cached()

--- a/webviz_subsurface/plugins/_group_tree/group_tree.py
+++ b/webviz_subsurface/plugins/_group_tree/group_tree.py
@@ -79,7 +79,8 @@ class GroupTree(WebvizPluginABC):
                 ensemble_paths={
                     ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                     for ens in ensembles
-                }
+                },
+                time_index = "monthly"
             )
         )
         smry = self.emodel.get_or_load_smry_cached()


### PR DESCRIPTION
Fixed #806 by adding time_index="monthly" to the loading of summary data. Ommiting that led to loading raw eclipse dates which were not even the same over the realizations.