### PR TITLE
`WellCompletion` handling different zone → layer mappings over realizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#940](https://github.com/equinor/webviz-subsurface/pull/940) - `SimulationTimeSeries` - Added configurable user defined vector definitions.
+- [#944](https://github.com/equinor/webviz-subsurface/pull/940) - `WellCompletions` - Added support for zone to layer mappings that are potentially different across realizations.
 
 ### Changed
 

--- a/tests/unit_tests/plugin_tests/test_well_completions.py
+++ b/tests/unit_tests/plugin_tests/test_well_completions.py
@@ -31,7 +31,7 @@ def test_extract_stratigraphy():
     correct and that the colors are added following the correct prioritization
     rules
     """
-    layer_zone_mapping = {1: "ZoneA.1", 2: "ZoneA.2", 3: "ZoneB.1"}
+    zone_names = ["ZoneA.1", "ZoneA.2", "ZoneB.1"]
     stratigraphy = [
         {
             "name": "ZoneA",
@@ -50,7 +50,7 @@ def test_extract_stratigraphy():
     theme_colors = ["#FFFFFF"]
 
     result = extract_stratigraphy(
-        layer_zone_mapping, stratigraphy, zone_color_mapping, theme_colors
+        zone_names, stratigraphy, zone_color_mapping, theme_colors
     )
     assert result == [
         {

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from ecl2df import EclFiles, common

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -41,6 +41,9 @@ def read_zone_layer_mapping(
     df_files = ens.find_files(zone_layer_mapping_file)
     dataframes = []
 
+    if df_files.empty:
+        return pd.DataFrame()
+
     for _, row in df_files.iterrows():
         real = row["REAL"]
         zonelist = common.parse_lyrfile(filename=row["FULLPATH"])
@@ -56,10 +59,9 @@ def read_zone_layer_mapping(
             for zonedict in zonelist
             if "color" in zonedict
         }
-        df_real["COLOR"] = df["ZONE"].map(zone_color_mapping)
+        df_real["COLOR"] = df_real["ZONE"].map(zone_color_mapping)
         dataframes.append(df_real)
 
-    print(pd.concat(dataframes))
     return pd.concat(dataframes)
 
 

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -31,11 +31,15 @@ def remove_invalid_colors(zonelist: List[Dict[str, Any]]) -> List[Dict[str, Any]
 def read_zone_layer_mapping(
     ensemble_path: str, zone_layer_mapping_file: str
 ) -> pd.DataFrame:
-    """Searches for a zone layer mapping file (lyr format) on the scratch disk. \
-    If one file is found it is parsed using functionality from the ecl2df \
-    library.
+    """Searches for all zone->layer mapping files for an ensemble. \
+    The files should be on lyr format and can be parsed using functionality \
+    from ecl2df.
 
-    UPDATE!
+    The results are returned as a dataframe with the following columns:
+    * REAL
+    * K1 (layer)
+    * ZONE
+    * COLOR
     """
     ens = scratch_ensemble("ens", ensemble_path, filter_file="OK")
     df_files = ens.find_files(zone_layer_mapping_file)

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -30,7 +30,7 @@ def remove_invalid_colors(zonelist: List[Dict[str, Any]]) -> List[Dict[str, Any]
 
 def read_zone_layer_mapping(
     ensemble_path: str, zone_layer_mapping_file: str
-) -> Tuple[Optional[Dict[int, str]], Optional[Dict[str, str]]]:
+) -> pd.DataFrame:
     """Searches for a zone layer mapping file (lyr format) on the scratch disk. \
     If one file is found it is parsed using functionality from the ecl2df \
     library.

--- a/webviz_subsurface/plugins/_well_completions/_business_logic.py
+++ b/webviz_subsurface/plugins/_well_completions/_business_logic.py
@@ -72,7 +72,8 @@ WellCompletionsDataModel {self.ensemble_name} {self.ensemble_path} {self.compdat
             ensemble_path=self.ensemble_path,
             well_connection_status_file=self.well_connection_status_file,
         )
-        layer_zone_mapping, zone_color_mapping = read_zone_layer_mapping(
+        # layer_zone_mapping, zone_color_mapping = read_zone_layer_mapping(
+        df_zone_layer = read_zone_layer_mapping(
             ensemble_path=self.ensemble_path,
             zone_layer_mapping_file=self.zone_layer_mapping_file,
         )
@@ -95,11 +96,17 @@ WellCompletionsDataModel {self.ensemble_name} {self.ensemble_path} {self.compdat
         realizations = list(sorted(df.REAL.unique()))
         layers = np.sort(df.K1.unique())
 
-        if layer_zone_mapping is None:
-            # use layers as zones
-            layer_zone_mapping = {layer: f"Layer{layer}" for layer in layers}
+        if df_zone_layer.empty:
+            print("her")
+        else:
+            df = df.merge(df_zone_layer, on=["K1", "REAL"])
+            # hva hvis det mangler verdier
 
-        df["ZONE"] = df.K1.map(layer_zone_mapping)
+        # if layer_zone_mapping is None:
+        #     # use layers as zones
+        #     layer_zone_mapping = {layer: f"Layer{layer}" for layer in layers}
+
+        # df["ZONE"] = df.K1.map(layer_zone_mapping)
 
         zone_names = list(dict.fromkeys(layer_zone_mapping.values()))
 

--- a/webviz_subsurface/plugins/_well_completions/_business_logic.py
+++ b/webviz_subsurface/plugins/_well_completions/_business_logic.py
@@ -119,7 +119,12 @@ WellCompletionsDataModel {self.ensemble_name} {self.ensemble_path} {self.compdat
             # Layers missing from the zone layer mapping will be filtered out here.
             df = df.merge(df_zone_layer, on=["K1", "REAL"], how="inner")
 
-        zone_names = list(df["ZONE"].unique())
+        # Get the zone names in the correct order
+        zone_names = (
+            df.drop_duplicates(subset=["K1", "ZONE"])
+            .sort_values(by="K1")["ZONE"]
+            .unique()
+        )
 
         zone_color_mapping = {
             item["ZONE"]: item["COLOR"]

--- a/webviz_subsurface/plugins/_well_completions/_business_logic.py
+++ b/webviz_subsurface/plugins/_well_completions/_business_logic.py
@@ -100,6 +100,8 @@ WellCompletionsDataModel {self.ensemble_name} {self.ensemble_path} {self.compdat
             print("her")
         else:
             df = df.merge(df_zone_layer, on=["K1", "REAL"])
+
+        print(df)
             # hva hvis det mangler verdier
 
         # if layer_zone_mapping is None:
@@ -108,7 +110,9 @@ WellCompletionsDataModel {self.ensemble_name} {self.ensemble_path} {self.compdat
 
         # df["ZONE"] = df.K1.map(layer_zone_mapping)
 
-        zone_names = list(dict.fromkeys(layer_zone_mapping.values()))
+        #zone_names = list(dict.fromkeys(layer_zone_mapping.values()))
+        zone_names = df["ZONE"].unique()
+        print(zone_names)
 
         result = {
             "version": "1.1.0",

--- a/webviz_subsurface/plugins/_well_completions/_business_logic.py
+++ b/webviz_subsurface/plugins/_well_completions/_business_logic.py
@@ -94,12 +94,14 @@ WellCompletionsDataModel {self.ensemble_name} {self.ensemble_path} {self.compdat
 
         time_steps = sorted(df.DATE.unique())
         realizations = list(sorted(df.REAL.unique()))
-        layers = np.sort(df.K1.unique())
 
         if df_zone_layer.empty:
-            print("her")
+            df["ZONE"] = df.agg(lambda x: f"Layer {x['K1']}", axis=1)
+            df["COLOR"] = np.nan
         else:
             df = df.merge(df_zone_layer, on=["K1", "REAL"])
+
+        zone_names = list(df["ZONE"].unique())
 
         zone_color_mapping = {
             item["ZONE"]: item["COLOR"]
@@ -108,18 +110,6 @@ WellCompletionsDataModel {self.ensemble_name} {self.ensemble_path} {self.compdat
             .drop_duplicates(keep="first")
             .to_dict("records")
         }
-        print(zone_color_mapping)
-        # hva hvis det mangler verdier
-
-        # if layer_zone_mapping is None:
-        #     # use layers as zones
-        #     layer_zone_mapping = {layer: f"Layer{layer}" for layer in layers}
-
-        # df["ZONE"] = df.K1.map(layer_zone_mapping)
-
-        # zone_names = list(dict.fromkeys(layer_zone_mapping.values()))
-        zone_names = df["ZONE"].unique()
-        print(zone_names)
 
         result = {
             "version": "1.1.0",


### PR DESCRIPTION
This PR extends the functionality in the `WellCompletion` plugin so that it handles zone->layer mappings that are potentially different across realizations (as is the case in the Drogon sample data).

---

### Contributor checklist

- [x] :tada: This PR closes #899.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Import the zone->layer mappings for all realizations and return the data as a dataframe
   - [x] merge the zone->layer dataframe with the compdat data on layer and realization
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have added an entry in `CHANGELOG.md`
