### PR TITLE
Updated target values in tests due to fixes in ecl 2.13.1

### DIFF
--- a/tests/unit_tests/model_tests/test_ensemble_model.py
+++ b/tests/unit_tests/model_tests/test_ensemble_model.py
@@ -44,7 +44,7 @@ def test_smry_load(testdata_folder):
     )
     smry = emodel.load_smry()
     assert len(smry.columns) == 933
-    assert len(smry["DATE"].unique()) == 2368
+    assert len(smry["DATE"].unique()) == 2369
 
 
 @pytest.mark.usefixtures("app")

--- a/tests/unit_tests/model_tests/test_ensemble_set_model.py
+++ b/tests/unit_tests/model_tests/test_ensemble_set_model.py
@@ -19,7 +19,7 @@ def test_single_ensemble(testdata_folder):
     assert emodel.ens_folders == {"iter-0": Path(testdata_folder) / "01_drogon_ahm"}
     smry = emodel.get_or_load_smry_cached()
     assert len(smry.columns) == 934
-    assert len(smry["DATE"].unique()) == 2368
+    assert len(smry["DATE"].unique()) == 2369
     assert smry["ENSEMBLE"].unique() == ["iter-0"]
     assert smry["ENSEMBLE"].dtype == np.dtype("O")
     assert all(
@@ -49,7 +49,7 @@ def test_smry_load_multiple_ensembles(testdata_folder):
     )
     smry = emodel.get_or_load_smry_cached()
     assert len(smry.columns) == 934
-    assert len(smry["DATE"].unique()) == 4164
+    assert len(smry["DATE"].unique()) == 4167
     assert set(smry["ENSEMBLE"].unique()) == set(["iter-0", "iter-3"])
     assert smry["ENSEMBLE"].dtype == np.dtype("O")
     # assert smry["DATE"].dtype == np.dtype("O") # Fails due to wrong input data?


### PR DESCRIPTION
Version 2.13.1 of `ecl` fixes some precision issues for calculation of timestamps, see https://github.com/equinor/ecl/pull/837
This PR updates the expected target values for our tests to match the new results from `ecl`