### PR TITLE
Added sensitivity comparison to `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Added
+- [#856](https://github.com/equinor/webviz-subsurface/pull/856) - `VolumetricAnalysis` - Added support for comparing sensitivities both within and across ensembles.
 - [#721](https://github.com/equinor/webviz-subsurface/pull/721) - Added data provider for reading ensemble summary data through a unified interface, supporting optional lazy resampling/interpolation depending on data input format.
 - [#845](https://github.com/equinor/webviz-subsurface/pull/845) - Added realization plot colored by sensitivity to tornado tab in `VolumetricAnalysis`. 
 

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -101,6 +101,9 @@ class InplaceVolumesModel:
 
         self._dataframe.sort_values(by=["ENSEMBLE", "REAL"], inplace=True)
 
+        # ensure ensemble column consists of strings
+        self._dataframe["ENSEMBLE"] = self._dataframe["ENSEMBLE"].astype(str)
+
         # compute and set property columns
         self._set_initial_property_columns()
         self._dataframe = self.compute_property_columns(self._dataframe)
@@ -136,6 +139,21 @@ class InplaceVolumesModel:
     @property
     def ensembles(self) -> List[str]:
         return list(self._dataframe["ENSEMBLE"].unique())
+
+    @property
+    def ensemble_sensitivities(self) -> Dict[str, list]:
+        return {
+            ens: (
+                list(
+                    self._dataframe.loc[
+                        self._dataframe["ENSEMBLE"] == ens, "SENSNAME_CASE"
+                    ].unique()
+                )
+                if "SENSNAME_CASE" in self._dataframe
+                else []
+            )
+            for ens in self.ensembles
+        }
 
     @property
     def property_columns(self) -> List[str]:

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -77,7 +77,9 @@ def comparison_controllers(
                 raise PreventUpdate
 
         return comparison_callback(
-            compare_on="ENSEMBLE",
+            compare_on="SENSNAME_CASE"
+            if selections["compare_on"] == "Sensitivity"
+            else "ENSEMBLE",
             volumemodel=volumemodel,
             selections=selections,
             display_option=display_option,
@@ -91,7 +93,7 @@ def comparison_callback(
     display_option: str,
 ) -> html.Div:
     if selections["value1"] == selections["value2"]:
-        return html.Div("Comparison between equal sources")
+        return html.Div("Comparison between equal data")
 
     # Handle None in highlight criteria input
     for key in ["Accept value", "Ignore <"]:
@@ -186,8 +188,15 @@ def comparison_callback(
         )
 
     if display_option == "plots":
-        resp1 = f"{selections['Response']} {selections['value1']}"
-        resp2 = f"{selections['Response']} {selections['value2']}"
+        if "|" in selections["value1"]:
+            ens1, sens1 = selections["value1"].split("|")
+            ens2, sens2 = selections["value2"].split("|")
+            value1, value2 = (sens1, sens2) if ens1 == ens2 else (ens1, ens2)
+        else:
+            value1, value2 = selections["value1"], selections["value2"]
+
+        resp1 = f"{selections['Response']} {value1}"
+        resp2 = f"{selections['Response']} {value2}"
 
         scatter_corr = create_scatterfig(
             df=df, x=resp1, y=resp2, selections=selections, groupby=groupby
@@ -242,20 +251,36 @@ def create_comparison_df(
     rename_diff_col: bool = False,
 ) -> pd.DataFrame:
 
-    value1, value2 = selections["value1"], selections["value2"]
     resp = selections["Response"]
-    selections["filters"][compare_on] = [value1, value2]
+    possible_pivot_columns = ["SOURCE", "ENSEMBLE"] + (
+        ["SENSNAME_CASE"] if "SENSNAME_CASE" in volumemodel.selectors else []
+    )
+    df = volumemodel.get_df(
+        selections["filters"], groups=groups + possible_pivot_columns
+    )
+    # filter dataframe and set values to compare against
+    if not "|" in selections["value1"]:
+        value1, value2 = selections["value1"], selections["value2"]
+        df = df[df[compare_on].isin([value1, value2])]
+    else:
+        ens1, sens1 = selections["value1"].split("|")
+        ens2, sens2 = selections["value2"].split("|")
+        if ens1 == ens2:
+            compare_on = "SENSNAME_CASE"
+        value1, value2 = (sens1, sens2) if ens1 == ens2 else (ens1, ens2)
 
-    groups = groups + ["SOURCE", "ENSEMBLE"]
-    df = volumemodel.get_df(selections["filters"], groups=groups)
+        df = df[
+            ((df["ENSEMBLE"] == ens1) & (df["SENSNAME_CASE"] == sens1))
+            | ((df["ENSEMBLE"] == ens2) & (df["SENSNAME_CASE"] == sens2))
+        ]
 
     # if no data left, or one of the selected SOURCE/ENSEMBLE is not present
     # in the dataframe after filtering, return empty dataframe
     if df.empty or any(x not in df[compare_on].values for x in [value1, value2]):
         return pd.DataFrame()
 
-    df = df.loc[:, groups + responses].pivot_table(
-        columns=compare_on, index=[x for x in groups if x != compare_on]
+    df = df.loc[:, groups + possible_pivot_columns + responses].pivot_table(
+        columns=compare_on, index=groups
     )
     responses = [x for x in responses if x in df]
     for col in responses:
@@ -274,9 +299,10 @@ def create_comparison_df(
     df.columns = df.columns.map(" ".join).str.strip(" ")
 
     # remove columns where all values are nan and drop SOURCE/ENSMEBLE column
-    df = df.dropna(how="all", axis=1).drop(
-        columns=["SOURCE", "ENSEMBLE"], errors="ignore"
-    )
+    dropcols = [
+        x for x in df.columns[df.isna().all()] if "diff" not in x
+    ] + possible_pivot_columns
+    df = df[[x for x in df.columns if x not in dropcols]]
 
     if rename_diff_col:
         df = df.rename(columns={f"{resp} diff": "diff", f"{resp} diff (%)": "diff (%)"})

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -180,11 +180,11 @@ def selections_controllers(
             settings[selector] = {"disable": disable, "value": value}
 
         # update dropdown options based on plot type
-        if selections["Plot type"] == "scatter":
+        if settings["Plot type"]["value"] == "scatter":
             y_elm = x_elm = (
                 volumemodel.responses + volumemodel.selectors + volumemodel.parameters
             )
-        elif selections["Plot type"] in ["box", "bar"]:
+        elif settings["Plot type"]["value"] in ["box", "bar"]:
             y_elm = x_elm = volumemodel.responses + volumemodel.selectors
             if selections.get("Y Response") is None:
                 settings["Y Response"]["value"] = selected_color_by
@@ -203,6 +203,12 @@ def selections_controllers(
         settings["X Response"]["options"] = [
             {"label": elm, "value": elm} for elm in x_elm
         ]
+        if (
+            settings["X Response"]["value"] is not None
+            and settings["X Response"]["value"] not in x_elm
+        ):
+            settings["X Response"]["value"] = x_elm[0]
+
         settings["Color by"]["options"] = [
             {"label": elm, "value": elm} for elm in colorby_elm
         ]
@@ -280,6 +286,10 @@ def selections_controllers(
             selected_data = page_selections["Group by"]
         if selected_tab == "tornado":
             selected_data = ["SENSNAME_CASE", page_selections["Subplots"]]
+        if selected_tab == "ens-comp":
+            selected_data = ["SENSNAME_CASE", "ENSEMBLE"]
+        if selected_tab == "src-comp":
+            selected_data = ["SOURCE"]
 
         # set "SENSNAME_CASE" multi also if "SENSNAME" OR "SENSCASE" is selected
         if any(senscol in selected_data for senscol in ("SENSNAME", "SENSCASE")):

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -107,7 +107,7 @@ def main_view(
                             uuid=get_uuid("selections"),
                             tab="src-comp",
                             volumemodel=volumemodel,
-                            compare_on="SOURCE",
+                            compare_on="Source",
                         ),
                         filter_layout(
                             uuid=get_uuid("filters"),
@@ -119,10 +119,11 @@ def main_view(
                 ),
             )
         )
-    if len(volumemodel.ensembles) > 1:
+    if len(volumemodel.ensembles) > 1 or volumemodel.sensrun:
+        compare_on = "Ensemble" if len(volumemodel.ensembles) > 1 else "Sensitivity"
         tabs.append(
             wcc.Tab(
-                label="Ensemble comparison",
+                label=f"{compare_on} comparison",
                 value="ens-comp",
                 children=tab_view_layout(
                     main_layout=comparison_main_layout(get_uuid("main-ens-comp")),
@@ -131,13 +132,13 @@ def main_view(
                             uuid=get_uuid("selections"),
                             tab="ens-comp",
                             volumemodel=volumemodel,
-                            compare_on="ENSEMBLE",
+                            compare_on=compare_on,
                         ),
                         filter_layout(
                             uuid=get_uuid("filters"),
                             tab="ens-comp",
                             volumemodel=volumemodel,
-                            hide_selectors=["ENSEMBLE", "FLUID_ZONE"],
+                            hide_selectors=["ENSEMBLE", "FLUID_ZONE", "SENSNAME_CASE"],
                         ),
                     ],
                 ),


### PR DESCRIPTION
This PR adds the functionality of comparing sensitivities across or within ensembles in the "Ensemble Comparison" tab in `VolumetricAnalysis`

![image](https://user-images.githubusercontent.com/61694854/143434629-a384e9e5-1d92-4e26-b95a-4b2850449d34.png)

- If single sensitivity ensemble as input the tab changes name to "Sensitivity comparison"
![image](https://user-images.githubusercontent.com/61694854/143434746-322c6c4b-7f19-4e7e-b789-0a765cc739cd.png)

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
