### PR TITLE
Fix `callback_typecheck` error for `wcc.Dialog` prop in `SimulationTimeSeries`

### DIFF
--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
@@ -116,6 +116,7 @@ class TimeSeriesSettings(SettingsGroupABC):
                     TimeSeriesSettings.Ids.VECTOR_CALCULATOR_DIALOG
                 ),
                 draggable=True,
+                open=False,
                 max_width="lg",
                 children=[
                     html.Div(


### PR DESCRIPTION
`open` is not required prop for wcc.Dialog, thus initial value was undefined, and the data type was undefined - i.e `None`. Resolved by defining initial state False, thus `open.propType = boolean` in `React`-component and python type is `bool`.
