### PR TITLE
Bugfixes `VolumetricAnalysis`

### DIFF
--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -281,9 +281,9 @@ def compute_highlighted_col(
     df: pd.DataFrame, response: str, value1: str, selections: dict
 ) -> list:
     highlight_mask = (df[response][value1] > selections["Ignore <"]) & (
-        df[response]["diff (%)"].abs() < selections["Accept value"]
-    ) | (df[response][value1] <= selections["Ignore <"])
-    return np.where(highlight_mask, "no", "yes")
+        df[response]["diff (%)"].abs() > selections["Accept value"]
+    )
+    return np.where(highlight_mask, "yes", "no")
 
 
 def find_higlighted_real_count(

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -24,10 +24,10 @@ def selections_controllers(
             {"id": get_uuid("selections"), "tab": "voldist", "settings": "Colorscale"},
             "colorscale",
         ),
+        Input(get_uuid("initial-load-info"), "data"),
         State(get_uuid("page-selected"), "data"),
         State(get_uuid("tabs"), "value"),
         State(get_uuid("selections"), "data"),
-        State(get_uuid("initial-load-info"), "data"),
         State({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "id"),
         State(
             {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": ALL}, "id"
@@ -37,10 +37,10 @@ def selections_controllers(
         selectors: list,
         filters: list,
         colorscale: str,
+        initial_load: dict,
         selected_page: str,
         selected_tab: str,
         previous_selection: dict,
-        initial_load: dict,
         selector_ids: list,
         filter_ids: list,
     ) -> dict:


### PR DESCRIPTION
Two bugfixes in `VolumetricAnalysis`:
- Fix an issue with the logic that controls what data are highlighted in the `Correlation` pages
- Fix an issue where the initial_load parameter came in as None for the `Fipfile QC` page

Both bugfixes are on non-released code