### PR TITLE
`SimulationTimeSeries`: Add statistics after realizations

### DIFF
--- a/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
@@ -319,16 +319,7 @@ def plugin_callbacks(
                         fanchart_options,
                     )
                 if visualization == VisualizationOptions.STATISTICS_AND_REALIZATIONS:
-                    # Configure line width and color scaling to easier separate
-                    # statistics traces and realization traces
-                    vectors_statistics_df = create_vectors_statistics_df(vectors_df)
-                    figure_builder.add_statistics_traces(
-                        vectors_statistics_df,
-                        ensemble,
-                        statistics_options,
-                        line_width=3,
-                    )
-                    # Show selected realizations on top - only filter df if realizations filter
+                    # Show selected realizations - only filter df if realizations filter
                     # query is not performed
                     figure_builder.add_realizations_traces(
                         vectors_df
@@ -336,6 +327,15 @@ def plugin_callbacks(
                         else vectors_df[vectors_df["REAL"].isin(selected_realizations)],
                         ensemble,
                         color_lightness_scale=150.0,
+                    )
+                    # Configure line width and color scaling + add statistics on top
+                    # to easier separate statistics traces and realization traces
+                    vectors_statistics_df = create_vectors_statistics_df(vectors_df)
+                    figure_builder.add_statistics_traces(
+                        vectors_statistics_df,
+                        ensemble,
+                        statistics_options,
+                        line_width=3,
                     )
 
         # Retrieve selected input providers

--- a/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
@@ -319,6 +319,8 @@ def plugin_callbacks(
                         fanchart_options,
                     )
                 if visualization == VisualizationOptions.STATISTICS_AND_REALIZATIONS:
+                    # Configure line width and color scaling to easier separate
+                    # statistics traces and realization traces.
                     # Show selected realizations - only filter df if realizations filter
                     # query is not performed
                     figure_builder.add_realizations_traces(

--- a/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
@@ -330,8 +330,7 @@ def plugin_callbacks(
                         ensemble,
                         color_lightness_scale=150.0,
                     )
-                    # Configure line width and color scaling + add statistics on top
-                    # to easier separate statistics traces and realization traces
+                    # Add statistics on top
                     vectors_statistics_df = create_vectors_statistics_df(vectors_df)
                     figure_builder.add_statistics_traces(
                         vectors_statistics_df,


### PR DESCRIPTION
Adds the statistics after the individual realizations rather than before, meaning that the statistics will be placed on top (though only for the given vector/ensemble. Additional vectors/ensembles will still be placed on top). Makes it easier to see statistics when plotting both (note difference in the area to the lower left with very high density of realizations covering all of the statistics).
Example:
Old behavior:
![image](https://user-images.githubusercontent.com/47146384/148429836-3b3136e0-e94a-49d3-8fa7-3e15a8587a33.png)

New behavior:
![image](https://user-images.githubusercontent.com/47146384/148429787-7e0c45e5-75cb-482e-a0ae-2acef6844aa1.png)
