### PR TITLE
 `GroupTree` plugin: bugfix related to BRANPROP group leaf nodes

### DIFF
--- a/webviz_subsurface/plugins/_group_tree/group_tree_data.py
+++ b/webviz_subsurface/plugins/_group_tree/group_tree_data.py
@@ -504,11 +504,6 @@ def create_leafnodetype_maps(
                 get_sumvec(datatype, nodename, nodekeyword)
                 for datatype in ["oilrate", "gasrate", "waterrate"]
             ]
-            inj_sumvecs = [
-                get_sumvec(datatype, nodename, nodekeyword)
-                for datatype in ["waterinjrate", "gasinjrate"]
-            ]
-
             sumprod = sum(
                 [
                     smry[sumvec].sum()
@@ -516,9 +511,22 @@ def create_leafnodetype_maps(
                     if sumvec in smry.columns
                 ]
             )
-            suminj = sum(
-                [smry[sumvec].sum() for sumvec in inj_sumvecs if sumvec in smry.columns]
-            )
+
+            if nodekeyword == "BRANPROP":
+                # BRANPROP nodes has no injection by definition
+                suminj = 0
+            else:
+                inj_sumvecs = [
+                    get_sumvec(datatype, nodename, nodekeyword)
+                    for datatype in ["waterinjrate", "gasinjrate"]
+                ]
+                suminj = sum(
+                    [
+                        smry[sumvec].sum()
+                        for sumvec in inj_sumvecs
+                        if sumvec in smry.columns
+                    ]
+                )
 
             is_prod_map[nodename] = sumprod > 0
             is_inj_map[nodename] = suminj > 0


### PR DESCRIPTION
This bug relates to node type classification of BRANPROP group leaf nodes. Group leaf nodes are classified by using summary data, but BRANPROP nodes does not have injection summary vectors by definition.  Therefore the `create_leafnodetype_maps` function was crashing.

This bug is fixed by setting suminj = 0 for BRANPROP group `nodes.`
