### PR TITLE
New data provider in `ParameterResponseCorrelation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#1017](https://github.com/equinor/webviz-subsurface/pull/1017) - `SeismicMisfit` - Added support for X,Y,Z,ID header in polygon files and improved error handling when inconsistency between obs and sim data.
+- [#1030](https://github.com/equinor/webviz-subsurface/pull/1030) - Implemented new summary data provider (using `.arrow` files) for the `ParameterResponseCorrelation` plugin.
 
 ## [0.2.13] - 2022-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [#1017](https://github.com/equinor/webviz-subsurface/pull/1017) - `SeismicMisfit` - Added support for X,Y,Z,ID header in polygon files and improved error handling when inconsistency between obs and sim data.
 - [#1030](https://github.com/equinor/webviz-subsurface/pull/1030) - Implemented new summary data provider (using `.arrow` files) for the `ParameterResponseCorrelation` plugin.
 
 ## [0.2.13] - 2022-05-05

--- a/webviz_subsurface/_providers/__init__.py
+++ b/webviz_subsurface/_providers/__init__.py
@@ -13,6 +13,7 @@ from .ensemble_summary_provider.ensemble_summary_provider import (
 from .ensemble_summary_provider.ensemble_summary_provider_factory import (
     EnsembleSummaryProviderFactory,
 )
+from .ensemble_summary_provider.utils import get_matching_vector_names
 from .ensemble_surface_provider import (
     EnsembleSurfaceProvider,
     EnsembleSurfaceProviderFactory,

--- a/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider.py
@@ -1,7 +1,5 @@
 import abc
 import datetime
-import fnmatch
-import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Sequence
@@ -118,20 +116,3 @@ class EnsembleSummaryProvider(abc.ABC):
         The returned DataFrame will always contain a 'REAL' column in addition to
         columns for all the requested vectors.
         """
-
-    def get_matching_vector_names(self, column_keys: List[str]) -> List[str]:
-        """Returns a list of vectors that match the input columns_keys that
-        can have unix shell wildcards.
-
-        This function is almost the same as filter_vectorlist_on_column_keys in
-        parameter_analysis/models/ensemble_timeseries_datamodel.py and should be
-        generalized somewhere.
-        """
-        try:
-            regex = re.compile(
-                "|".join([fnmatch.translate(col) for col in column_keys]),
-                flags=re.IGNORECASE,
-            )
-            return [vec for vec in self.vector_names() if regex.fullmatch(vec)]
-        except re.error:
-            return []

--- a/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider.py
@@ -1,5 +1,7 @@
 import abc
 import datetime
+import fnmatch
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional, Sequence
@@ -116,3 +118,20 @@ class EnsembleSummaryProvider(abc.ABC):
         The returned DataFrame will always contain a 'REAL' column in addition to
         columns for all the requested vectors.
         """
+
+    def get_matching_vector_names(self, column_keys: List[str]) -> List[str]:
+        """Returns a list of vectors that match the input columns_keys that
+        can have unix shell wildcards.
+
+        This function is almost the same as filter_vectorlist_on_column_keys in
+        parameter_analysis/models/ensemble_timeseries_datamodel.py and should be
+        generalized somewhere.
+        """
+        try:
+            regex = re.compile(
+                "|".join([fnmatch.translate(col) for col in column_keys]),
+                flags=re.IGNORECASE,
+            )
+            return [vec for vec in self.vector_names() if regex.fullmatch(vec)]
+        except re.error:
+            return []

--- a/webviz_subsurface/_providers/ensemble_summary_provider/utils.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/utils.py
@@ -1,0 +1,27 @@
+import fnmatch
+import re
+from typing import List
+
+from .ensemble_summary_provider import EnsembleSummaryProvider
+
+
+def get_matching_vector_names(
+    provider: EnsembleSummaryProvider, column_keys: List[str]
+) -> List[str]:
+    """Returns a list of vectors that match the input columns_keys that
+    can have unix shell wildcards.
+
+    Example of use:
+    column_keys = ["FOPT", "WGOR*"]
+    matching_vector_names = get_matching_vector_names(provider, column_keys)
+    df = provider.get_vectors_df(matching_vector_names, None)
+
+    """
+    try:
+        regex = re.compile(
+            "|".join([fnmatch.translate(col) for col in column_keys]),
+            flags=re.IGNORECASE,
+        )
+        return [vec for vec in provider.vector_names() if regex.fullmatch(vec)]
+    except re.error:
+        return []

--- a/webviz_subsurface/_providers/ensemble_summary_provider/utils.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/utils.py
@@ -17,11 +17,8 @@ def get_matching_vector_names(
     df = provider.get_vectors_df(matching_vector_names, None)
 
     """
-    try:
-        regex = re.compile(
-            "|".join([fnmatch.translate(col) for col in column_keys]),
-            flags=re.IGNORECASE,
-        )
-        return [vec for vec in provider.vector_names() if regex.fullmatch(vec)]
-    except re.error:
-        return []
+    regex = re.compile(
+        "|".join([fnmatch.translate(col) for col in column_keys]),
+        flags=re.IGNORECASE,
+    )
+    return [vec for vec in provider.vector_names() if regex.fullmatch(vec)]

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -797,6 +797,10 @@ def create_df_from_summary_provider(
     dfs = []
     for ens_name, provider in provider_set.items():
         matching_sumvecs = get_matching_vector_names(provider, column_keys)
+        if not matching_sumvecs:
+            raise ValueError(
+                f"No vectors matching the given column_keys: {column_keys} for ensemble: {ens_name}"
+            )
         df = provider.get_vectors_df(matching_sumvecs, None)
         df["ENSEMBLE"] = ens_name
         dfs.append(df)

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -30,7 +30,7 @@ class ParameterResponseCorrelation(WebvizPluginABC):
     """Visualizes correlations between numerical input parameters and responses.
 
 ---
-**Three main options for input data: Aggregated, file per realization and read from UNSMRY.**
+**Three main options for input data: Aggregated, file per realization and read from `.arrow`.**
 
 **Using aggregated data**
 * **`parameter_csv`:** Aggregated csvfile for input parameters with `REAL` and `ENSEMBLE` columns \
@@ -47,15 +47,15 @@ columns (absolute path or relative to config file).
 
 **Using simulation time series data directly from `UNSMRY` files as responses**
 * **`ensembles`:** Which ensembles in `shared_settings` to visualize. The lack of `response_file` \
-                implies that the input data should be time series data from simulation `.UNSMRY` \
-                files, read using `fmu-ensemble`.
+                implies that the input data should be time series data from `.arrow` file \
+* **`rel_file_pattern`:** Relative file path to `.arrow` file.
 * **`column_keys`:** (Optional) slist of simulation vectors to include as responses when reading \
                 from UNSMRY-files in the defined ensembles (default is all vectors). * can be \
                 used as wild card.
 * **`sampling`:** (Optional) sampling frequency when reading simulation data directly from \
                `.UNSMRY`-files (default is monthly).
 
-?> The `UNSMRY` input method implies that the "DATE" vector will be used as a filter \
+?> The `.arrow` input method implies that the "DATE" vector will be used as a filter \
    of type `single` (as defined below under `response_filters`).
 
 
@@ -90,7 +90,7 @@ would make more sense (though the pressures in this case would not be volume wei
 and the aggregation would therefore likely be imprecise).
 
 !> It is **strongly recommended** to keep the data frequency to a regular frequency (like \
-`monthly` or `yearly`). This applies to both csv input and when reading from `UNSMRY` \
+`monthly` or `yearly`). This applies to both csv input and when reading from `.arrow` \
 (controlled by the `sampling` key). This is because the statistics are calculated per DATE over \
 all realizations in an ensemble, and the available dates should therefore not differ between \
 individual realizations of an ensemble.
@@ -112,17 +112,12 @@ The `response_file` must have the response columns (and the columns to use as `r
 if that option is used).
 
 
