### PR TITLE
Fix: Skip emodel in `webvizstore` in `VolumetricAnalysis for aggregated input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#921](https://github.com/equinor/webviz-subsurface/pull/921) - Fixed bug with History Vectors in new `SimulationTimeSeries` plugin. Replaced hard coded realization number of 0, with first valid realization in provider.
+- [#926](https://github.com/equinor/webviz-subsurface/pull/926) - `VolumetricAnalysis` - Fixed bug when building portables with aggregated (csvfile_vol) input.
 
 ## [0.2.9] - 2022-01-06
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
@@ -226,11 +226,12 @@ reek_test_data/aggregated_data/parameters.csv)
         store_functions = []
         if self.csvfile_vol is not None:
             store_functions.append((read_csv, [{"csv_file": self.csvfile_vol}]))
+        else:
+            store_functions.extend(self.emodel.webvizstore)
         if self.fipfile is not None:
             store_functions.append((get_path, [{"path": self.fipfile}]))
         if self.csvfile_parameters is not None:
             store_functions.append((read_csv, [{"csv_file": self.csvfile_parameters}]))
-        store_functions.extend(self.emodel.webvizstore)
         return store_functions
 
 


### PR DESCRIPTION
### Contributor checklist

- [X] :tada: This PR closes #925.
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
