### PR TITLE
Fixes to `ParameterResponseCorrelation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Changed
+- [#853](https://github.com/equinor/webviz-subsurface/pull/853) - `ParameterResponseCorrelation` improvements. Constant parameters are removed from the correlation figure, and option to set maximum number of parameters is added. Trendline is added to the scatterplot. Axis in correlation figure is now calculated based on data.
 - [#844](https://github.com/equinor/webviz-subsurface/pull/844) - `SeismicMisfit` improvements. Data ranges now follows selected attribute. User defined zooms are now kept during callbacks. New option in slice plot to show individual realizations. Prettyfied all hoverdata. New colorscales. Polygons sorted by name in drop down selector.
 
 ## [0.2.7] - 2021-11-08


### PR DESCRIPTION
PR with improvements to the `ParameterResponseCorrelation` plugin:

- Parsing of the parameter dataframe with ParameterModel to remove prefixes from gen_kw, and drop constant parameters 
- Added option of setting the maximum number of parameters shown in the correlation bar
- Added trendline to scatterplot
- Set xaxis range for correlation barchart from data instead of using -1 and 1

After:
![image](https://user-images.githubusercontent.com/61694854/142881093-da886536-42a6-4d95-9eb7-f6550e4f485a.png)


Before:
![image](https://user-images.githubusercontent.com/61694854/142881135-72bb593a-c5ac-4894-8a00-53da4bba3201.png)


---

### Contributor checklist

- [x] :tada: This PR closes #852