-**Using simulation time series data directly from `UNSMRY` files as responses**
+**Using simulation time series data directly from `.arrow` files as responses**
 
 Parameters are extracted automatically from the `parameters.txt` files in the individual
-realizations, using the `fmu-ensemble` library.
+realizations.
 
-Responses are extracted automatically from the `UNSMRY` files in the individual realizations,
-using the `fmu-ensemble` library.
-
-!> The `UNSMRY` files are auto-detected by `fmu-ensemble` in the `eclipse/model` folder of the \
-individual realizations. You should therefore not have more than one `UNSMRY` file in this \
-folder, to avoid risk of not extracting the right data.
+Responses are extracted automatically from the `.arrow` files in the individual realizations.
 """
 
     # pylint:disable=too-many-arguments, too-many-locals

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -20,6 +20,7 @@ from webviz_subsurface._providers import (
     EnsembleTableProviderFactory,
     EnsembleTableProviderSet,
     Frequency,
+    get_matching_vector_names,
 )
 
 
@@ -776,7 +777,7 @@ def read_csv(csv_file) -> pd.DataFrame:
 
 
 def create_df_from_table_provider(provider: EnsembleTableProviderSet) -> pd.DataFrame:
-    """This function is the same as in parameter analysis and could be generalized."""
+    """Aggregates parameters from all ensemble into a common dataframe."""
     dfs = []
     for ens in provider.ensemble_names():
         df = provider.ensemble_provider(ens).get_column_data(
@@ -790,11 +791,11 @@ def create_df_from_table_provider(provider: EnsembleTableProviderSet) -> pd.Data
 def create_df_from_summary_provider(
     provider_set: Dict[str, EnsembleSummaryProvider], column_keys: List[str]
 ) -> pd.DataFrame:
-    """Descr"""
+    """Aggregates summary data from all ensembles into a common dataframe."""
     dfs = []
     for ens_name, provider in provider_set.items():
-        all_sumvecs = provider.get_matching_vector_names(column_keys)
-        df = provider.get_vectors_df(all_sumvecs, None)
+        matching_sumvecs = get_matching_vector_names(provider, column_keys)
+        df = provider.get_vectors_df(matching_sumvecs, None)
         df["ENSEMBLE"] = ens_name
         dfs.append(df)
 

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Callable, Dict, List, Tuple
 
 import pandas as pd
 import webviz_core_components as wcc
@@ -215,7 +215,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
         self.set_callbacks(app)
 
     @property
-    def tour_steps(self):
+    def tour_steps(self) -> List[Dict[str, Any]]:
         steps = [
             {
                 "id": self.uuid("layout"),
@@ -279,12 +279,12 @@ Responses are extracted automatically from the `.arrow` files in the individual 
         return steps
 
     @property
-    def ensembles(self):
+    def ensembles(self) -> List[str]:
         """Returns list of ensembles"""
         return list(self.parameterdf["ENSEMBLE"].unique())
 
     @property
-    def filter_layout(self):
+    def filter_layout(self) -> List[Any]:
         """Layout to display selectors for response filters"""
         children = []
         for col_name, col_type in self.response_filters.items():
@@ -332,7 +332,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
         return children
 
     @property
-    def control_layout(self):
+    def control_layout(self) -> List[Any]:
         """Layout to select e.g. iteration and response"""
         max_params = len(self.parameter_columns)
         return [
@@ -396,7 +396,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
         ]
 
     @property
-    def layout(self):
+    def layout(self) -> wcc.FlexBox:
         """Main layout"""
         return wcc.FlexBox(
             id=self.uuid("layout"),
@@ -456,7 +456,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
         )
 
     @property
-    def correlation_input_callbacks(self):
+    def correlation_input_callbacks(self) -> List[Input]:
         """List of Inputs for correlation callback"""
         callbacks = [
             Input(self.uuid("ensemble"), "value"),
@@ -473,7 +473,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
         return callbacks
 
     @property
-    def distribution_input_callbacks(self):
+    def distribution_input_callbacks(self) -> List[Input]:
         """List of Inputs for distribution callback"""
         callbacks = [
             Input(self.uuid("correlation-graph"), "clickData"),
@@ -487,7 +487,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
                 callbacks.append(Input(self.uuid(f"filter-{col_name}"), "value"))
         return callbacks
 
-    def set_callbacks(self, app):
+    def set_callbacks(self, app) -> None:
         @app.callback(
             [
                 Output(self.uuid("correlation-graph"), "figure"),
@@ -599,7 +599,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
             ]
             return make_distribution_plot(df, parameter, response, self.theme)
 
-    def add_webvizstore(self):
+    def add_webvizstore(self) -> List[Tuple[Callable, List[Dict]]]:
         if self.parameter_csv and self.response_csv:
             return [
                 (
@@ -635,7 +635,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
         return []
 
 
-def correlate(inputdf, response, method="pearson"):
+def correlate(inputdf, response, method="pearson") -> pd.DataFrame:
     """Returns the correlation matrix for a dataframe"""
     if method == "pearson":
         corrdf = inputdf.corr(method=method)
@@ -649,9 +649,7 @@ def correlate(inputdf, response, method="pearson"):
     return corrdf.reindex(corrdf[response].abs().sort_values().index)
 
 
-def make_correlation_plot(
-    series, response, theme, corr_method, corr_cutoff, max_parameters
-):
+def make_correlation_plot(series, response, theme, corr_method) -> Dict[str, Any]:
     """Make Plotly trace for correlation plot"""
     xaxis_range = max(abs(series.values)) * 1.1
     layout = {
@@ -735,11 +733,10 @@ def make_distribution_plot(df, parameter, response, theme):
             },
         )
     )
-
     return fig
 
 
-def make_range_slider(domid, values, col_name):
+def make_range_slider(domid, values, col_name) -> wcc.RangeSlider:
     try:
         values.apply(pd.to_numeric, errors="raise")
     except ValueError as exc:
@@ -765,7 +762,7 @@ def make_range_slider(domid, values, col_name):
     )
 
 
-def theme_layout(theme, specific_layout):
+def theme_layout(theme, specific_layout) -> Dict:
     layout = {}
     layout.update(theme["layout"])
     layout.update(specific_layout)

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -650,7 +650,9 @@ def correlate(inputdf, response, method="pearson") -> pd.DataFrame:
     return corrdf.reindex(corrdf[response].abs().sort_values().index)
 
 
-def make_correlation_plot(series, response, theme, corr_method) -> Dict[str, Any]:
+def make_correlation_plot(
+    series, response, theme, corr_method, corr_cutoff, max_parameters
+) -> Dict[str, Any]:
     """Make Plotly trace for correlation plot"""
     xaxis_range = max(abs(series.values)) * 1.1
     layout = {


### PR DESCRIPTION
This PR implements the new summary data provider i `ParameterResponseCorrelation`. 

I also needed to make a general function that matches column_keys with * as wildcard. I have put it in EnsembleSummaryProvider, but we can discuss where it should be.

### Contributor checklist

- [x] :tada: This PR closes `ParameterResponseCorrelation `in #858
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [x] New data provider
   - [x] General function that matches column_keys with wild cards
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
