### PR TITLE
Fix hover info for observation trace new SimulationTimeSeries plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#926](https://github.com/equinor/webviz-subsurface/pull/926) - `VolumetricAnalysis` - Fixed bug when building portables with aggregated (`csvfile_vol`) input.
 - [#929](https://github.com/equinor/webviz-subsurface/pull/929) - `TornadoWidget` - No longer skipping sensitivities with `SENSNAME="ref"` from tornado bars if there is more than one realization with `SENSNAME="ref"`.
 - [#932](https://github.com/equinor/webviz-subsurface/pull/932) - `RftPlotter` - Fixed bug related to calculated correlations returning `NaN` if the response variable has constant values.
+- [#937](https://github.com/equinor/webviz-subsurface/pull/937) - `SimulationTimeSeries` - Fixed hover info for observation trace
 
 ### Changed
 

--- a/tests/unit_tests/plugin_tests/test_simulation_time_series/test_utils/test_create_vector_traces_utils.py
+++ b/tests/unit_tests/plugin_tests/test_simulation_time_series/test_utils/test_create_vector_traces_utils.py
@@ -73,6 +73,7 @@ def test_crate_vector_observation_traces() -> None:
     expected_traces = [
         {
             "name": "Observation",
+            "legendgroup": "Observation",
             "x": [datetime.datetime(2020, 1, 1), []],
             "y": [2.0, []],
             "marker": {"color": "black"},
@@ -86,6 +87,7 @@ def test_crate_vector_observation_traces() -> None:
         },
         {
             "name": "Observation",
+            "legendgroup": "Observation",
             "x": [datetime.datetime(2020, 6, 5), []],
             "y": [5.0, []],
             "marker": {"color": "black"},

--- a/webviz_subsurface/plugins/_simulation_time_series/_property_serialization/vector_subplot_builder.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_property_serialization/vector_subplot_builder.py
@@ -320,7 +320,7 @@ class VectorSubplotBuilder(GraphFigureBuilderBase):
         self._add_vector_traces_set_to_figure(
             {
                 vector_name: create_vector_observation_traces(
-                    vector_observations, self._observation_color, "Observation"
+                    vector_observations, color=self._observation_color
                 )
             }
         )

--- a/webviz_subsurface/plugins/_simulation_time_series/utils/create_vector_traces_utils.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/utils/create_vector_traces_utils.py
@@ -22,43 +22,50 @@ from ..utils.from_timeseries_cumulatives import is_interval_or_average_vector
 
 
 def create_vector_observation_traces(
-    vector_observations: dict, color: str = "black", legend_group: Optional[str] = None
+    vector_observations: dict,
+    color: str = "black",
+    legend_group: Optional[str] = None,
+    show_legend: bool = False,
 ) -> List[dict]:
     """Create list of observations traces from vector observations
 
     `Input:`
     * vector_observations: dict - Dictionary with observation data for a vector
     * color: str - Color of observation traces for vector
-    * legend_group: Optional[str] - Name of legend group, added as legend group and name if provided
+    * legend_group: Optional[str] - Overwrite default legend group. Name of legend group, added as
+    legend group and name if provided.
+    * show_legend: bool - Show legend status for traces
+
 
     `Return:`
     List of marker traces for each observation for vector
     """
     observation_traces: List[dict] = []
 
+    _name = "Observation" if legend_group is None else "Observation: " + legend_group
+    _legend_group = "Observation" if legend_group is None else legend_group
+
     for observation in vector_observations.get("observations", []):
-        hovertext = observation.get("comment", "")
+        hovertext = observation.get("comment", None)
         hovertemplate = (
             "(%{x}, %{y})<br>" + hovertext if hovertext else "(%{x}, %{y})<br>"
         )
-        trace = {
-            "name": "Observation",
-            "x": [observation.get("date"), []],
-            "y": [observation.get("value"), []],
-            "marker": {"color": color},
-            "hovertemplate": hovertemplate,
-            "showlegend": False,
-            "error_y": {
-                "type": "data",
-                "array": [observation.get("error"), []],
-                "visible": True,
-            },
-        }
-        if legend_group:
-            trace["name"] = "Observation: " + legend_group
-            trace["legendgroup"] = legend_group
-
-        observation_traces.append(trace)
+        observation_traces.append(
+            {
+                "name": _name,
+                "legendgroup": _legend_group,
+                "x": [observation.get("date"), []],
+                "y": [observation.get("value"), []],
+                "marker": {"color": color},
+                "hovertemplate": hovertemplate,
+                "showlegend": show_legend,
+                "error_y": {
+                    "type": "data",
+                    "array": [observation.get("error"), []],
+                    "visible": True,
+                },
+            }
+        )
     return observation_traces
 
 

--- a/webviz_subsurface/plugins/_simulation_time_series/utils/create_vector_traces_utils.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/utils/create_vector_traces_utils.py
@@ -46,7 +46,7 @@ def create_vector_observation_traces(
     _legend_group = "Observation" if legend_group is None else legend_group
 
     for observation in vector_observations.get("observations", []):
-        hovertext = observation.get("comment", None)
+        hovertext = observation.get("comment")
         hovertemplate = (
             "(%{x}, %{y})<br>" + hovertext if hovertext else "(%{x}, %{y})<br>"
         )


### PR DESCRIPTION
Fix incorrect hover info for observation trace in `SimulationTimeSeries`-plugin when grouped by Time Series.

Default name and legend group fixing issue with trace name in hover info.

Resolves issue: https://github.com/equinor/webviz-subsurface/issues/931

----

### Contributor checklist

- Default legend group and name "Observation".
- Updated unit test