### PR TITLE
RftPlotter: update param response selections by clicking in bar chart

### DIFF
--- a/webviz_subsurface/plugins/_rft_plotter/_callbacks/callbacks.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_callbacks/callbacks.py
@@ -17,10 +17,8 @@ def plugin_callbacks(
     app: Dash, get_uuid: Callable, datamodel: RftPlotterDataModel
 ) -> None:
     @app.callback(
-        Output(get_uuid("well"), "value"),
-        [
-            Input(get_uuid(LayoutElements.MAP), "clickData"),
-        ],
+        Output(get_uuid(LayoutElements.FORMATIONS_WELL), "value"),
+        Input(get_uuid(LayoutElements.MAP_GRAPH), "clickData"),
     )
     def _get_clicked_well(click_data: Dict[str, List[Dict[str, Any]]]) -> str:
         if not click_data:
@@ -34,12 +32,10 @@ def plugin_callbacks(
 
     @app.callback(
         Output(get_uuid(LayoutElements.MAP), "children"),
-        [
-            Input(get_uuid(LayoutElements.MAP_ENSEMBLE), "value"),
-            Input(get_uuid(LayoutElements.MAP_SIZE_BY), "value"),
-            Input(get_uuid(LayoutElements.MAP_COLOR_BY), "value"),
-            Input(get_uuid(LayoutElements.MAP_DATE_RANGE), "value"),
-        ],
+        Input(get_uuid(LayoutElements.MAP_ENSEMBLE), "value"),
+        Input(get_uuid(LayoutElements.MAP_SIZE_BY), "value"),
+        Input(get_uuid(LayoutElements.MAP_COLOR_BY), "value"),
+        Input(get_uuid(LayoutElements.MAP_DATE_RANGE), "value"),
     )
     def _update_map(
         ensemble: str, sizeby: str, colorby: str, dates: List[float]
@@ -54,18 +50,17 @@ def plugin_callbacks(
             wcc.Graph(
                 style={"height": "84vh"},
                 figure={"data": figure.traces, "layout": figure.layout},
+                id=get_uuid(LayoutElements.MAP_GRAPH),
             )
         ]
 
     @app.callback(
         Output(get_uuid(LayoutElements.FORMATIONS_GRAPH), "children"),
-        [
-            Input(get_uuid(LayoutElements.FORMATIONS_WELL), "value"),
-            Input(get_uuid(LayoutElements.FORMATIONS_DATE), "value"),
-            Input(get_uuid(LayoutElements.FORMATIONS_ENSEMBLE), "value"),
-            Input(get_uuid(LayoutElements.FORMATIONS_LINETYPE), "value"),
-            Input(get_uuid(LayoutElements.FORMATIONS_DEPTHOPTION), "value"),
-        ],
+        Input(get_uuid(LayoutElements.FORMATIONS_WELL), "value"),
+        Input(get_uuid(LayoutElements.FORMATIONS_DATE), "value"),
+        Input(get_uuid(LayoutElements.FORMATIONS_ENSEMBLE), "value"),
+        Input(get_uuid(LayoutElements.FORMATIONS_LINETYPE), "value"),
+        Input(get_uuid(LayoutElements.FORMATIONS_DEPTHOPTION), "value"),
     )
     def _update_formation_plot(
         well: str, date: str, ensembles: List[str], linetype: str, depth_option: str
@@ -146,14 +141,10 @@ def plugin_callbacks(
         ], "realization"
 
     @app.callback(
-        [
-            Output(get_uuid(LayoutElements.FORMATIONS_DATE), "options"),
-            Output(get_uuid(LayoutElements.FORMATIONS_DATE), "value"),
-        ],
-        [
-            Input(get_uuid(LayoutElements.FORMATIONS_WELL), "value"),
-        ],
-        [State(get_uuid(LayoutElements.FORMATIONS_DATE), "value")],
+        Output(get_uuid(LayoutElements.FORMATIONS_DATE), "options"),
+        Output(get_uuid(LayoutElements.FORMATIONS_DATE), "value"),
+        Input(get_uuid(LayoutElements.FORMATIONS_WELL), "value"),
+        State(get_uuid(LayoutElements.FORMATIONS_DATE), "value"),
     )
     def _update_date(well: str, current_date: str) -> Tuple[List[Dict[str, str]], str]:
         dates = datamodel.date_in_well(well)
@@ -163,12 +154,10 @@ def plugin_callbacks(
 
     @app.callback(
         Output(get_uuid(LayoutElements.MISFITPLOT_GRAPH), "children"),
-        [
-            Input(get_uuid(LayoutElements.FILTER_WELLS["misfitplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_ZONES["misfitplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_DATES["misfitplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_ENSEMBLES["misfitplot"]), "value"),
-        ],
+        Input(get_uuid(LayoutElements.FILTER_WELLS["misfitplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_ZONES["misfitplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_DATES["misfitplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_ENSEMBLES["misfitplot"]), "value"),
     )
     def _misfit_plot(
         wells: List[str], zones: List[str], dates: List[str], ensembles: List[str]
@@ -184,14 +173,12 @@ def plugin_callbacks(
 
     @app.callback(
         Output(get_uuid(LayoutElements.CROSSPLOT_GRAPH), "children"),
-        [
-            Input(get_uuid(LayoutElements.FILTER_WELLS["crossplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_ZONES["crossplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_DATES["crossplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_ENSEMBLES["crossplot"]), "value"),
-            Input(get_uuid(LayoutElements.CROSSPLOT_SIZE_BY), "value"),
-            Input(get_uuid(LayoutElements.CROSSPLOT_COLOR_BY), "value"),
-        ],
+        Input(get_uuid(LayoutElements.FILTER_WELLS["crossplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_ZONES["crossplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_DATES["crossplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_ENSEMBLES["crossplot"]), "value"),
+        Input(get_uuid(LayoutElements.CROSSPLOT_SIZE_BY), "value"),
+        Input(get_uuid(LayoutElements.CROSSPLOT_COLOR_BY), "value"),
     )
     def _crossplot(
         wells: List[str],
@@ -211,12 +198,10 @@ def plugin_callbacks(
 
     @app.callback(
         Output(get_uuid(LayoutElements.ERRORPLOT_GRAPH), "children"),
-        [
-            Input(get_uuid(LayoutElements.FILTER_WELLS["errorplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_ZONES["errorplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_DATES["errorplot"]), "value"),
-            Input(get_uuid(LayoutElements.FILTER_ENSEMBLES["errorplot"]), "value"),
-        ],
+        Input(get_uuid(LayoutElements.FILTER_WELLS["errorplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_ZONES["errorplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_DATES["errorplot"]), "value"),
+        Input(get_uuid(LayoutElements.FILTER_ENSEMBLES["errorplot"]), "value"),
     )
     def _errorplot(
         wells: List[str], zones: List[str], dates: List[str], ensembles: List[str]

--- a/webviz_subsurface/plugins/_rft_plotter/_callbacks/parameter_response_callbacks.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_callbacks/parameter_response_callbacks.py
@@ -19,14 +19,57 @@ def paramresp_callbacks(
         State(get_uuid(LayoutElements.PARAMRESP_CORRTYPE), "value"),
         prevent_initial_call=True,
     )
-    def _update_parameter_selected(
+    def _update_param_from_clickdata(
         corr_vector_clickdata: Union[None, dict],
         corrtype: str,
     ) -> str:
         """Update the selected parameter from clickdata"""
-        if corr_vector_clickdata is None or corrtype != "sim_vs_param":
+        if corr_vector_clickdata is None or corrtype == "param_vs_sim":
             raise PreventUpdate
         return corr_vector_clickdata.get("points", [{}])[0].get("y")
+
+    @app.callback(
+        Output(get_uuid(LayoutElements.PARAMRESP_WELL), "value"),
+        Output(get_uuid(LayoutElements.PARAMRESP_DATE_DROPDOWN), "children"),
+        Output(get_uuid(LayoutElements.PARAMRESP_ZONE_DROPDOWN), "children"),
+        Input(get_uuid(LayoutElements.PARAMRESP_CORR_BARCHART_FIGURE), "clickData"),
+        State(get_uuid(LayoutElements.PARAMRESP_CORRTYPE), "value"),
+        State(get_uuid(LayoutElements.PARAMRESP_WELL), "value"),
+        State(get_uuid(LayoutElements.PARAMRESP_DATE), "value"),
+        State(get_uuid(LayoutElements.PARAMRESP_ZONE), "value"),
+        prevent_initial_call=True,
+    )
+    def _update_selections_from_clickdata(
+        corr_vector_clickdata: Union[None, dict],
+        corrtype: str,
+        well: str,
+        date: str,
+        zone: str,
+    ) -> Tuple[str, wcc.Dropdown, wcc.Dropdown]:
+        """Update well, date and zone from clickdata"""
+        if corr_vector_clickdata is None or corrtype == "sim_vs_param":
+            raise PreventUpdate
+
+        clickdata = corr_vector_clickdata.get("points", [{}])[0].get("y")
+        ls_clickdata = clickdata.split()
+
+        dates_in_well, zones_in_well = datamodel.well_dates_and_zones(well)
+        dates_dropdown = wcc.Dropdown(
+            label="Date",
+            id=get_uuid(LayoutElements.PARAMRESP_DATE),
+            options=[{"label": date, "value": date} for date in dates_in_well],
+            value=ls_clickdata[1],
+            clearable=False,
+        )
+        zones_dropdown = wcc.Dropdown(
+            label="Zone",
+            id=get_uuid(LayoutElements.PARAMRESP_ZONE),
+            options=[{"label": zone, "value": zone} for zone in zones_in_well],
+            value=ls_clickdata[2],
+            clearable=False,
+        )
+
+        return ls_clickdata[0], dates_dropdown, zones_dropdown
 
     @app.callback(
         Output(get_uuid(LayoutElements.PARAMRESP_DATE), "options"),

--- a/webviz_subsurface/plugins/_rft_plotter/_layout.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_layout.py
@@ -54,6 +54,8 @@ class LayoutElements:
     PARAMRESP_CORR_BARCHART_FIGURE = "paramresp-corr-barchart-figure"
     PARAMRESP_SCATTERPLOT = "paramresp-scatterplot"
     PARAMRESP_FORMATIONS = "paramresp-formations"
+    PARAMRESP_DATE_DROPDOWN = "paramresp-well-dropdown"
+    PARAMRESP_ZONE_DROPDOWN = "paramresp-zone-dropdown"
 
 
 def main_layout(get_uuid: Callable, datamodel: RftPlotterDataModel) -> wcc.Tabs:
@@ -199,19 +201,25 @@ def parameter_response_selector_layout(
                         value=well_names[0] if well_names else "",
                         clearable=False,
                     ),
-                    wcc.Dropdown(
-                        label="Date",
-                        id=get_uuid(LayoutElements.PARAMRESP_DATE),
-                        options=None,
-                        value=None,
-                        clearable=False,
+                    html.Div(
+                        id=get_uuid(LayoutElements.PARAMRESP_DATE_DROPDOWN),
+                        children=wcc.Dropdown(
+                            label="Date",
+                            id=get_uuid(LayoutElements.PARAMRESP_DATE),
+                            options=None,
+                            value=None,
+                            clearable=False,
+                        ),
                     ),
-                    wcc.Dropdown(
-                        label="Zone",
-                        id=get_uuid(LayoutElements.PARAMRESP_ZONE),
-                        options=None,
-                        clearable=False,
-                        value=None,
+                    html.Div(
+                        id=get_uuid(LayoutElements.PARAMRESP_ZONE_DROPDOWN),
+                        children=wcc.Dropdown(
+                            label="Zone",
+                            id=get_uuid(LayoutElements.PARAMRESP_ZONE),
+                            options=None,
+                            clearable=False,
+                            value=None,
+                        ),
                     ),
                     wcc.Dropdown(
                         label="Parameter",

--- a/webviz_subsurface/plugins/_rft_plotter/_layout.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_layout.py
@@ -9,6 +9,7 @@ from ._business_logic import RftPlotterDataModel
 # pylint: disable = too-few-public-methods
 class LayoutElements:
     MAP = "map-wrapper"
+    MAP_GRAPH = "map-graph"
     FORMATIONS_GRAPH = "formations-graph-wrapper"
     MISFITPLOT_GRAPH = "misfit-graph-wrapper"
     CROSSPLOT_GRAPH = "crossplot-graph-wrapper"


### PR DESCRIPTION
This PR fixes the problem of not being able to update selections by clicking in the bar chart when the chart is in param_vs_sim mode. The trick is to avoid callbacks triggering each other in an infinite loop, but that is solved by updating the whole dropdown objects (for date and zone) instead of only the value.

Also fixes a bug in the callback that was updating the formations well by clicking in the map.