### PR TITLE
Improved error reporting for `.arrow` files where dates are not monotonically increasing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#938](https://github.com/equinor/webviz-subsurface/pull/938) - `ProdMisfit` - New plugin for well production misfit visualization. Features visualization of production misfit at selected dates, production coverage at selected dates and heatmap representation of ensemble mean misfit for selected dates.
 - [#1013](https://github.com/equinor/webviz-subsurface/pull/1013) - `MapViewerFMU` - Added option to specify the folder where maps are located (relative to runpath in each realization).
 
+### Changed
+
+- [#1015](https://github.com/equinor/webviz-subsurface/pull/1015) - Improved error reporting for .arrow files where dates are not monotonically increasing.
+
 ### Fixed
 
 - [#1014](https://github.com/equinor/webviz-subsurface/pull/1014) - `ParameterResponseCorrelation` and `BhpQc` - fix bug in range slider. `VolumetricAnalysis` - prevent "Totals" volumes (if present) beeing included in the sum when comparing static and dynamic volumes, and do not include non-numeric columns as volumetric responses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#1015](https://github.com/equinor/webviz-subsurface/pull/1015) - Improved error reporting for .arrow files where dates are not monotonically increasing.
+- [#1015](https://github.com/equinor/webviz-subsurface/pull/1015) - Improved error reporting for `.arrow` files where dates are not monotonically increasing.
 
 ### Fixed
 

--- a/tests/unit_tests/provider_tests/test_ensemble_summary_provider_impl_arrow_lazy.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_summary_provider_impl_arrow_lazy.py
@@ -386,4 +386,4 @@ def test_create_with_repeated_dates(tmp_path: Path) -> None:
     # fmt:on
 
     with pytest.raises(ValueError):
-        provider = _create_provider_obj_with_data(input_data, tmp_path)
+        _create_provider_obj_with_data(input_data, tmp_path)

--- a/tests/unit_tests/provider_tests/test_ensemble_summary_provider_impl_arrow_lazy.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_summary_provider_impl_arrow_lazy.py
@@ -5,10 +5,13 @@ from typing import Dict
 import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
+import pytest
 
 from webviz_subsurface._providers.ensemble_summary_provider._provider_impl_arrow_lazy import (
     Frequency,
     ProviderImplArrowLazy,
+    _find_first_non_increasing_date_pair,
+    _is_date_column_monotonically_increasing,
 )
 from webviz_subsurface._providers.ensemble_summary_provider.ensemble_summary_provider import (
     EnsembleSummaryProvider,
@@ -336,3 +339,51 @@ def test_get_vectors_for_date_with_resampling(tmp_path: Path) -> None:
     assert df["REAL"][0] == 1
     assert df["TOT_t"][0] == 30.0
     assert df["RATE_r"][0] == 4.0
+
+
+def test_monotonically_increasing_date_util_functions() -> None:
+    table_with_duplicate = pa.Table.from_pydict(
+        {
+            "DATE": [
+                np.datetime64("2020-01-01", "ms"),
+                np.datetime64("2020-01-02", "ms"),
+                np.datetime64("2020-01-02", "ms"),
+                np.datetime64("2020-01-03", "ms"),
+            ],
+        },
+    )
+
+    table_with_decrease = pa.Table.from_pydict(
+        {
+            "DATE": [
+                np.datetime64("2020-01-01", "ms"),
+                np.datetime64("2020-01-05", "ms"),
+                np.datetime64("2020-01-04", "ms"),
+                np.datetime64("2020-01-10", "ms"),
+            ],
+        },
+    )
+
+    assert not _is_date_column_monotonically_increasing(table_with_duplicate)
+    offending_pair = _find_first_non_increasing_date_pair(table_with_duplicate)
+    assert offending_pair[0] == np.datetime64("2020-01-02", "ms")
+    assert offending_pair[1] == np.datetime64("2020-01-02", "ms")
+
+    assert not _is_date_column_monotonically_increasing(table_with_decrease)
+    offending_pair = _find_first_non_increasing_date_pair(table_with_decrease)
+    assert offending_pair[0] == np.datetime64("2020-01-05", "ms")
+    assert offending_pair[1] == np.datetime64("2020-01-04", "ms")
+
+
+def test_create_with_repeated_dates(tmp_path: Path) -> None:
+    # fmt:off
+    input_data = [
+        ["DATE",                                 "REAL", "A"],
+        [np.datetime64("2000-01-02T00:00", "ms"), 1,     10.0],
+        [np.datetime64("2500-12-20T23:59", "ms"), 1,     11.0],
+        [np.datetime64("2500-12-20T23:59", "ms"), 1,     12.0],
+    ]
+    # fmt:on
+
+    with pytest.raises(ValueError):
+        provider = _create_provider_obj_with_data(input_data, tmp_path)

--- a/webviz_subsurface/_providers/ensemble_summary_provider/_provider_impl_arrow_lazy.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/_provider_impl_arrow_lazy.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -43,12 +43,23 @@ def _sort_table_on_real_then_date(table: pa.Table) -> pa.Table:
     return sorted_table
 
 
-def _is_date_column_sorted(table: pa.Table) -> bool:
+def _is_date_column_monotonically_increasing(table: pa.Table) -> bool:
     dates_np = table.column("DATE").to_numpy()
     if not np.all(np.diff(dates_np) > np.timedelta64(0)):
         return False
 
     return True
+
+
+def _find_first_non_increasing_date_pair(
+    table: pa.Table,
+) -> Tuple[Optional[np.datetime64], Optional[np.datetime64]]:
+    dates_np = table.column("DATE").to_numpy()
+    offending_indices = np.asarray(np.diff(dates_np) <= np.timedelta64(0)).nonzero()[0]
+    if not offending_indices:
+        return (None, None)
+
+    return (dates_np[offending_indices[0]], dates_np[offending_indices[0] + 1])
 
 
 class ProviderImplArrowLazy(EnsembleSummaryProvider):
@@ -123,17 +134,26 @@ class ProviderImplArrowLazy(EnsembleSummaryProvider):
         timer = PerfTimer()
 
         unique_column_names = set()
-        for table in per_real_tables.values():
+        for real_num, table in per_real_tables.items():
             unique_column_names.update(table.schema.names)
 
             if "REAL" in table.schema.names:
-                raise ValueError("Input tables should not have REAL column")
+                raise ValueError(
+                    f"Input tables should not have REAL column (real={real_num})"
+                )
 
             if table.schema.field("DATE").type != pa.timestamp("ms"):
-                raise ValueError("DATE column must have timestamp[ms] data type")
+                raise ValueError(
+                    f"DATE column must have timestamp[ms] data type (real={real_num})"
+                )
 
-            if not _is_date_column_sorted(table):
-                raise ValueError("DATE column must be sorted")
+            if not _is_date_column_monotonically_increasing(table):
+                offending_pair = _find_first_non_increasing_date_pair(table)
+                raise ValueError(
+                    f"DATE column must be monotonically increasing\n"
+                    f"Error detected in realization: {real_num}\n"
+                    f"First offending timestamps: {offending_pair[0], offending_pair[0]}"
+                )
 
         LOGGER.debug(
             f"Concatenating {len(per_real_tables)} tables with "

--- a/webviz_subsurface/_providers/ensemble_summary_provider/_provider_impl_arrow_lazy.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/_provider_impl_arrow_lazy.py
@@ -152,7 +152,7 @@ class ProviderImplArrowLazy(EnsembleSummaryProvider):
                 raise ValueError(
                     f"DATE column must be monotonically increasing\n"
                     f"Error detected in realization: {real_num}\n"
-                    f"First offending timestamps: {offending_pair[0], offending_pair[0]}"
+                    f"First offending timestamps: {offending_pair}"
                 )
 
         LOGGER.debug(

--- a/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider_factory.py
@@ -224,9 +224,13 @@ class EnsembleSummaryProviderFactory(WebvizFactory):
             )
         et_import_smry_s = timer.lap_s()
 
-        ProviderImplArrowLazy.write_backing_store_from_per_realization_tables(
-            self._storage_dir, storage_key, per_real_tables
-        )
+        try:
+            ProviderImplArrowLazy.write_backing_store_from_per_realization_tables(
+                self._storage_dir, storage_key, per_real_tables
+            )
+        except ValueError as exc:
+            raise ValueError(f"Failed to write backing store for: {ens_path}") from exc
+
         et_write_s = timer.lap_s()
 
         provider = ProviderImplArrowLazy.from_backing_store(


### PR DESCRIPTION
Improved error reporting when loading `.arrow` files that contain dates that are not strictly monotonically increasing.
Now reports both the failing realization number and the two first offending timestamps. 
Also chains in an additional exception to indicate the failing ensemble.

This PR is related to #979. It does not mitigate the issue but provides additional on why and where the problem occurs.
