### PR TITLE
Format dates in download for resampled date in SimulationTimeSeries

### DIFF
--- a/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
@@ -43,6 +43,7 @@ from .utils.delta_ensemble_utils import create_delta_ensemble_names
 from .utils.derived_ensemble_vectors_accessor_utils import (
     create_derived_vectors_accessor_dict,
 )
+from .utils.from_timeseries_cumulatives import datetime_to_intervalstr
 from .utils.history_vectors import create_history_vectors_df
 from .utils.provider_set_utils import create_vector_plot_titles_from_provider_set
 from .utils.trace_line_shape import get_simulation_line_shape
@@ -569,6 +570,11 @@ def plugin_callbacks(
                             loc=0, column="ENSEMBLE", value=ensemble_name_list
                         )
 
+                        if vector.startswith(("AVG_", "INTVL_")):
+                            vector_df["DATE"] = vector_df["DATE"].apply(
+                                datetime_to_intervalstr, freq=resampling_frequency
+                            )
+
                         vector_key = vector + "_realizations"
                         if vector_dataframe_dict.get(vector_key) is None:
                             vector_dataframe_dict[vector_key] = vector_df
@@ -595,6 +601,13 @@ def plugin_callbacks(
                         )
 
                         vector_key = vector + "_statistics"
+
+                        if vector.startswith(("AVG_", "INTVL_")):
+                            vector_statistics_df.loc[
+                                :, ("DATE", "")
+                            ] = vector_statistics_df.loc[:, ("DATE", "")].apply(
+                                datetime_to_intervalstr, freq=resampling_frequency
+                            )
                         if vector_dataframe_dict.get(vector_key) is None:
                             vector_dataframe_dict[vector_key] = vector_statistics_df
                         else:

--- a/webviz_subsurface/plugins/_simulation_time_series/utils/from_timeseries_cumulatives.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/utils/from_timeseries_cumulatives.py
@@ -151,7 +151,7 @@ def rename_vector_from_cumulative(vector: str, as_rate: bool) -> str:
 # pylint: disable=too-many-return-statements
 def datetime_to_intervalstr(date: datetime.datetime, freq: Frequency) -> Optional[str]:
     if date is None:
-        return date
+        return None
 
     if freq == Frequency.DAILY:
         return f"{date.year}-{date.month:02d}-{date.day:02d}"

--- a/webviz_subsurface/plugins/_simulation_time_series/utils/from_timeseries_cumulatives.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/utils/from_timeseries_cumulatives.py
@@ -1,5 +1,10 @@
+import datetime
+from typing import Optional
+
 import numpy as np
 import pandas as pd
+
+from webviz_subsurface._providers import Frequency
 
 ###################################################################################
 # NOTE: This code is a copy and modification of
@@ -141,3 +146,25 @@ def rename_vector_from_cumulative(vector: str, as_rate: bool) -> str:
         if as_rate
         else f"INTVL_{vector}"
     )
+
+
+# pylint: disable=too-many-return-statements
+def datetime_to_intervalstr(date: datetime.datetime, freq: Frequency) -> Optional[str]:
+    if date is None:
+        return date
+
+    if freq == Frequency.DAILY:
+        return f"{date.year}-{date.month:02d}-{date.day:02d}"
+    if freq == Frequency.WEEKLY:
+        # Note: weekyear may differ from actual year for week numbers 1,52,53.
+        (weekyear, week, _) = date.isocalendar()
+        return f"{weekyear}-W{week:02d}"
+    if freq == Frequency.MONTHLY:
+        return f"{date.year}-{date.month:02d}"
+    if freq == Frequency.QUARTERLY:
+        return f"{date.year}-Q{(date.month//3+1)}"
+    if freq == Frequency.YEARLY:
+        return f"{date.year}"
+
+    # Using isoformat if frequency is none of the listed instead of error.
+    return date.isoformat()

--- a/webviz_subsurface/plugins/_simulation_time_series/utils/from_timeseries_cumulatives.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/utils/from_timeseries_cumulatives.py
@@ -162,7 +162,7 @@ def datetime_to_intervalstr(date: datetime.datetime, freq: Frequency) -> Optiona
     if freq == Frequency.MONTHLY:
         return f"{date.year}-{date.month:02d}"
     if freq == Frequency.QUARTERLY:
-        return f"{date.year}-Q{(date.month//3+1)}"
+        return f"{date.year}-Q{1 + (date.month-1)//3}"
     if freq == Frequency.YEARLY:
         return f"{date.year}"
 


### PR DESCRIPTION
The old `ReservoirSimulationTimeSeries` has some logic to modify the `DATE` column when downloading the special vectors that we calculate from cumulatives over a certain interval in time (those starting with AVG_ and INTVL_). The logic was introduced to reduce risk of misunderstandings from users related to whether the date was e.g. at the beginning of the interval, at the end, or the middle. Instead, the `DATE` axis was reduced down to what describes the interval best. A yearly interval would leave only `YYYY`, a monthly would give `YYYY-MM` and daily would give `YYYY-MM-DD`.

This PR implements the same logic for the new `SimulationTimeSeries` plugin, though now using the `Frequency` dataclass + extended to support weeks and quarters.