### PR TITLE
Bugfix in `ParameterResponseCorrelation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#1094](https://github.com/equinor/webviz-subsurface/pull/1094) - Fixed issues with ambiguous truth of `pandas.Series` in `EnsembleSummaryProvider`.
+- [#1107](https://github.com/equinor/webviz-subsurface/pull/1107) - Fixed bug in `ParameterResponseCorrelation` that caused the plugin to fail if the `response_filters` parameter was not given.
 
 ### Changed
 

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -424,8 +424,6 @@ Responses are extracted automatically from the `.arrow` files in the individual 
                                     children=self.filter_layout,
                                 )
                             ]
-                            if self.response_filters
-                            else []
                         ),
                     ),
                 ),

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -414,17 +414,13 @@ Responses are extracted automatically from the `.arrow` files in the individual 
                         children=[
                             wcc.Selectors(
                                 label="Controls", children=self.control_layout
-                            )
-                        ]
-                        + (
-                            [
-                                wcc.Selectors(
-                                    label="Filters",
-                                    id=self.uuid("filters"),
-                                    children=self.filter_layout,
-                                )
-                            ]
-                        ),
+                            ),
+                            wcc.Selectors(
+                                label="Filters",
+                                id=self.uuid("filters"),
+                                children=self.filter_layout,
+                            ),
+                        ],
                     ),
                 ),
                 wcc.FlexColumn(


### PR DESCRIPTION
Fixed a bug in `ParameterResponseCorrelation` that caused the plugin to fail if `response_filters` was not given as input parameter. Now the filters layout will always be added with at least the parameter filter.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
