### PR TITLE
Various bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#938](https://github.com/equinor/webviz-subsurface/pull/938) - `ProdMisfit` - New plugin for well production misfit visualization. Features visualization of production misfit at selected dates, production coverage at selected dates and heatmap representation of ensemble mean misfit for selected dates.
 - [#1013](https://github.com/equinor/webviz-subsurface/pull/1013) - `MapViewerFMU` - Added option to specify the folder where maps are located (relative to runpath in each realization).
 
+### Fixed
+
+- [#1014](https://github.com/equinor/webviz-subsurface/pull/1014) - `ParameterResponseCorrelation` - fix bug in range slider. `VolumetricAnalysis` - prevent "Totals" volumes (if present) beeing included in the sum when comparing static and dynamic volumes, and do not include non-numeric columns as volumetric responses.
+
 ## [0.2.12] - 2022-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#1014](https://github.com/equinor/webviz-subsurface/pull/1014) - `ParameterResponseCorrelation` - fix bug in range slider. `VolumetricAnalysis` - prevent "Totals" volumes (if present) beeing included in the sum when comparing static and dynamic volumes, and do not include non-numeric columns as volumetric responses.
+- [#1014](https://github.com/equinor/webviz-subsurface/pull/1014) - `ParameterResponseCorrelation` and `BhpQc` - fix bug in range slider. `VolumetricAnalysis` - prevent "Totals" volumes (if present) beeing included in the sum when comparing static and dynamic volumes, and do not include non-numeric columns as volumetric responses.
 
 ## [0.2.12] - 2022-04-07
 

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 
 from .ensemble_set_model import EnsembleSetModel
 from .parameter_model import ParametersModel
@@ -164,7 +165,9 @@ class InplaceVolumesModel:
         return [
             x
             for x in self._dataframe
-            if x not in self.selectors and x not in self.property_columns
+            if x not in self.selectors
+            and x not in self.property_columns
+            and is_numeric_dtype(self._dataframe[x])
         ]
 
     @property

--- a/webviz_subsurface/plugins/_bhp_qc.py
+++ b/webviz_subsurface/plugins/_bhp_qc.py
@@ -190,6 +190,7 @@ class BhpQc(WebvizPluginABC):
                             id=self.uuid("n_wells"),
                             min=1,
                             max=len(self.wells),
+                            step=1,
                             value=min(10, len(self.wells)),
                             marks={1: 1, len(self.wells): len(self.wells)},
                         ),

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -308,6 +308,7 @@ folder, to avoid risk of not extracting the right data.
                     id=self.uuid("max-params"),
                     min=1,
                     max=max_params,
+                    step=1,
                     marks={1: "1", max_params: str(max_params)},
                     value=max_params,
                 ),

--- a/webviz_subsurface/plugins/_swatinit_qc/_business_logic.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_business_logic.py
@@ -57,6 +57,10 @@ class SwatinitQcDataModel:
         self.faultlines_df = read_csv(faultlines) if faultlines else None
 
         if ensemble is not None:
+            if isinstance(ensemble, list):
+                raise TypeError(
+                    'Incorrent argument type, "ensemble" must be a string instead of a list'
+                )
             if realization is None:
                 raise ValueError('Incorrent arguments, "realization" must be specified')
 

--- a/webviz_subsurface/plugins/_swatinit_qc/_figures.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_figures.py
@@ -257,7 +257,7 @@ class PropertiesVsDepthSubplots:
             if contact in self.dframe and self.dframe["EQLNUM"].nunique() == 1:
                 # contacts are assumed constant in the dataframe
                 value = self.dframe[contact].values[0]
-                if value not in [0, 1000]:
+                if value > self.dframe["Z"].min():
                     self._figure.add_hline(
                         value,
                         line={"color": "black", "dash": "dash", "width": 1.5},

--- a/webviz_subsurface/plugins/_swatinit_qc/_figures.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_figures.py
@@ -257,6 +257,7 @@ class PropertiesVsDepthSubplots:
             if contact in self.dframe and self.dframe["EQLNUM"].nunique() == 1:
                 # contacts are assumed constant in the dataframe
                 value = self.dframe[contact].values[0]
+                # do not include dummy contacts (shallower than the dataset)
                 if value > self.dframe["Z"].min():
                     self._figure.add_hline(
                         value,

--- a/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
@@ -49,8 +49,10 @@ class VolumeValidatorAndCombinator:
         self.disjoint_set_df = (
             fipmapper.FipMapper(yamlfile=fipfile).disjoint_sets() if fipfile else None
         )
-        self.dframe = self.validate_and_combine_sources(volumes_table)
-        self.drop_rows_with_totals_from_selectors()
+
+        self.dframe = self.validate_and_combine_sources(
+            self.drop_rows_with_totals_from_selectors(volumes_table)
+        )
         self.volume_type = self.set_volumetric_type()
 
         if self.volume_type == "mixed":
@@ -218,7 +220,11 @@ class VolumeValidatorAndCombinator:
             )
             self.dframe.drop(columns=total_columns, inplace=True)
 
-    def drop_rows_with_totals_from_selectors(self) -> None:
+    def drop_rows_with_totals_from_selectors(
+        self, dframe: pd.DataFrame
+    ) -> pd.DataFrame:
         """Drop rows containing total volumes ("Totals") if present"""
-        for sel in [col for col in self.VALID_STATIC_SELECTORS if col in self.dframe]:
-            self.dframe = self.dframe.loc[self.dframe[sel] != "Totals"]
+        selectors = [col for col in ["ZONE", "REGION", "FACIES"] if col in dframe]
+        for sel in selectors:
+            dframe = dframe.loc[dframe[sel] != "Totals"]
+        return dframe

--- a/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
@@ -220,9 +220,8 @@ class VolumeValidatorAndCombinator:
             )
             self.dframe.drop(columns=total_columns, inplace=True)
 
-    def drop_rows_with_totals_from_selectors(
-        self, dframe: pd.DataFrame
-    ) -> pd.DataFrame:
+    @staticmethod
+    def drop_rows_with_totals_from_selectors(dframe: pd.DataFrame) -> pd.DataFrame:
         """Drop rows containing total volumes ("Totals") if present"""
         selectors = [col for col in ["ZONE", "REGION", "FACIES"] if col in dframe]
         for sel in selectors:


### PR DESCRIPTION
PR with bugfixes:

1. `ParameterResponseCorrelation` and `BhpQc`: add step=1 to slider to prevent bug due to float numbers
3. `SwatinitQC`: don't show contacts if the contacts are shallower than the dataset (dummy contacts)
4. `VolumericAnalysis`: only include numeric columns as volumetric responses
7. `VolumericAnalysis`: remove rows with Totals" before summing volumes over disjoint sets 
6. `VolumericAnalysis`: prevent rows beeing removed if the License is called "Totals" ("Totals" should only be removed from `Zone/Region/Facies`)