### PR TITLE
Change label and add hoverinfo for uncertainty envelope in StructuralUncertainty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED] - YYYY-MM-DD
+### Added
+- [#880](https://github.com/equinor/webviz-subsurface/pull/880) - Show hover information for uncertainty envelope in `StructuralUncertainty`.
 
 ### Fixed
 

--- a/webviz_subsurface/plugins/_structural_uncertainty/figures/intersection.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/figures/intersection.py
@@ -122,7 +122,7 @@ def get_plotly_traces_uncertainty_envelope(
                 legend_group=name,
                 legend_name=legendname,
                 show_legend=showlegend,
-                show_hoverinfo=False,
+                show_hoverinfo=True,
             )
         )
     return fan_chart_traces

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
@@ -267,7 +267,7 @@ def statistical_layout(uuid: str, value: List[str]) -> html.Div:
             {"label": "Max", "value": "Max"},
             {"label": "Realizations", "value": "Realizations"},
             {
-                "label": "Uncertainty envelope (slow)",
+                "label": "Uncertainty envelope",
                 "value": "Uncertainty envelope",
             },
         ],


### PR DESCRIPTION

### Contributor checklist

- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Show hoverinfo for uncertainty envelope
   - [ ] Remove "slow" from checkbox label as the calculation is now fast.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
