### PR TITLE
Adjustments in  `RftPlotter` due to changes in `ParametersModel`

### DIFF
--- a/webviz_subsurface/plugins/_rft_plotter/_business_logic.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_business_logic.py
@@ -51,7 +51,7 @@ class RftPlotterDataModel:
             self.ertdatadf = read_csv(self.csvfile_rft_ert)
 
             # Must send a dummy dataframe to ParametersModel
-            # The ensembles will be identified as a sensrun
+            # The ensembles will be identified as sensitivity runs
             self.param_model = ParametersModel(
                 pd.DataFrame(
                     columns=["REAL", "ENSEMBLE", "SENSNAME", "SENSCASE"],

--- a/webviz_subsurface/plugins/_rft_plotter/_business_logic.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_business_logic.py
@@ -49,7 +49,17 @@ class RftPlotterDataModel:
 
         if csvfile_rft_ert is not None:
             self.ertdatadf = read_csv(self.csvfile_rft_ert)
-            self.param_model = ParametersModel(pd.DataFrame())
+
+            # Must send a dummy dataframe to ParametersModel
+            # The ensembles will be identified as a sensrun
+            self.param_model = ParametersModel(
+                pd.DataFrame(
+                    columns=["REAL", "ENSEMBLE", "SENSNAME", "SENSCASE"],
+                    data=[
+                        [0, "ensemble", "sensname", "low"],
+                    ],
+                )
+            )
 
         if ensembles is not None:
             ens_paths = {


### PR DESCRIPTION
Fixes a bug in `RftPlotter` that caused the plugin to crash when it was run with an aggregated `csv `file. The bug came from updates in the `ParametersModel `class. It is fixed by passing a dummy dataframe to `ParametersModel`. The dummy dataframe is made so that the ensembles will be identified as sensitivity runs. Then the parameters response tab will not be added.
