### PR TITLE
Removed `ert` from test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ TESTS_REQUIRE = [
     "bandit",
     "black>=21.4b0",
     "dash[testing]",
-    "ert",
     "flaky",
     "isort",
     "mypy",


### PR DESCRIPTION
Removed `ert` from test dependencies since it is no longer needed and causes test run to fail.
