### PR TITLE
Allow mixing sensitivity and gen_kw ensembles in `ParametersModel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#845](https://github.com/equinor/webviz-subsurface/pull/845) - Added realization plot colored by sensitivity to tornado tab in `VolumetricAnalysis`. 
 
 ### Changed
+- [#855](https://github.com/equinor/webviz-subsurface/pull/855) - `VolumetricAnalysis` now supports mixing sensitivity and non-sensitivity ensembles.
 - [#853](https://github.com/equinor/webviz-subsurface/pull/853) - `ParameterResponseCorrelation` improvements. Constant parameters are removed from the correlation figure, and option to set maximum number of parameters is added. Trendline is added to the scatterplot. Axis in correlation figure is now calculated based on data.
 - [#844](https://github.com/equinor/webviz-subsurface/pull/844) - `SeismicMisfit` improvements. Data ranges now follows selected attribute. User defined zooms are now kept during callbacks. New option in slice plot to show individual realizations. Prettyfied all hoverdata. New colorscales. Polygons sorted by name in drop down selector.
 - [#842](https://github.com/equinor/webviz-subsurface/pull/842) - `GroupTree` improvements. Supporting groups as leaf nodes.

--- a/webviz_subsurface/_models/parameter_model.py
+++ b/webviz_subsurface/_models/parameter_model.py
@@ -106,10 +106,11 @@ class ParametersModel:
         if "SENSNAME" not in self._dataframe:
             return False
 
-        if self.dataframe["SENSNAME"].isnull().values.any():
-            raise ValueError(
-                "Ensembles with and without sensitivity data mixed - this is not supported!"
-            )
+        # if mix of gen_kw and sensitivity ensembles add
+        # dummy sensitivvity columns to gen_kw ensembles
+        gen_kw_mask = self._dataframe["SENSNAME"].isnull()
+        self._dataframe.loc[gen_kw_mask, "SENSNAME"] = "🎲"
+        self._dataframe.loc[gen_kw_mask, "SENSCASE"] = "p10_p90"
 
         # set senstype from senscase
         mc_mask = self._dataframe["SENSCASE"] == "p10_p90"


### PR DESCRIPTION
PR to support a mix of sensitivity ensembles and gen_kw ensembles in `ParametersModel`. 
A dice is added as SENSNAME to gen_kw ensembles for easy distinction from sensitivity ensembles:
![image](https://user-images.githubusercontent.com/61694854/143310656-2d6c6eb6-c39c-40d9-9a8e-f2b7e523533c.png)
