### PR TITLE
Place `VectorCalculator` in `Div` with fixed height

### DIFF
--- a/webviz_subsurface/plugins/_simulation_time_series/_layout.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_layout.py
@@ -345,10 +345,15 @@ def __vector_calculator_dialog_layout(
         draggable=True,
         max_width="lg",
         children=[
-            wsc.VectorCalculator(
-                id=get_uuid(LayoutElements.VECTOR_CALCULATOR),
-                vectors=vector_data,
-                expressions=predefined_expressions,
+            html.Div(
+                style={"height": "40vh"},
+                children=[
+                    wsc.VectorCalculator(
+                        id=get_uuid(LayoutElements.VECTOR_CALCULATOR),
+                        vectors=vector_data,
+                        expressions=predefined_expressions,
+                    )
+                ],
             )
         ],
     )


### PR DESCRIPTION
Place in div with fixed height for new VectorCalculator refactoring in https://github.com/equinor/webviz-subsurface-components/pull/860.

`wcc.Dialog` adjusts to content and `VectorCalculator` is refactored to adjust to parent, thus height is controlled by div width
