### PR TITLE
Bugfixes to `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#809](https://github.com/equinor/webviz-subsurface/pull/809) - `GroupTree` - added more statistical options (P10, P90, P50/Median, Max, Min). Some improvements to the menu layout and behaviour
 
 ### Fixed
+- [#833](https://github.com/equinor/webviz-subsurface/pull/833) - Fixed errors in `VolumetricAnalysis` related to empty/insufficient data after filtering in the `tornadoplots` and `comparison` tabs.
 - [#817](https://github.com/equinor/webviz-subsurface/pull/817) - `DiskUsage` - Fixed formatting error in bar chart tooltip.
 - [#820](https://github.com/equinor/webviz-subsurface/pull/820) - `SurfaceWithGridCrossSection` - Fixed an issue with intersecting grids generated with
 `xtgeo==2.15.2`. Grids exported from RMS with this version of xtgeo should be re-exported using a newer version as the subgrid information is incorrect.

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -85,9 +85,23 @@ def selections_controllers(
     @callback(
         Output(get_uuid("initial-load-info"), "data"),
         Input(get_uuid("page-selected"), "data"),
+        Input({"id": get_uuid("selections"), "tab": ALL, "selector": ALL}, "value"),
+        Input(
+            {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": ALL},
+            "value",
+        ),
         State(get_uuid("initial-load-info"), "data"),
     )
-    def _store_initial_load_info(page_selected: str, initial_load: dict) -> dict:
+    def _store_initial_load_info(
+        page_selected: str,
+        _selectors_changed: list,
+        _filters_changed: list,
+        initial_load: dict,
+    ) -> Dict[str, bool]:
+        """
+        Store info (True/False) reagarding if a page is initally loaded.
+        Updating filters or selectors will set the value to False
+        """
         if initial_load is None:
             initial_load = {}
         initial_load[page_selected] = page_selected not in initial_load
@@ -265,7 +279,7 @@ def selections_controllers(
         if selected_tab == "table" and page_selections["Group by"] is not None:
             selected_data = page_selections["Group by"]
         if selected_tab == "tornado":
-            selected_data = ["SENSNAME"]
+            selected_data = ["SENSNAME", page_selections["Subplots"]]
 
         output = {}
         for selector in ["SOURCE", "ENSEMBLE", "SENSNAME"]:

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/tornado_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/tornado_controllers.py
@@ -13,7 +13,7 @@ from webviz_subsurface._models import InplaceVolumesModel
 
 from ..utils.table_and_figure_utils import create_data_table, create_table_columns
 from ..utils.utils import update_relevant_components
-from ..views.tornado_view import tornado_plots_layout
+from ..views.tornado_view import tornado_error_layout, tornado_plots_layout
 
 
 # pylint: disable=too-many-locals
@@ -58,25 +58,29 @@ def tornado_controllers(
                 filters.update(SENSNAME=selections["Sensitivities"])
 
             dframe = volumemodel.get_df(filters=filters, groups=groups)
-            dframe.rename(columns={response: "VALUE"}, inplace=True)
 
-            df_groups = (
-                dframe.groupby(selections["Subplots"]) if subplots else [(None, dframe)]
-            )
-
-            for group, df in df_groups:
-                figure, table, columns = tornado_figure_and_table(
-                    df=df,
-                    response=response,
-                    selections=selections,
-                    theme=theme,
-                    sensitivity_colors=sens_colors(),
-                    font_size=max((20 - (0.4 * len(df_groups))), 10),
-                    group=group,
+            ref_in_dframe = selections["Reference"] in dframe["SENSNAME"].unique()
+            if ref_in_dframe and not dframe.empty:
+                dframe.rename(columns={response: "VALUE"}, inplace=True)
+                df_groups = (
+                    dframe.groupby(selections["Subplots"])
+                    if subplots
+                    else [(None, dframe)]
                 )
-                figures.append(figure)
-                if selections["tornado_table"]:
-                    tables.append(table)
+
+                for group, df in df_groups:
+                    figure, table, columns = tornado_figure_and_table(
+                        df=df,
+                        response=response,
+                        selections=selections,
+                        theme=theme,
+                        sensitivity_colors=sens_colors(),
+                        font_size=max((20 - (0.4 * len(df_groups))), 10),
+                        group=group,
+                    )
+                    figures.append(figure)
+                    if selections["tornado_table"]:
+                        tables.append(table)
 
         if selections["Shared axis"] and selections["Scale"] != "True":
             x_absmax = max([max(abs(trace.x)) for fig in figures for trace in fig.data])
@@ -96,6 +100,12 @@ def tornado_controllers(
                             height="42vh",
                             table_id={"table_id": f"{page_selected}-torntable"},
                         ),
+                    )
+                    if figures
+                    else tornado_error_layout(
+                        "No data left after filtering"
+                        if dframe.empty
+                        else f"Reference sensitivity '{selections['Reference']}' not in input data"
                     ),
                     "conditions": {"page": page_selected},
                 }

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/tornado_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/tornado_view.py
@@ -60,6 +60,15 @@ def tornado_plots_layout(figures: list, table: list) -> html.Div:
     )
 
 
+def tornado_error_layout(message: str) -> wcc.Frame:
+    return wcc.Frame(
+        color="white",
+        highlight=False,
+        style={"height": "91vh"},
+        children=html.Div(message, style={"margin-top": "40px"}),
+    )
+
+
 def tornado_selections_layout(
     uuid: str, volumemodel: InplaceVolumesModel, tab: str
 ) -> html.Div:


### PR DESCRIPTION
PR with bugfixes to the `VolumetricAnalysis` plugin:
- Handle empty dataframes after filtering in the `comparison` pages 
- Handle empty dataframes and missing tornado reference after filtering in the `tornadoplots` page 
- Fix error in the "update" logic of pages – set the initial_load state to False after a user selection is made
- Ensure the filter for the selected subplot column is set to multi in the `tornadoplots` page

