### PR TITLE
Fixed formatting error in `DiskUsage` bar chart tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#734](https://github.com/equinor/webviz-subsurface/pull/645) - New plugin, SeismicMisfit, for comparing observed and modelled seismic attributes. Multiple views, including misfit quantification and coverage plots.
 - [#809](https://github.com/equinor/webviz-subsurface/pull/809) - `GroupTree` - added more statistical options (P10, P90, P50/Median, Max, Min). Some improvements to the menu layout and behaviour
 
+### Fixed
+- [#817](https://github.com/equinor/webviz-subsurface/pull/817) - `DiskUsage` - Fixed formatting error in bar chart tooltip.
+
 ## [0.2.6] - 2021-10-08
 
 ### Added

--- a/webviz_subsurface/plugins/_disk_usage.py
+++ b/webviz_subsurface/plugins/_disk_usage.py
@@ -104,7 +104,7 @@ class DiskUsage(WebvizPluginABC):
                 {
                     "y": self.disk_usage["usageGiB"],
                     "x": self.disk_usage["userid"],
-                    "text": self.disk_usage["usageGiB"].map(lambda x: "{x:.2f} GiB"),
+                    "text": self.disk_usage["usageGiB"].map(lambda x: f"{x:.2f} GiB"),
                     "hoverinfo": "x+text",
                     "type": "bar",
                 }


### PR DESCRIPTION
Added missing `f` in front of (what was supposed to be) an `f-string` in the bar chart tooltips for the `DiskUsage` plugin

---

### Contributor checklist

- [X] :tada: This PR closes #816 
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
