### PR TITLE
Update `WellLogViewer` data format to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Fixed
-- [#985](https://github.com/equinor/webviz-subsurface/pull/985) - 'WellLogViewer' - Updated data format to latest version. Requires no changes in input data.
+- [#985](https://github.com/equinor/webviz-subsurface/pull/985) - `WellLogViewer` - Updated data format to latest version. Requires no changes in input data.
 
 ## [0.2.11] - 2022-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Fixed
+- [#985](https://github.com/equinor/webviz-subsurface/pull/985) - 'WellLogViewer' - Updated data format to latest version. Requires no changes in input data.
+
 ## [0.2.11] - 2022-03-14
 
 ### Added

--- a/webviz_subsurface/plugins/_well_log_viewer/utils/xtgeo_well_log_to_json.py
+++ b/webviz_subsurface/plugins/_well_log_viewer/utils/xtgeo_well_log_to_json.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import xtgeo
 
 
-def xtgeo_well_logs_to_json_format(well: xtgeo.Well) -> List[Dict]:
+def xtgeo_well_logs_to_json_format(well: xtgeo.Well) -> Dict:
 
     header = generate_header(well_name=well.name)
     curves = []
@@ -31,26 +31,13 @@ def xtgeo_well_logs_to_json_format(well: xtgeo.Well) -> List[Dict]:
     dframe = well.dataframe[curve_names]
     dframe = dframe.reindex(curve_names, axis=1)
 
-    return [{"header": header, "curves": curves, "data": dframe.values.tolist()}]
+    return {"header": header, "curves": curves, "data": dframe.values.tolist()}
 
 
 def generate_header(well_name: str, logrun_name: str = "log") -> Dict[str, Any]:
     return {
         "name": logrun_name,
         "well": well_name,
-        "wellbore": None,
-        "field": None,
-        "country": None,
-        "date": None,
-        "operator": None,
-        "serviceCompany": None,
-        "runNumber": None,
-        "elevation": None,
-        "source": None,
-        "startIndex": None,
-        "endIndex": None,
-        "step": None,
-        "dataUri": None,
     }
 
 


### PR DESCRIPTION
Fix to support Well log Viewer in version 0.4.10. Data format changed from list of json object to a single object.
Also removed some unused metadata that had the wrong format.

This PR closes #984.
