### PR TITLE
Grouptree more statistical options

### DIFF
--- a/webviz_subsurface/plugins/_group_tree/controllers/controllers.py
+++ b/webviz_subsurface/plugins/_group_tree/controllers/controllers.py
@@ -13,25 +13,27 @@ def controllers(
     @app.callback(
         Output({"id": get_uuid("controls"), "element": "tree_mode"}, "options"),
         Output({"id": get_uuid("controls"), "element": "tree_mode"}, "value"),
-        Output({"id": get_uuid("controls"), "element": "realization"}, "options"),
-        Output({"id": get_uuid("controls"), "element": "realization"}, "value"),
+        Output({"id": get_uuid("options"), "element": "statistical_option"}, "value"),
+        Output({"id": get_uuid("options"), "element": "realization"}, "options"),
+        Output({"id": get_uuid("options"), "element": "realization"}, "value"),
         Input({"id": get_uuid("controls"), "element": "ensemble"}, "value"),
     )
     def _update_ensemble_options(
         ensemble: str,
-    ) -> Tuple[List[Dict[str, Any]], str, List[Dict[str, Any]], Optional[int]]:
+    ) -> Tuple[List[Dict[str, Any]], str, str, List[Dict[str, Any]], Optional[int]]:
         """Updates the selection options when the ensemble value changes"""
         tree_mode_options: List[Dict[str, Any]] = [
             {
-                "label": "Ensemble mean",
-                "value": "plot_mean",
+                "label": "Statistics",
+                "value": "statistics",
             },
             {
                 "label": "Single realization",
                 "value": "single_real",
             },
         ]
-        tree_mode_value = "plot_mean"
+        tree_mode_value = "statistics"
+        stat_options_default = "mean"
 
         if not grouptreedata.tree_is_equivalent_in_all_real(ensemble):
             tree_mode_options[0]["label"] = "Ensemble mean (disabled)"
