### PR TITLE
Update MapViewerFMU to new changes in DeckGLMap component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1118](https://github.com/equinor/webviz-subsurface/pull/1118) - `MapViewerFMU` - Removed `zoom` and `bounds` props from `DeckGLMap` as they are now automatically calculated.
 - [#1094](https://github.com/equinor/webviz-subsurface/pull/1094) - Fixed issues with ambiguous truth of `pandas.Series` in `EnsembleSummaryProvider`.
 - [#1107](https://github.com/equinor/webviz-subsurface/pull/1107) - Fixed bug in `ParameterResponseCorrelation` that caused the plugin to fail if the `response_filters` parameter was not given.
 

--- a/webviz_subsurface/plugins/_map_viewer_fmu/layout.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/layout.py
@@ -253,9 +253,7 @@ class MapViewLayout(FullScreen):
                 DeckGLMap(
                     id={"id": get_uuid(LayoutElements.DECKGLMAP), "tab": tab},
                     layers=update_map_layers(1),
-                    zoom=-4,
                     colorTables=color_tables,
-                    bounds=[0, 0, 1000, 1000],
                 ),
                 style={"height": LayoutStyle.MAPHEIGHT},
             ),


### PR DESCRIPTION
Remove `zoom` and `bounds` prop as these are now calculated automatically.
