### PR TITLE
SeismicMisfit update, including attr selector and reworked config

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -74,10 +74,10 @@ jobs:
       env:
         # If you want the CI to (temporarily) run against your fork of the testdada,
         # change the value her from "equinor" to your username.
-        TESTDATA_REPO_OWNER: rnyb
+        TESTDATA_REPO_OWNER: equinor
         # If you want the CI to (temporarily) run against another branch than master,
         # change the value her from "master" to the relevant branch name.
-        TESTDATA_REPO_BRANCH: add-drogon-info
+        TESTDATA_REPO_BRANCH: master
       run: |
         git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/webviz-subsurface-testdata.git
         # Copy any clientside script to the test folder before running tests


### PR DESCRIPTION
---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [x] Remove any decimals in color-bar when plotting region numbers
   - [x] Removed ensemble paths from "Ensemble info", include attribute names instead
   - [x]  Include attribute selector, one selector per tab (selector is local to tab). 
   * Old implementation needed one page per. 
   * Can only view one attribute at a time (but many ensembles as before)attribute. 
   * yaml config: input as list of attribute names. 
   * _seismic_misfit.py: creates dict of dataframes in init (one df per attribute)
   - [x] Attribute_name input - hardcode assumption that obs and sim attr file names are equal
   - [x]  Calculate initial marker size automatic based on number of datapoints
   - [x] Add marker size selector for obsdata map view
   - [x] Include polygon dropdown selector in map views
   * polygon argument: the user can now choose to give path to folder to automatically fetch all csv files in that folder. 
   * Alternatively assign filename directly, with or without *-notation. Previous setup only had option to include one polygon file.
   - [x] Updated code to read one combined obs/meta data file
   * Previously the code read two seperate files. One with obs data and one
with meta data. The updated code requires that the obs/meta file has
the prefix "meta--", but otherwise the same name as the names given in
attributes input list.
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