@@ -42,6 +44,7 @@ def controllers(
         return (
             tree_mode_options,
             tree_mode_value,
+            stat_options_default,
             real_options,
             real_default,
         )
@@ -49,7 +52,7 @@ def controllers(
     @app.callback(
         Output(get_uuid("grouptree_wrapper"), "children"),
         Input({"id": get_uuid("controls"), "element": "tree_mode"}, "value"),
-        Input({"id": get_uuid("controls"), "element": "realization"}, "value"),
+        Input({"id": get_uuid("options"), "element": "realization"}, "value"),
         Input({"id": get_uuid("filters"), "element": "prod_inj_other"}, "value"),
         State({"id": get_uuid("controls"), "element": "ensemble"}, "value"),
     )
@@ -72,7 +75,11 @@ def controllers(
 
     @app.callback(
         Output(
-            {"id": get_uuid("controls"), "element": "single_real_options"},
+            {"id": get_uuid("options"), "element": "statistical_options"},
+            "style",
+        ),
+        Output(
+            {"id": get_uuid("options"), "element": "single_real_options"},
             "style",
         ),
         Input(
@@ -80,7 +87,9 @@ def controllers(
             "value",
         ),
     )
-    def _show_hide_single_real_options(tree_mode: str) -> Dict:
-        if tree_mode == "plot_mean":
-            return {"display": "none"}
-        return {"display": "block"}
+    def _show_hide_single_real_options(
+        tree_mode: str,
+    ) -> Tuple[Dict[str, str], Dict[str, str]]:
+        if tree_mode == "statistics":
+            return {"display": "block"}, {"display": "none"}
+        return {"display": "none"}, {"display": "block"}

--- a/webviz_subsurface/plugins/_group_tree/controllers/controllers.py
+++ b/webviz_subsurface/plugins/_group_tree/controllers/controllers.py
@@ -52,16 +52,17 @@ def controllers(
     @app.callback(
         Output(get_uuid("grouptree_wrapper"), "children"),
         Input({"id": get_uuid("controls"), "element": "tree_mode"}, "value"),
+        Input({"id": get_uuid("options"), "element": "statistical_option"}, "value"),
         Input({"id": get_uuid("options"), "element": "realization"}, "value"),
         Input({"id": get_uuid("filters"), "element": "prod_inj_other"}, "value"),
         State({"id": get_uuid("controls"), "element": "ensemble"}, "value"),
     )
     def _render_grouptree(
-        tree_mode: str, real: int, prod_inj_other: list, ensemble: str
+        tree_mode: str, stat_option: str, real: int, prod_inj_other: list, ensemble: str
     ) -> list:
         """This callback updates the input dataset to the Grouptree component."""
         data, edge_options, node_options = grouptreedata.create_grouptree_dataset(
-            ensemble, tree_mode, real, prod_inj_other
+            ensemble, tree_mode, stat_option, real, prod_inj_other
         )
 
         return [

--- a/webviz_subsurface/plugins/_group_tree/group_tree_data.py
+++ b/webviz_subsurface/plugins/_group_tree/group_tree_data.py
@@ -49,6 +49,7 @@ class GroupTreeData:
         self,
         ensemble: str,
         tree_mode: str,
+        stat_option: str,
         real: int,
         prod_inj_other: List[str],
     ) -> Tuple[List[Dict[Any, Any]], List[Dict[str, str]], List[Dict[str, str]]]:
@@ -68,7 +69,17 @@ class GroupTreeData:
         smry_ens = self.smry[self.smry["ENSEMBLE"] == ensemble]
         # smry_ens.dropna(how="all", axis=1, inplace=True)
         if tree_mode == "statistics":
-            smry_ens = smry_ens.groupby("DATE").mean().reset_index()
+            if stat_option == "mean":
+                smry_ens = smry_ens.groupby("DATE").mean().reset_index()
+            elif stat_option in ["p50", "p10", "p90"]:
+                quantile = {"p50": 0.5, "p10": 0.9, "p90": 0.1}[stat_option]
+                smry_ens = smry_ens.groupby("DATE").quantile(quantile).reset_index()
+            elif stat_option == "max":
+                smry_ens = smry_ens.groupby("DATE").max().reset_index()
+            elif stat_option == "min":
+                smry_ens = smry_ens.groupby("DATE").min().reset_index()
+            else:
+                raise ValueError(f"Statistical option: {stat_option} not implemented")
         else:
             smry_ens = smry_ens[smry_ens["REAL"] == real]
 

--- a/webviz_subsurface/plugins/_group_tree/group_tree_data.py
+++ b/webviz_subsurface/plugins/_group_tree/group_tree_data.py
@@ -67,7 +67,7 @@ class GroupTreeData:
         # Filter smry
         smry_ens = self.smry[self.smry["ENSEMBLE"] == ensemble]
         # smry_ens.dropna(how="all", axis=1, inplace=True)
-        if tree_mode == "plot_mean":
+        if tree_mode == "statistics":
             smry_ens = smry_ens.groupby("DATE").mean().reset_index()
         else:
             smry_ens = smry_ens[smry_ens["REAL"] == real]

--- a/webviz_subsurface/plugins/_group_tree/group_tree_data.py
+++ b/webviz_subsurface/plugins/_group_tree/group_tree_data.py
@@ -67,7 +67,7 @@ class GroupTreeData:
 
         # Filter smry
         smry_ens = self.smry[self.smry["ENSEMBLE"] == ensemble]
-        # smry_ens.dropna(how="all", axis=1, inplace=True)
+
         if tree_mode == "statistics":
             if stat_option == "mean":
                 smry_ens = smry_ens.groupby("DATE").mean().reset_index()

--- a/webviz_subsurface/plugins/_group_tree/views/main_view.py
+++ b/webviz_subsurface/plugins/_group_tree/views/main_view.py
@@ -5,6 +5,7 @@ from dash import html
 
 from .filters_view import filters_layout
 from .selections_view import selections_layout
+from .options_view import options_layout
 
 
 def main_view(get_uuid: Callable, ensembles: list) -> wcc.FlexBox:
@@ -19,6 +20,7 @@ def main_view(get_uuid: Callable, ensembles: list) -> wcc.FlexBox:
                         style={"height": "82vh"},
                         children=[
                             selections_layout(get_uuid, ensembles),
+                            options_layout(get_uuid),
                             filters_layout(get_uuid),
                         ],
                     )

--- a/webviz_subsurface/plugins/_group_tree/views/options_view.py
+++ b/webviz_subsurface/plugins/_group_tree/views/options_view.py
@@ -5,7 +5,7 @@ from dash import html
 
 
 def options_layout(get_uuid: Callable) -> wcc.Selectors:
-    """The filters part of the menu"""
+    """The options part of the menu"""
     options_uuid = get_uuid("options")
     return wcc.Selectors(
         id=get_uuid("options_layout"),

--- a/webviz_subsurface/plugins/_group_tree/views/options_view.py
+++ b/webviz_subsurface/plugins/_group_tree/views/options_view.py
@@ -1,0 +1,43 @@
+from typing import Callable
+
+import webviz_core_components as wcc
+from dash import html
+
+
+def options_layout(get_uuid: Callable) -> wcc.Selectors:
+    """The filters part of the menu"""
+    options_uuid = get_uuid("options")
+    return wcc.Selectors(
+        id=get_uuid("options_layout"),
+        label="Options",
+        children=[
+            html.Div(
+                id={"id": options_uuid, "element": "statistical_options"},
+                children=[
+                    wcc.RadioItems(
+                        id={"id": options_uuid, "element": "statistical_option"},
+                        options=[
+                            {"label": "Mean", "value": "mean"},
+                            {"label": "P50/Median", "value": "p50"},
+                            {"label": "P10", "value": "p10"},
+                            {"label": "P90", "value": "p90"},
+                            {"label": "Max", "value": "max"},
+                            {"label": "Min", "value": "min"},
+                        ],
+                    )
+                ],
+            ),
+            html.Div(
+                id={"id": options_uuid, "element": "single_real_options"},
+                children=[
+                    wcc.Dropdown(
+                        label="Realization",
+                        id={"id": options_uuid, "element": "realization"},
+                        options=[],
+                        value=None,
+                        multi=False,
+                    )
+                ],
+            ),
+        ],
+    )

--- a/webviz_subsurface/plugins/_group_tree/views/selections_view.py
+++ b/webviz_subsurface/plugins/_group_tree/views/selections_view.py
@@ -1,7 +1,6 @@
 from typing import Callable
 
 import webviz_core_components as wcc
-from dash import html
 
 
 def selections_layout(get_uuid: Callable, ensembles: list) -> wcc.Selectors:
@@ -21,17 +20,6 @@ def selections_layout(get_uuid: Callable, ensembles: list) -> wcc.Selectors:
             wcc.RadioItems(
                 label="Mean or realization",
                 id={"id": controls_uuid, "element": "tree_mode"},
-            ),
-            html.Div(
-                id={"id": controls_uuid, "element": "single_real_options"},
-                children=[
-                    wcc.Dropdown(
-                        id={"id": controls_uuid, "element": "realization"},
-                        options=[],
-                        value=None,
-                        multi=False,
-                    )
-                ],
             ),
         ],
     )


### PR DESCRIPTION
Solves #785. Added more statistical options: P50, P10, P90, Max and min. Also added an `Options `section to the menu that makes it look nicer.