### PR TITLE
General improvements to VolumetricAnalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [#889](https://github.com/equinor/webviz-subsurface/pull/889) - Added `rel_file_pattern` argument to .arrow related factory methods in EnsembleSummaryProviderFactory.
+- [#895](https://github.com/equinor/webviz-subsurface/pull/895) - Various improvements to `VolumetricAnalysis` mainly affecting functionality in the `Inplace distribution` tab e.g. merged functionality in pages `Custom plotting` and `1 plot / 1 table` into one, added colorby option in `Plots per zone/region`, and added shade to the convergence plot to indicate missing realizations.
 
 ## [0.2.8] - 2021-12-10
 

--- a/webviz_subsurface/_assets/css/inplace_volumes.css
+++ b/webviz_subsurface/_assets/css/inplace_volumes.css
@@ -1,11 +1,10 @@
 .webviz-inplace-vol-btn {
     background-color: #E8E8E8;
     width: 100%;
-    display: block;
-    margin-left: auto;
     font-size: 12px;
     height: 30px;
     line-height:30px;
+    padding:0px;
 }
 
 

--- a/webviz_subsurface/_figures/px_figure.py
+++ b/webviz_subsurface/_figures/px_figure.py
@@ -44,7 +44,9 @@ def set_default_args(**plotargs: Any) -> dict:
             facet_row_spacing=max((0.08 - (0.00071 * facet_cols)), 0.03),
             facet_col_spacing=max((0.06 - (0.00071 * facet_cols)), 0.03),
         )
-        plotargs["custom_data"] = [plotargs["facet_col"]]
+        plotargs["custom_data"] = plotargs.get("custom_data", []) + [
+            plotargs["facet_col"]
+        ]
     return plotargs
 
 
@@ -136,10 +138,8 @@ def set_marker_color(trace: go) -> go:
         and isinstance(trace.marker.color, str)
         and "#" in trace.marker.color
     ):
