### PR TITLE
Support `dash>=2.6`

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -49,7 +49,6 @@ jobs:
         if [[ $(pip freeze) ]]; then
           pip freeze | grep -vw "pip" | xargs pip uninstall -y
         fi
-        pip install "dash<2.6.0" # removed "_NoUpdate" in dash==2.6.0
         pip install "bleach<5"  # https://github.com/equinor/webviz-config/issues/586
         pip install "werkzeug<2.1"  # ...while waiting for https://github.com/plotly/dash/issues/1992
         pip install "selenium<4.3"  # breaking change in selenium==4.3

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_response_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_response_controller.py
@@ -2,7 +2,7 @@ from typing import Callable, Tuple, Union
 
 import pandas as pd
 from dash import ALL, Dash, Input, Output, State, callback_context, no_update
-from dash.dash import _NoUpdate
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._figures import BarChart, ScatterPlot, TimeSeriesFigure
@@ -75,11 +75,11 @@ def property_response_controller(
     def _update_correlation_figure(
         label: str, ensemble: str
     ) -> Tuple[
-        Union[float, _NoUpdate],
-        Union[float, _NoUpdate],
-        Union[float, _NoUpdate],
+        Union[float, NoUpdate],
+        Union[float, NoUpdate],
+        Union[float, NoUpdate],
         list,
-        Union[dict, _NoUpdate],
+        Union[dict, NoUpdate],
         bool,
     ]:
         if label is not None:

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import xtgeo
 from dash import Dash, Input, Output, State, callback_context, no_update
-from dash.dash import _NoUpdate
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._datainput.well import (
@@ -344,7 +344,7 @@ def update_maps(
     def _update_from_map_click(
         clicked_shape: Optional[Dict],
         _polyline: List[List[float]],
-    ) -> Tuple[str, Union[_NoUpdate, str]]:
+    ) -> Tuple[str, Union[NoUpdate, str]]:
         """Update intersection source and optionally selected well when
         user clicks a shape in map"""
         ctx = callback_context.triggered[0]


### PR DESCRIPTION
It looks like the private class `NoUpdate` was moved in https://github.com/plotly/dash/commit/43e42eaecbd912c5391db5acd81566a35786a26a.

The class is only used in type checking on our side, so we have two options:
* Coninue use the dash private class in the type checking.
* Loosen up the type checking on our side.

After discussion, we go for the first solution, and hope dash itself gets type hinted in the near future (such that also `NoUpdate` becomes a public entity).