### PR TITLE
Pinned `dash` to `<2.6.0` in order to keep `_NoUpdate` class available.

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -49,6 +49,7 @@ jobs:
         if [[ $(pip freeze) ]]; then
           pip freeze | grep -vw "pip" | xargs pip uninstall -y
         fi
+        pip install "dash<2.6.0" # removed "_NoUpdate" in dash==2.6.0
         pip install "bleach<5"  # https://github.com/equinor/webviz-config/issues/586
         pip install "werkzeug<2.1"  # ...while waiting for https://github.com/plotly/dash/issues/1992
         pip install "selenium<4.3"  # breaking change in selenium==4.3


### PR DESCRIPTION
The newest `dash` version does no longer come with a `_NoUpdate` class which is used by some of the plugins in `webviz_subsurface`. In order to give the plugin authors time to fix this issue/find a different solution, the `dash` version was pinned to `<2.6.0` in the GitHub workflow (in order to avoid failing checks).
---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] -
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
