### PR TITLE
Bugfix `VolumetricAnalysis` - tornados hidden if both dynamic and static sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#988](https://github.com/equinor/webviz-subsurface/pull/988) - `ParameterAnalysis` and `PropertyStatistics` - Switched to the VectorSelector component, and other various improvements.
 
 ### Fixed
+- [#996](https://github.com/equinor/webviz-subsurface/pull/996) - `VolumetricAnalysis` - Fixed issue with the `Tornadoplot` tab not shown if volumes from both dynamic and static sources were included.
 - [#985](https://github.com/equinor/webviz-subsurface/pull/985) - `WellLogViewer` - Updated data format to latest version. Requires no changes in input data.
 
 ### Changed

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -68,7 +68,7 @@ def main_view(
             ),
         )
     )
-    if volumemodel.sensrun and volumemodel.volume_type != "mixed":
+    if volumemodel.sensrun:
         tabs.append(
             wcc.Tab(
                 label="Tornadoplots",


### PR DESCRIPTION
An old statement (not needed anymore) caused the "Tornadoplots" tab in `VolumetricAnalysis` to not appear if both static and dynamic volume sources were mixed.