### PR TITLE
Two bugfixes in `VolumetricAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#972](https://github.com/equinor/webviz-subsurface/pull/972) - FIxed bug occuring when ensembles had different PORE/PORV naming standards in the volumetric input files. Also fixed bug occuring if only BO and/or BG was selected in the table.
 - [#958](https://github.com/equinor/webviz-subsurface/pull/958) - Disable unwanted calculation of `marks` in some `RangeSlider` components.
 
 ## [0.2.10] - 2022-02-09

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -60,7 +60,7 @@ class InplaceVolumesModel:
                     volumes_table, selectors
                 )
 
-            # stack dataframe on fluid zone and add fluid as column istead of a column suffix
+            # stack dataframe on fluid zone and add fluid as column instead of a column suffix
             dfs = []
             for fluid in ["OIL", "GAS", "WATER"]:
                 fluid_columns = [
@@ -311,16 +311,16 @@ class InplaceVolumesModel:
         dframe = self.compute_property_columns(dframe, properties)
         if "FLUID_ZONE" not in groups:
             if not filters.get("FLUID_ZONE") == ["oil"]:
-                dframe["BO"] = "NA"
+                dframe["BO"] = np.nan
             if not filters.get("FLUID_ZONE") == ["gas"]:
-                dframe["BG"] = "NA"
+                dframe["BG"] = np.nan
         return dframe
 
 
 def filter_df(dframe: pd.DataFrame, filters: dict) -> pd.DataFrame:
     """
     Filter dataframe using dictionary with form
-    'column_name': [list ov values to keep]
+    'column_name': [list of values to keep]
     """
     for filt, values in filters.items():
         dframe = dframe.loc[dframe[filt].isin(values)]

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
@@ -58,6 +58,16 @@ def distribution_controllers(
             if item in volumemodel.parameters and item not in parameters:
                 parameters.append(item)
 
+        # for bo/bg the data should be grouped on fluid zone
+        if any(x in selected_data for x in ["BO", "BG"]) and "FLUID_ZONE" not in groups:
+            if "BO" in selected_data and "BG" in selected_data:
+                return html.Div(
+                    "Can't plot BO against BG", style={"margin-top": "40px"}
+                )
+            selections["filters"]["FLUID_ZONE"] = [
+                "oil" if "BO" in selected_data else "gas"
+            ]
+
         dframe = volumemodel.get_df(
             filters=selections["filters"], groups=groups, parameters=parameters
         )


### PR DESCRIPTION
Bugfixes in `VolumetricAnalysis`:

-  Selecting only BO and/or BG in the table introduced a bug in pandas saying "no numeric types to aggregate". This is avoided by setting these to nan instead of "NA" when the data was not grouped on "FLUID_ZONE"  
- If volumefiles from one ensemble contained PORE and volumefiles from another enemble contained PORV, the PORV renaming led to two columns with PORV in the merged dataset and an error occured.

---

### Contributor checklist
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
