### PR TITLE
Added `rel_file_pattern` argument to EnsembleSummaryProviderFactory methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
-## [0.2.8] - 2021-12-10
-
 ### Changed
 - [#889](https://github.com/equinor/webviz-subsurface/pull/889) - Added `rel_file_pattern` argument to .arrow related factory methods in EnsembleSummaryProviderFactory.
+
+## [0.2.8] - 2021-12-10
 
 ### Fixed
 - [#877](https://github.com/equinor/webviz-subsurface/pull/877) - Update `WellLogViewer` to work with the latest version of the component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.8] - 2021-12-10
 
+### Changed
+- [#889](https://github.com/equinor/webviz-subsurface/pull/889) - Added `rel_file_pattern` argument to .arrow related factory methods in EnsembleSummaryProviderFactory.
+
 ### Fixed
 - [#877](https://github.com/equinor/webviz-subsurface/pull/877) - Update `WellLogViewer` to work with the latest version of the component.
-
 - [#875](https://github.com/equinor/webviz-subsurface/pull/875) - Fixed an issue with the uncertainty envelope in `Structural Uncertainty` where the plot misbehaved for discontinuous surfaces. A side effect is that percentile calculations are now much faster.
 
 ### Added

--- a/tests/unit_tests/provider_tests/test_ensemble_summary_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_summary_provider.py
@@ -58,7 +58,9 @@ def test_create_from_arrow_unsmry_lazy(testdata_folder: Path, tmp_path: Path) ->
     # _dump_smry_to_csv_using_fmu(ensemble_path, "monthly", "expected_smry.csv")
 
     factory = EnsembleSummaryProviderFactory(tmp_path, allow_storage_writes=True)
-    provider = factory.create_from_arrow_unsmry_lazy(ensemble_path)
+    provider = factory.create_from_arrow_unsmry_lazy(
+        ens_path=ensemble_path, rel_file_pattern="share/results/unsmry/*.arrow"
+    )
 
     assert provider.supports_resampling()
 
@@ -100,7 +102,9 @@ def test_arrow_unsmry_lazy_vector_metadata(
 
     ensemble_path = str(testdata_folder / "01_drogon_ahm/realization-*/iter-0")
     factory = EnsembleSummaryProviderFactory(tmp_path, allow_storage_writes=True)
-    provider = factory.create_from_arrow_unsmry_lazy(ensemble_path)
+    provider = factory.create_from_arrow_unsmry_lazy(
+        ens_path=ensemble_path, rel_file_pattern="share/results/unsmry/*.arrow"
+    )
 
     meta: Optional[VectorMetadata] = provider.vector_metadata("FOPR")
     assert meta is not None
@@ -141,7 +145,9 @@ def test_create_from_arrow_unsmry_presampled_monthly(
 
     factory = EnsembleSummaryProviderFactory(tmp_path, allow_storage_writes=True)
     provider = factory.create_from_arrow_unsmry_presampled(
-        str(ensemble_path), Frequency.MONTHLY
+        ens_path=str(ensemble_path),
+        rel_file_pattern="share/results/unsmry/*.arrow",
+        sampling_frequency=Frequency.MONTHLY,
     )
 
     assert not provider.supports_resampling()

--- a/webviz_subsurface/_providers/ensemble_summary_provider/_arrow_unsmry_import.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/_arrow_unsmry_import.py
@@ -58,18 +58,20 @@ def _load_table_from_arrow_file(entry: FileEntry) -> pa.Table:
     return reader.read_all()
 
 
-def load_per_realization_arrow_unsmry_files(ens_path: str) -> Dict[int, pa.Table]:
+def load_per_realization_arrow_unsmry_files(
+    ens_path: str, rel_file_pattern: str
+) -> Dict[int, pa.Table]:
     """Load summary data stored in per-realization arrow files.
     Returns dictionary containing a PyArrow table for each realization, indexed by
     realization number.
+
+    `rel_file_pattern` denotes a file pattern relative to the realization's runpath,
+    typical value is: "share/results/unsmry/*.arrow"
     """
 
     LOGGER.debug(f"load_per_realization_arrow_unsmry_files() starting - {ens_path}")
+    LOGGER.debug(f"looking for .arrow files using relative pattern: {rel_file_pattern}")
     timer = PerfTimer()
-
-    # We should probably expose this realization relative search pattern as a
-    # user configurable parameter to this function
-    rel_file_pattern = "share/results/unsmry/*.arrow"
 
     per_real_tables: Dict[int, pa.Table] = {}
     globpattern = os.path.join(ens_path, rel_file_pattern)

--- a/webviz_subsurface/_providers/ensemble_summary_provider/dev_compare_fmu_to_lazy_provider.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/dev_compare_fmu_to_lazy_provider.py
@@ -274,7 +274,9 @@ def main() -> None:
     factory = EnsembleSummaryProviderFactory(
         root_storage_dir, allow_storage_writes=True
     )
-    provider = factory.create_from_arrow_unsmry_lazy(ensemble_path)
+    provider = factory.create_from_arrow_unsmry_lazy(
+        ens_path=ensemble_path, rel_file_pattern="share/results/unsmry/*.arrow"
+    )
     # provider = factory.create_from_arrow_unsmry_presampled(ensemble_path, frequency)
 
     print("## Loading data into reference DataFrame...")

--- a/webviz_subsurface/_providers/ensemble_summary_provider/dev_provider_perf_testing.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/dev_provider_perf_testing.py
@@ -241,7 +241,9 @@ def main() -> None:
         root_storage_dir, allow_storage_writes=True
     )
 
-    provider = factory.create_from_arrow_unsmry_lazy(ensemble_path)
+    provider = factory.create_from_arrow_unsmry_lazy(
+        ens_path=ensemble_path, rel_file_pattern="share/results/unsmry/*.arrow"
+    )
     resampling_frequency = frequency
 
     # provider = factory.create_from_arrow_unsmry_presampled(ensemble_path, frequency)


### PR DESCRIPTION
Added new `rel_file_pattern` argument to `EnsembleSummaryProviderFactory.create_from_arow_unsmry_lazy()` and `EnsembleSummaryProviderFactory.create_from_arrow_unsmry_presampled()` methods.

---

### Contributor checklist

- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