-        opacity = (
-            0.5
-            if trace.type in ["scatter", "scattergl"]
-            else marker_attributes.get("opacity", 0.7)
+        opacity = marker_attributes.get(
+            "opacity", 0.5 if trace.type in ["scatter", "scattergl"] else 0.7
         )
         trace.update(marker_line=dict(color=trace.marker.color, width=1))
         trace.update(marker_color=hex_to_rgb(trace.marker.color, opacity=opacity))
@@ -246,7 +246,7 @@ def hover_box_text(
     color_col: Optional[str],
 ) -> str:
     colors = list(dframe[color_col].unique()) if color_col in dframe else []
-    facet = trace["customdata"][0][0] if trace["customdata"] is not None else ""
+    facet = trace["customdata"][-1][0] if trace["customdata"] is not None else ""
     text = f"<b>{x}</b><br>" f"<b>{facet}</b><br>"
     if not colors:
         series = get_filtered_x_series(dframe, x, facet_col, facet)

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -184,6 +184,14 @@ class InplaceVolumesModel:
         return self.volume_columns + self.property_columns
 
     @property
+    def hc_responses(self) -> List[str]:
+        return [
+            x
+            for x in ["STOIIP", "GIIP", "ASSOCIATEDGAS", "ASSOCIATEDOIL"]
+            if x in self.volume_columns
+        ]
+
+    @property
     def parameters(self) -> List[str]:
         return self.pmodel.parameters
 
@@ -221,11 +229,15 @@ class InplaceVolumesModel:
         available volume columns"""
         self._property_columns = []
 
-        if all(col in self._dataframe for col in ["NET", "BULK"]):
+        if all(
+            col in self._dataframe for col in ["NET", "BULK"]
+        ) and not self._dataframe["NET"].equals(self._dataframe["BULK"]):
             self._property_columns.append("NTG")
         if all(col in self._dataframe for col in ["BULK", "PORV"]):
             self._property_columns.append("PORO")
-        if all(col in self._dataframe for col in ["NET", "PORV"]):
+        if all(
+            col in self._dataframe for col in ["NET", "PORV"]
+        ) and not self._dataframe["NET"].equals(self._dataframe["BULK"]):
             self._property_columns.append("PORO_NET")
         if all(col in self._dataframe for col in ["HCPV", "PORV"]):
             self._property_columns.append("SW")
@@ -246,9 +258,9 @@ class InplaceVolumesModel:
         if "NTG" in properties:
             dframe["NTG"] = dframe["NET"] / dframe["BULK"]
         if "PORO" in properties:
-            if "NET" in dframe.columns:
-                dframe["PORO_NET"] = dframe["PORV"] / dframe["NET"]
             dframe["PORO"] = dframe["PORV"] / dframe["BULK"]
+        if "PORO_NET" in properties:
+            dframe["PORO_NET"] = dframe["PORV"] / dframe["NET"]
         if "SW" in properties:
             dframe["SW"] = 1 - (dframe["HCPV"] / dframe["PORV"])
         if "BO" in properties:

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/fipfile_qc_controller.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/fipfile_qc_controller.py
@@ -46,7 +46,7 @@ def fipfile_qc_controller(get_uuid: Callable, disjoint_set_df: pd.DataFrame) -> 
                 children=create_data_table(
                     columns=create_table_columns(df.columns),
                     data=df.to_dict("records"),
-                    height="88vh",
+                    height="82vh",
                     table_id={"table_id": "disjointset-info"},
                     style_cell_conditional=[
                         {"if": {"column_id": ["SET", "FIPNUM"]}, "width": "10%"},

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
@@ -23,7 +23,7 @@ def layout_controllers(get_uuid: Callable) -> None:
     ) -> tuple:
 
         ctx = callback_context.triggered[0]
-        initial_pages = {"voldist": "1p1t", "tornado": "torn_multi"}
+        initial_pages = {"voldist": "custom", "tornado": "torn_multi"}
 
         # handle initial callback
         if ctx["prop_id"] == ".":
@@ -123,33 +123,3 @@ def layout_controllers(get_uuid: Callable) -> None:
             else:
                 main_layout.append({"display": "none"})
         return main_layout
-
-    @callback(
-        Output(
-            {
-                "id": get_uuid("main-voldist"),
-                "wrapper": ALL,
-                "page": "custom",
-            },
-            "style",
-        ),
-        Input(
-            {"id": get_uuid("main-voldist"), "element": "plot-table-select"}, "value"
-        ),
-        State(
-            {
-                "id": get_uuid("main-voldist"),
-                "wrapper": ALL,
-                "page": "custom",
-            },
-            "id",
-        ),
-    )
-    def _show_hide_1x1(plot_table_select: str, all_ids: dict) -> list:
-        styles = []
-        for input_id in all_ids:
-            if input_id["wrapper"] == plot_table_select:
-                styles.append({"display": "block"})
-            else:
-                styles.append({"display": "none"})
-        return styles

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -128,6 +128,10 @@ def selections_controllers(
             "value",
         ),
         State(
+            {"id": get_uuid("selections"), "tab": "voldist", "selector": "bottom_viz"},
+            "options",
+        ),
+        State(
             {"id": get_uuid("selections"), "tab": "voldist", "selector": ALL}, "value"
         ),
         State({"id": get_uuid("selections"), "tab": "voldist", "selector": ALL}, "id"),
@@ -139,6 +143,7 @@ def selections_controllers(
         plot_type: str,
         selected_page: str,
         selected_color_by: list,
+        visualization_options: list,
         selector_values: list,
         selector_ids: list,
         previous_selection: Optional[dict],
@@ -165,8 +170,8 @@ def selections_controllers(
             "Plot type": ["per_zr", "conv"],
             "Y Response": ["per_zr", "conv"],
             "X Response": [],
-            "Color by": ["per_zr", "conv"],
-            "Subplots": ["per_zr", "1p1t"],
+            "Color by": ["conv"],
+            "Subplots": ["per_zr"],
         }
 
         settings: Dict[str, dict] = {}
@@ -195,7 +200,7 @@ def selections_controllers(
         colorby_elm = (
             list(volumemodel.dataframe.columns) + volumemodel.parameters
             if settings["Plot type"]["value"] == "scatter"
-            else volumemodel.selectors
+            else [x for x in volumemodel.selectors if x != "REAL"]
         )
         settings["Y Response"]["options"] = [
             {"label": elm, "value": elm} for elm in y_elm
@@ -212,6 +217,18 @@ def selections_controllers(
         settings["Color by"]["options"] = [
             {"label": elm, "value": elm} for elm in colorby_elm
         ]
+
+        # disable vizualisation radioitem for some pages
+        for x in visualization_options:
+            x["disabled"] = selected_page != "custom"
+
+        settings["bottom_viz"] = {
+            "options": visualization_options,
+            "value": "none"
+            if selected_page != "custom"
+            else selections.get("bottom_viz"),
+        }
+
         return tuple(
             update_relevant_components(
                 id_list=selector_ids,

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/tornado_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/tornado_controllers.py
@@ -113,14 +113,14 @@ def tornado_controllers(
                 columns=columns,
                 selectors=[selections["Subplots"]] if subplots else [],
                 data=[x for table in tables for x in table],
-                height="41vh",
+                height="39vh",
                 table_id={"table_id": f"{page_selected}-torntable"},
             )
         elif selections["bottom_viz"] == "realplot" and figures:
             bottom_display = [
                 wcc.Graph(
                     config={"displayModeBar": False},
-                    style={"height": "41vh"},
+                    style={"height": "40vh"},
                     figure=realplot,
                 )
                 if not subplots
@@ -305,7 +305,7 @@ def create_realplot(df: pd.DataFrame, sensitivity_colors: dict) -> go.Figure:
             color="sensname_case",
             color_discrete_map=senscasecolors,
             barmode="overlay",
-            hover_data={"casetype": True},
+            custom_data=["casetype"],
             yaxis={"range": [df["VALUE"].min() * 0.7, df["VALUE"].max() * 1.1]},
             opacity=0.85,
         )

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Union
 import plotly.graph_objects as go
 import webviz_core_components as wcc
 from dash import dash_table
-from dash.dash_table.Format import Format
 
 
 def create_table_columns(
@@ -28,7 +27,7 @@ def create_table_columns(
             elif col in use_si_format:
                 data["format"] = {"locale": {"symbol": ["", ""]}, "specifier": "$.4s"}
             else:
-                data["format"] = Format(precision=3)
+                data["format"] = {"specifier": ".3~r"}
         table_columns.append(data)
     return table_columns
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/utils.py
@@ -1,4 +1,5 @@
-from typing import List
+import itertools
+from typing import List, Tuple
 
 import dash
 
@@ -15,3 +16,14 @@ def update_relevant_components(id_list: list, update_info: List[dict]) -> list:
 
 def move_to_end_of_list(element: str, list_of_elements: list) -> list:
     return [x for x in list_of_elements if x != element] + [element]
+
+
+def to_ranges(list_of_integers: List[int]) -> List[Tuple[int, int]]:
+    """Return list of tuples with ranges from list of integers"""
+    ranges = []
+    for _, group in itertools.groupby(
+        enumerate(sorted(list_of_integers)), lambda t: t[1] - t[0]
+    ):
+        int_range = list(group)
+        ranges.append((int_range[0][1], int_range[-1][1]))
+    return ranges

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -8,36 +8,31 @@ from webviz_subsurface._models import InplaceVolumesModel
 
 
 def comparison_main_layout(uuid: str) -> html.Div:
-    return wcc.Frame(
-        color="white",
-        highlight=False,
-        style={"height": "91vh"},
-        children=[
-            html.Div(
-                style={"margin-bottom": "20px"},
-                children=wcc.RadioItems(
-                    vertical=False,
-                    id={"id": uuid, "element": "display-option"},
-                    options=[
-                        {
-                            "label": "QC plots",
-                            "value": "plots",
-                        },
-                        {
-                            "label": "Difference table for selected response",
-                            "value": "single-response table",
-                        },
-                        {
-                            "label": "Difference table for multiple responses",
-                            "value": "multi-response table",
-                        },
-                    ],
-                    value="plots",
-                ),
+    return [
+        html.Div(
+            style={"margin-bottom": "20px"},
+            children=wcc.RadioItems(
+                vertical=False,
+                id={"id": uuid, "element": "display-option"},
+                options=[
+                    {
+                        "label": "QC plots",
+                        "value": "plots",
+                    },
+                    {
+                        "label": "Difference table for selected response",
+                        "value": "single-response table",
+                    },
+                    {
+                        "label": "Difference table for multiple responses",
+                        "value": "multi-response table",
+                    },
+                ],
+                value="plots",
             ),
-            html.Div(id={"id": uuid, "wrapper": "table"}),
-        ],
-    )
+        ),
+        html.Div(id={"id": uuid, "wrapper": "table"}),
+    ]
 
 
 def comparison_qc_plots_layout(
@@ -52,33 +47,33 @@ def comparison_qc_plots_layout(
             html.Div(
                 children=wcc.Graph(
                     config={"displayModeBar": False},
-                    style={"height": "22vh"},
+                    style={"height": "21vh"},
                     figure=fig_diff_vs_real,
                 )
                 if real_plot
                 else [],
             ),
             wcc.FlexBox(
-                style={"height": "32vh" if real_plot else "54vh"},
+                style={"height": "31vh" if real_plot else "52vh"},
                 children=[
                     wcc.FlexColumn(
                         children=wcc.Graph(
                             config={"displayModeBar": False},
-                            style={"height": "31vh" if real_plot else "53vh"},
+                            style={"height": "30vh" if real_plot else "51vh"},
                             figure=fig_diff_vs_response,
                         )
                     ),
                     wcc.FlexColumn(
                         children=wcc.Graph(
                             config={"displayModeBar": False},
-                            style={"height": "31vh" if real_plot else "53vh"},
+                            style={"height": "30vh" if real_plot else "51vh"},
                             figure=fig_corr,
                         )
                     ),
                 ],
             ),
             wcc.Frame(
-                style={"height": "31vh"},
+                style={"height": "29vh"},
                 children=[
                     wcc.Header("Highlighted data"),
                     wcc.Graph(

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/fipfile_qc_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/fipfile_qc_layout.py
@@ -6,10 +6,7 @@ from dash import html
 
 
 def fipfile_qc_main_layout(uuid: str) -> wcc.Frame:
-    return wcc.Frame(
-        color="white",
-        highlight=False,
-        style={"height": "91vh"},
+    return html.Div(
         children=[
             html.Div(
                 style={"margin-bottom": "20px"},

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -2,7 +2,7 @@ from typing import Callable, Optional
 
 import pandas as pd
 import webviz_core_components as wcc
-from dash import dcc, html
+from dash import dcc
 from webviz_config import WebvizConfigTheme
 
 from webviz_subsurface._models import InplaceVolumesModel
@@ -32,9 +32,7 @@ def main_view(
             label="Inplace distributions",
             value="voldist",
             children=tab_view_layout(
-                main_layout=distributions_main_layout(
-                    uuid=get_uuid("main-voldist"), volumemodel=volumemodel
-                ),
+                main_layout=distributions_main_layout(uuid=get_uuid("main-voldist")),
                 sidebar_layout=[
                     selections_layout(
                         uuid=get_uuid("selections"),
@@ -182,11 +180,13 @@ def tab_view_layout(main_layout: list, sidebar_layout: list) -> wcc.FlexBox:
     return wcc.FlexBox(
         children=[
             wcc.Frame(
-                style={"flex": 1, "height": "91vh"},
+                style={"flex": 1, "height": "87vh"},
                 children=sidebar_layout,
             ),
-            html.Div(
-                style={"flex": 6, "height": "91vh"},
+            wcc.Frame(
+                style={"flex": 6, "height": "87vh"},
+                color="white",
+                highlight=False,
                 children=main_layout,
             ),
         ]

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
@@ -25,12 +25,11 @@ def selections_layout(
             html.Div(
                 style={"margin-bottom": "20px"},
                 children=[
-                    button(uuid=uuid, title="1 plot / 1 table", page_id="1p1t"),
+                    button(uuid=uuid, title="Custom plotting", page_id="custom"),
                     button(uuid=uuid, title=f"Plots per {selectors}", page_id="per_zr"),
                     button(
                         uuid=uuid, title="Convergence plot mean/p10/p90", page_id="conv"
                     ),
-                    button(uuid=uuid, title="Custom plotting", page_id="custom"),
                 ],
             ),
             plot_selections_layout(uuid, volumemodel, tab),
@@ -57,7 +56,22 @@ def plot_selections_layout(
     return wcc.Selectors(
         label="PLOT CONTROLS",
         open_details=True,
-        children=plot_selector_dropdowns(uuid=uuid, volumemodel=volumemodel, tab=tab),
+        children=plot_selector_dropdowns(uuid=uuid, volumemodel=volumemodel, tab=tab)
+        + [
+            html.Div(
+                style={"margin-top": "10px"},
+                children=wcc.RadioItems(
+                    label="Visualization below plot:",
+                    id={"id": uuid, "tab": tab, "selector": "bottom_viz"},
+                    options=[
+                        {"label": "Table", "value": "table"},
+                        {"label": "None", "value": "none"},
+                    ],
+                    vertical=False,
+                    value="table",
+                ),
+            ),
+        ],
     )
 
 
@@ -89,11 +103,7 @@ def table_selections_layout(
             ),
             wcc.SelectWithLabel(
                 label="Responses",
-                id={
-                    "id": uuid,
-                    "tab": tab,
-                    "selector": "table_responses",
-                },
+                id={"id": uuid, "tab": tab, "selector": "table_responses"},
                 options=[{"label": i, "value": i} for i in responses],
                 value=responses,
                 size=min(20, len(responses)),
@@ -130,7 +140,7 @@ def plot_selector_dropdowns(
             elements = [x for x in volumemodel.selectors if x != "REAL"]
             value = None
         if selector == "Color by":
-            elements = volumemodel.selectors
+            elements = [x for x in volumemodel.selectors if x != "REAL"]
             value = "ENSEMBLE"
 
         dropdowns.append(
@@ -140,7 +150,7 @@ def plot_selector_dropdowns(
                 options=[{"label": elm, "value": elm} for elm in elements],
                 value=value,
                 clearable=selector in ["Subplots", "Color by", "Y Response"],
-                disabled=selector in ["Subplots", "Y Response"],
+                disabled=selector == "Y Response",
             )
         )
     return dropdowns

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/tornado_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/tornado_view.py
@@ -9,13 +9,9 @@ from ..utils.table_and_figure_utils import create_figure_matrix
 def tornado_main_layout(uuid: str) -> html.Div:
     return html.Div(
         children=[
+            html.Div(id={"id": uuid, "page": "torn_multi"}, style={"display": "block"}),
             html.Div(
-                id={"id": uuid, "page": "torn_multi"},
-                style={"display": "block"},
-            ),
-            html.Div(
-                id={"id": uuid, "page": "torn_bulk_inplace"},
-                style={"display": "none"},
+                id={"id": uuid, "page": "torn_bulk_inplace"}, style={"display": "none"}
             ),
         ]
     )
@@ -23,14 +19,11 @@ def tornado_main_layout(uuid: str) -> html.Div:
 
 def tornado_plots_layout(figures: list, bottom_display: list) -> html.Div:
     matrix = create_figure_matrix(figures)
-    max_height = 42 if bottom_display else 88
+    max_height = 45 if bottom_display else 86
 
     return html.Div(
         children=[
-            wcc.Frame(
-                color="white",
-                highlight=False,
-                style={"height": "44vh" if bottom_display else "91vh"},
+            html.Div(
                 children=[
                     wcc.FlexBox(
                         children=[
@@ -50,26 +43,20 @@ def tornado_plots_layout(figures: list, bottom_display: list) -> html.Div:
                     for row in matrix
                 ],
             ),
-            wcc.Frame(
-                color="white",
-                highlight=False,
+            html.Div(
+                bottom_display,
                 style={
-                    "height": "44vh",
+                    "height": "40vh",
                     "display": "block" if bottom_display else "none",
+                    "margin-top": "20px",
                 },
-                children=html.Div(bottom_display, style={"margin-top": "20px"}),
             ),
         ]
     )
 
 
 def tornado_error_layout(message: str) -> wcc.Frame:
-    return wcc.Frame(
-        color="white",
-        highlight=False,
-        style={"height": "91vh"},
-        children=html.Div(message, style={"margin-top": "40px"}),
-    )
+    return html.Div(message, style={"margin-top": "40px"})
 
 
 def tornado_selections_layout(


### PR DESCRIPTION
Several improvements to VolumetricAnalysis, some based on of user-feedback.

**Main changes `Inplace distributions` tab**

- Merged functionality in pages `1 plot/1 table` and `Custom plotting`, in order to make it less confusing for the users what page to use, and also simplify the code logic. The only real difference between the two pages was that the user could make subplots in the `Custom plotting`. This is still available, and an option to hide the table below is added to make more space for the subplots. 
- Added useful "colorby" feature to the barplots in `Plots per zone/region` page. If colorby is selected the piechart is hidden.
- Change to returning entire layout for the pages, instead of individual figures --> if a selection/filter changes all plots needs to be updated anyway. This helps improving the readability of the code and reduces a lot of code lines.
- Remove "REAL" as colorby option for plot types other than "scatter"
- Remove the fluid annotation automatically if the x-response is a HC-response
- Added shading to `Convergence plot`s to indicate missing realizations, and added more explanatory hoverinfo.  

**Other general changes**

- Adjust heights of different views to remove overflow
- `Comparions tab`: extend x-axis range by 10% to fix formatting issue when only one data point, and add dotted lines indicating the "highlight threshold" for all plots with difference in percent on the y-axis
- `Tornado tab`: removed confusing "casetype" in hover for the "realization plot" 
- Only calculate "NTG" and "PORO_NET" columns if "NET" varies from "BULK"

<img src="https://user-images.githubusercontent.com/61694854/146772392-4009018b-ec6a-4e5d-82a0-fcff60dcc704.png" width="250"> 

![image](https://user-images.githubusercontent.com/61694854/146773186-684be522-5589-45aa-8402-797533ae1007.png)


![image](https://user-images.githubusercontent.com/61694854/146778809-37c3d941-0a63-4c70-8fd0-80d1e3936825.png)

