### PR TITLE
Fix issues with just one parameter and for aggregated data in `ParameterResponseCorrelation`

### DIFF
--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -308,10 +308,10 @@ folder, to avoid risk of not extracting the right data.
                     id=self.uuid("max-params"),
                     min=1,
                     max=max_params,
-                    marks={"1": 1, str(max_params): max_params},
+                    marks={1: "1", max_params: str(max_params)},
                     value=max_params,
                 ),
-                style={"margin-top": "10px"},
+                style={"marginTop": "10px"},
             ),
         ]
 
@@ -330,9 +330,15 @@ folder, to avoid risk of not extracting the right data.
                                 label="Controls", children=self.control_layout
                             )
                         ]
-                        + [wcc.Selectors(label="Filters", children=self.filter_layout)]
-                        if self.response_filters
-                        else [],
+                        + (
+                            [
+                                wcc.Selectors(
+                                    label="Filters", children=self.filter_layout
+                                )
+                            ]
+                            if self.response_filters
+                            else []
+                        ),
                     ),
                 ),
                 wcc.FlexColumn(


### PR DESCRIPTION
---

Tbh; Not sure why the parenthesis is needed for the filter selectors, but for some reason it makes a difference...


### Contributor checklist

- [X] :tada: This PR closes #1000.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Fix issue with slider being misconfigured. Error only occured if only using 1 parameter
   - [X] Paranthesis for filter selectors for some strange reason needed when using aggregated data. No idea why it helps.

- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
 Have skipped changelog, as I am not really sure why this in fact is a "fix". Seems to work though...
