### PR TITLE
Disable rangeslider marks in cross-section plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#940](https://github.com/equinor/webviz-subsurface/pull/940) - `SimulationTimeSeries` - Changed vector annotation from "AVG_" with suffix "R" and "INTVL_" to "PER_DAY_" and "PER_INTVL_". Retrieve `VectorDefinitions` via Python-API for `webviz-subsurface-components`.
 - [#956](https://github.com/equinor/webviz-subsurface/pull/956) - `SimulationTimeSeries` - Deprecate usage of user input options {vector1, vector2, vector3}. Add list of vectors as user input options for initially selected vectors.
 
+### Fixed
+
+- [#958](https://github.com/equinor/webviz-subsurface/pull/958) - Disable unwanted calculation of `marks` in some `RangeSlider` components.
+
 ## [0.2.10] - 2022-02-09
 
 ### Fixed

--- a/webviz_subsurface/plugins/_property_statistics/views/property_response_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_response_view.py
@@ -96,6 +96,7 @@ def filter_correlated_parameter(get_uuid: Callable, labels: List[str]) -> html.D
             wcc.RangeSlider(
                 id=get_uuid("property-response-correlated-slider"),
                 disabled=True,
+                marks=None,
             ),
         ]
     )

--- a/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
@@ -236,7 +236,11 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                                 wcc.RangeSlider(
                                     label="Set color range",
                                     id=self.ids("color-values"),
-                                    tooltip={"always_visible": False},
+                                    tooltip={
+                                        "placement": "bottom",
+                                        "always_visible": True,
+                                    },
+                                    marks=None,
                                 ),
                                 html.Button(
                                     id=self.ids("color-range-btn"),

--- a/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
@@ -228,7 +228,11 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                                 wcc.RangeSlider(
                                     label="Set color range",
                                     id=self.ids("color-values"),
-                                    tooltip={"always_visible": False},
+                                    tooltip={
+                                        "placement": "bottom",
+                                        "always_visible": True,
+                                    },
+                                    marks=None,
                                 ),
                                 html.Button(
                                     id=self.ids("color-range-btn"),


### PR DESCRIPTION
In Dash > 2.10 the `RangeSlider` component automatically calculates `marks` from `min` and `max`.
If `min` and `max` is not provided this calculation fails.
Marks are not needed for our use, so we can set `marks=None` to disable this behaviour.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
