### PR TITLE
Increased maximum number of selected vectors in `SimulationTimeSeries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1020](https://github.com/equinor/webviz-subsurface/pull/1020) - `WellAnalysis` - Several improvements and bug fixes. F.ex a well attribute filter in the well overview plots and the possibility to see production only after a given date.
 - [#1017](https://github.com/equinor/webviz-subsurface/pull/1017) - `SeismicMisfit` - Added support for X,Y,Z,ID header in polygon files and improved error handling when inconsistency between obs and sim data.
 - [#1030](https://github.com/equinor/webviz-subsurface/pull/1030) - Implemented new summary data provider (using `.arrow` files) for the `ParameterResponseCorrelation` plugin.
+- [#1041](https://github.com/equinor/webviz-subsurface/pull/1041) - Increased maximum number of selected vectors in `SimulationTimeSeries` plugin.
 
 ## [0.2.13] - 2022-05-05
 

--- a/webviz_subsurface/plugins/_simulation_time_series/_layout.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_layout.py
@@ -259,7 +259,7 @@ def __settings_layout(
                 children=[
                     wsc.VectorSelector(
                         id=get_uuid(LayoutElements.VECTOR_SELECTOR),
-                        maxNumSelectedNodes=3,
+                        maxNumSelectedNodes=100,
                         data=vector_selector_data,
                         persistence=True,
                         persistence_type="session",

--- a/webviz_subsurface/plugins/_simulation_time_series/_property_serialization/vector_subplot_builder.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_property_serialization/vector_subplot_builder.py
@@ -64,7 +64,7 @@ class VectorSubplotBuilder(GraphFigureBuilderBase):
             rows=max(1, len(self._selected_vectors)),
             cols=1,
             shared_xaxes=True,
-            vertical_spacing=0.05,
+            vertical_spacing=min(0.05, 1 / max(1, len(self._selected_vectors))),
             subplot_titles=[vector_titles.get(elm, elm) for elm in selected_vectors],
         )
         if theme:


### PR DESCRIPTION
Increased maximum number of selected vectors in `SimulationTimeSeries` to 100.

Also modified the vertical spacing between subplots to avoid error when requesting > 21 subplots (both when plotting per time series or per ensemble). Only relevant to avoid errors, as that many subplots will anyways be useless considering the height of each plot. 
---

### Contributor checklist

- [X] :tada: This PR closes #1040.
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Increase allowable selections
   - [X] Make the vertical spacing between subplots more robust
_- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR._ **No tests added**
- [X] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
