### PR TITLE
Replace VectorCalculator modal with draggable dialog in SimulationTimeSeries

### DIFF
--- a/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_callbacks.py
@@ -793,13 +793,15 @@ def plugin_callbacks(
         return (new_delta_ensembles, table_data, ensemble_options)
 
     @app.callback(
-        Output(get_uuid(LayoutElements.VECTOR_CALCULATOR_MODAL), "is_open"),
+        Output(get_uuid(LayoutElements.VECTOR_CALCULATOR_DIALOG), "open"),
         [
             Input(get_uuid(LayoutElements.VECTOR_CALCULATOR_OPEN_BUTTON), "n_clicks"),
         ],
-        [State(get_uuid(LayoutElements.VECTOR_CALCULATOR_MODAL), "is_open")],
+        [State(get_uuid(LayoutElements.VECTOR_CALCULATOR_DIALOG), "open")],
     )
-    def _toggle_vector_calculator_modal(n_open_clicks: int, is_open: bool) -> bool:
+    def _toggle_vector_calculator_dialog_open(
+        n_open_clicks: int, is_open: bool
+    ) -> bool:
         if n_open_clicks:
             return not is_open
         raise PreventUpdate
@@ -829,10 +831,10 @@ def plugin_callbacks(
                 "data",
             ),
         ],
-        Input(get_uuid(LayoutElements.VECTOR_CALCULATOR_MODAL), "is_open"),
+        Input(get_uuid(LayoutElements.VECTOR_CALCULATOR_DIALOG), "open"),
         [
             State(
-                get_uuid(LayoutElements.VECTOR_CALCULATOR_EXPRESSIONS_OPEN_MODAL),
+                get_uuid(LayoutElements.VECTOR_CALCULATOR_EXPRESSIONS_OPEN_DIALOG),
                 "data",
             ),
             State(
@@ -847,8 +849,8 @@ def plugin_callbacks(
             ),
         ],
     )
-    def _update_vector_calculator_expressions_on_modal_close(
-        is_modal_open: bool,
+    def _update_vector_calculator_expressions_on_dialog_close(
+        is_dialog_open: bool,
         new_expressions: List[ExpressionInfo],
         current_expressions: List[ExpressionInfo],
         current_selected_vectors: List[str],
@@ -858,7 +860,7 @@ def plugin_callbacks(
         """Update vector calculator expressions, propagate expressions to VectorSelectors,
         update current selections and trigger re-rendering of graphing if necessary
         """
-        if is_modal_open or (new_expressions == current_expressions):
+        if is_dialog_open or (new_expressions == current_expressions):
             raise PreventUpdate
 
         # Create current selected expressions for comparison - Deep copy!
@@ -919,12 +921,12 @@ def plugin_callbacks(
 
     @app.callback(
         Output(
-            get_uuid(LayoutElements.VECTOR_CALCULATOR_EXPRESSIONS_OPEN_MODAL),
+            get_uuid(LayoutElements.VECTOR_CALCULATOR_EXPRESSIONS_OPEN_DIALOG),
             "data",
         ),
         Input(get_uuid(LayoutElements.VECTOR_CALCULATOR), "expressions"),
     )
-    def _update_vector_calculator_expressions_when_modal_open(
+    def _update_vector_calculator_expressions_when_dialog_open(
         expressions: List[ExpressionInfo],
     ) -> list:
         new_expressions: List[ExpressionInfo] = [

--- a/webviz_subsurface/plugins/_simulation_time_series/_layout.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_layout.py
@@ -1,7 +1,6 @@
 import datetime
 from typing import Callable, List, Optional
 
-import dash_bootstrap_components as dbc
 import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
 from dash import dash_table, dcc, html
@@ -37,11 +36,11 @@ class LayoutElements:
     VECTOR_SELECTOR = "vector_selector"
 
     VECTOR_CALCULATOR = "vector_calculator"
-    VECTOR_CALCULATOR_MODAL = "vector_calculator_modal"
+    VECTOR_CALCULATOR_DIALOG = "vector_calculator_dialog"
     VECTOR_CALCULATOR_OPEN_BUTTON = "vector_calculator_open_button"
     VECTOR_CALCULATOR_EXPRESSIONS = "vector_calculator_expressions"
-    VECTOR_CALCULATOR_EXPRESSIONS_OPEN_MODAL = (
-        "vector_calculator_expressions_open_modal"
+    VECTOR_CALCULATOR_EXPRESSIONS_OPEN_DIALOG = (
+        "vector_calculator_expressions_open_dialog"
     )
 
     DELTA_ENSEMBLE_A_DROPDOWN = "delta_ensemble_A_dropdown"
@@ -320,7 +319,7 @@ def __settings_layout(
                 label="Filter Realizations",
                 children=__realization_filters(get_uuid, realizations),
             ),
-            __vector_calculator_modal_layout(
+            __vector_calculator_dialog_layout(
                 get_uuid=get_uuid,
                 vector_data=vector_calculator_data,
                 predefined_expressions=predefined_expressions,
@@ -330,37 +329,28 @@ def __settings_layout(
                 data=predefined_expressions,
             ),
             dcc.Store(
-                id=get_uuid(LayoutElements.VECTOR_CALCULATOR_EXPRESSIONS_OPEN_MODAL),
+                id=get_uuid(LayoutElements.VECTOR_CALCULATOR_EXPRESSIONS_OPEN_DIALOG),
                 data=predefined_expressions,
             ),
         ]
     )
 
 
-def __vector_calculator_modal_layout(
-    get_uuid: Callable,
-    vector_data: list,
-    predefined_expressions: List[ExpressionInfo],
-) -> dbc.Modal:
-    return dbc.Modal(
-        style={"marginTop": "20vh", "width": "1300px"},
+def __vector_calculator_dialog_layout(
+    get_uuid: Callable, vector_data: list, predefined_expressions: List[ExpressionInfo]
+) -> wcc.Dialog:
+    return wcc.Dialog(
+        title="Vector Calculator",
+        id=get_uuid(LayoutElements.VECTOR_CALCULATOR_DIALOG),
+        draggable=True,
+        max_width="lg",
         children=[
-            dbc.ModalHeader("Vector Calculator"),
-            dbc.ModalBody(
-                html.Div(
-                    children=[
-                        wsc.VectorCalculator(
-                            id=get_uuid(LayoutElements.VECTOR_CALCULATOR),
-                            vectors=vector_data,
-                            expressions=predefined_expressions,
-                        )
-                    ],
-                ),
-            ),
+            wsc.VectorCalculator(
+                id=get_uuid(LayoutElements.VECTOR_CALCULATOR),
+                vectors=vector_data,
+                expressions=predefined_expressions,
+            )
         ],
-        id=get_uuid(LayoutElements.VECTOR_CALCULATOR_MODAL),
-        size="lg",
-        centered=True,
     )
 
 


### PR DESCRIPTION
Replace the `Modal`-component from `Dash Bootstrap Components` with new draggable `Dialog`-component in `wcc`.

---

#### Closing:
* https://github.com/equinor/webviz-subsurface/issues/959