### PR TITLE
Make it possible to `import webviz_subsurface` without `opm` and `ecl2df`. Include test install and import on `windows`

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -10,7 +10,7 @@ on:
       - published
   schedule:
     # Run CI daily and check that tests are working with latest dependencies
-    - cron:  '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   webviz-subsurface:
@@ -18,137 +18,173 @@ jobs:
     if: github.event_name != 'push' || github.ref == 'refs/heads/master' || contains(github.event.head_commit.message, '[deploy test]')
     runs-on: ubuntu-latest
     env:
-      PYTHONWARNINGS: default  # We want to see e.g. DeprecationWarnings
+      PYTHONWARNINGS: default # We want to see e.g. DeprecationWarnings
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
+      - name: 🧹 Remove unused pre-installed software
+        run: |
+          # https://github.com/actions/virtual-environments/issues/751
+          # https://github.com/actions/virtual-environments/issues/709
+          sudo apt-get purge p7zip* yarn ruby-full ghc* php7*
+          sudo apt-get autoremove
+          sudo apt-get clean
+          df -h
 
-    - name: 🧹 Remove unused pre-installed software
-      run: |
-        # https://github.com/actions/virtual-environments/issues/751
-        # https://github.com/actions/virtual-environments/issues/709
-        sudo apt-get purge p7zip* yarn ruby-full ghc* php7*
-        sudo apt-get autoremove
-        sudo apt-get clean
-        df -h
+      - name: 📖 Checkout commit locally
+        uses: actions/checkout@v2
 
-    - name: 📖 Checkout commit locally
-      uses: actions/checkout@v2
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: 🐍 Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: 📦 Install webviz-subsurface with dependencies
+        run: |
+          pip install --upgrade pip
+          if [[ $(pip freeze) ]]; then
+            pip freeze | grep -vw "pip" | xargs pip uninstall -y
+          fi
+          pip install "bleach<5"  # https://github.com/equinor/webviz-config/issues/586
+          pip install "werkzeug<2.1"  # ...while waiting for https://github.com/plotly/dash/issues/1992
+          pip install "selenium<4.3"  # breaking change in selenium==4.3
+          pip install "scipy<1.9.3"   # breaking change in scipy==1.9.3
+          pip install "pytest<7.2.0"
+          pip install "pytest-xdist<3.0"
+          pip install "xtgeo<2.20.2"
+          pip install .
 
-    - name: 📦 Install webviz-subsurface with dependencies
-      run: |
-        pip install --upgrade pip
-        if [[ $(pip freeze) ]]; then
-          pip freeze | grep -vw "pip" | xargs pip uninstall -y
-        fi
-        pip install "bleach<5"  # https://github.com/equinor/webviz-config/issues/586
-        pip install "werkzeug<2.1"  # ...while waiting for https://github.com/plotly/dash/issues/1992
-        pip install "selenium<4.3"  # breaking change in selenium==4.3
-        pip install "scipy<1.9.3"   # breaking change in scipy==1.9.3
-        pip install "pytest<7.2.0"
-        pip install "pytest-xdist<3.0"
-        pip install "xtgeo<2.20.2"
-        pip install .
+          # Testing against our latest release (including pre-releases)
+          pip install --pre --upgrade webviz-config webviz-core-components webviz-subsurface-components
 
-        # Testing against our latest release (including pre-releases)
-        pip install --pre --upgrade webviz-config webviz-core-components webviz-subsurface-components
+      - name: 📦 Install test dependencies
+        run: |
+          pip install .[tests]
+          wget https://chromedriver.storage.googleapis.com/$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)/chromedriver_linux64.zip
+          unzip chromedriver_linux64.zip
+          export PATH=$PATH:$PWD
 
-    - name: 📦 Install test dependencies
-      run: |
-        pip install .[tests]
-        wget https://chromedriver.storage.googleapis.com/$(wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE -q -O -)/chromedriver_linux64.zip
-        unzip chromedriver_linux64.zip
-        export PATH=$PATH:$PWD
+      - name: 🧾 List all installed packages
+        run: pip freeze
 
-    - name: 🧾 List all installed packages
-      run: pip freeze
+      - name: 🕵️ Check code style & linting
+        run: |
+          black --check webviz_subsurface tests setup.py
+          pylint webviz_subsurface tests setup.py
+          bandit -r -c ./bandit.yml webviz_subsurface tests setup.py
+          isort --check-only webviz_subsurface tests setup.py
+          mypy --package webviz_subsurface
 
-    - name: 🕵️ Check code style & linting
-      run: |
-        black --check webviz_subsurface tests setup.py
-        pylint webviz_subsurface tests setup.py
-        bandit -r -c ./bandit.yml webviz_subsurface tests setup.py
-        isort --check-only webviz_subsurface tests setup.py
-        mypy --package webviz_subsurface
+      - name: 🤖 Run tests
+        env:
+          # If you want the CI to (temporarily) run against your fork of the testdada,
+          # change the value her from "equinor" to your username.
+          TESTDATA_REPO_OWNER: equinor
+          # If you want the CI to (temporarily) run against another branch than master,
+          # change the value her from "master" to the relevant branch name.
+          TESTDATA_REPO_BRANCH: master
+        run: |
+          git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/webviz-subsurface-testdata.git
+          # Copy any clientside script to the test folder before running tests
+          mkdir ./tests/assets && cp ./webviz_subsurface/_assets/js/* ./tests/assets
+          pytest ./tests --headless --forked --testdata-folder ./webviz-subsurface-testdata
+          rm -rf ./tests/assets
+          webviz docs --portable ./docs_build --skip-open
 
-    - name: 🤖 Run tests
-      env:
-        # If you want the CI to (temporarily) run against your fork of the testdada,
-        # change the value her from "equinor" to your username.
-        TESTDATA_REPO_OWNER: equinor
-        # If you want the CI to (temporarily) run against another branch than master,
-        # change the value her from "master" to the relevant branch name.
-        TESTDATA_REPO_BRANCH: master
-      run: |
-        git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/webviz-subsurface-testdata.git
-        # Copy any clientside script to the test folder before running tests
-        mkdir ./tests/assets && cp ./webviz_subsurface/_assets/js/* ./tests/assets
-        pytest ./tests --headless --forked --testdata-folder ./webviz-subsurface-testdata
-        rm -rf ./tests/assets
-        webviz docs --portable ./docs_build --skip-open
+      - name: 🐳 Build Docker example image
+        run: |
+          pip install --pre webviz-config-equinor
+          export SOURCE_URL_WEBVIZ_SUBSURFACE=https://github.com/$GITHUB_REPOSITORY
+          export GIT_POINTER_WEBVIZ_SUBSURFACE=$GITHUB_REF
+          webviz build ./webviz-subsurface-testdata/webviz_examples/webviz-full-demo.yml --portable ./example_subsurface_app --theme equinor
+          rm -rf ./webviz-subsurface-testdata
+          pushd example_subsurface_app
+          docker build -t webviz/example_subsurface_image:equinor-theme .
+          popd
 
-    - name: 🐳 Build Docker example image
-      run: |
-        pip install --pre webviz-config-equinor
-        export SOURCE_URL_WEBVIZ_SUBSURFACE=https://github.com/$GITHUB_REPOSITORY
-        export GIT_POINTER_WEBVIZ_SUBSURFACE=$GITHUB_REF
-        webviz build ./webviz-subsurface-testdata/webviz_examples/webviz-full-demo.yml --portable ./example_subsurface_app --theme equinor
-        rm -rf ./webviz-subsurface-testdata
-        pushd example_subsurface_app
-        docker build -t webviz/example_subsurface_image:equinor-theme .
-        popd
+      - name: 🐳 Update Docker Hub example image
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/master' && matrix.python-version == '3.8'
+        run: |
+          echo ${{ secrets.dockerhub_webviz_token }} | docker login --username webviz --password-stdin
+          docker push webviz/example_subsurface_image:equinor-theme
 
-    - name: 🐳 Update Docker Hub example image
-      if: github.event_name != 'schedule' && github.ref == 'refs/heads/master' && matrix.python-version == '3.8'
-      run: |
-        echo ${{ secrets.dockerhub_webviz_token }} | docker login --username webviz --password-stdin
-        docker push webviz/example_subsurface_image:equinor-theme
+      - name: 🐳 Update review/test Docker example image
+        if: github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[deploy test]') && matrix.python-version == '3.8'
+        run: |
+          docker tag webviz/example_subsurface_image:equinor-theme ${{ secrets.review_docker_registry_url }}/${{ secrets.review_container_name }}
 
-    - name: 🐳 Update review/test Docker example image
-      if: github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[deploy test]') && matrix.python-version == '3.8'
-      run: |
-        docker tag webviz/example_subsurface_image:equinor-theme ${{ secrets.review_docker_registry_url }}/${{ secrets.review_container_name }}
+          echo ${{ secrets.review_docker_registry_token }} | docker login ${{ secrets.review_docker_registry_url }} --username ${{ secrets.review_docker_registry_username }} --password-stdin
+          docker push ${{ secrets.review_docker_registry_url }}/${{ secrets.review_container_name }}
 
-        echo ${{ secrets.review_docker_registry_token }} | docker login ${{ secrets.review_docker_registry_url }} --username ${{ secrets.review_docker_registry_username }} --password-stdin
-        docker push ${{ secrets.review_docker_registry_url }}/${{ secrets.review_container_name }}
+      - name: 🚢 Build and deploy Python package
+        if: github.event_name == 'release' && matrix.python-version == '3.8'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_webviz_token }}
+        run: |
+          python -m pip install --upgrade setuptools wheel twine
+          python setup.py sdist bdist_wheel
+          twine upload dist/*
 
-    - name: 🚢 Build and deploy Python package
-      if: github.event_name == 'release' && matrix.python-version == '3.8'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.pypi_webviz_token }}
-      run: |
-        python -m pip install --upgrade setuptools wheel twine
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - name: 📚 Update GitHub pages
+        if: github.event_name == 'release' && matrix.python-version == '3.8'
+        run: |
+          cp -R ./docs_build ../docs_build
 
-    - name: 📚 Update GitHub pages
-      if: github.event_name == 'release' && matrix.python-version == '3.8'
-      run: |
-        cp -R ./docs_build ../docs_build
+          git config --local user.email "webviz-github-action"
+          git config --local user.name "webviz-github-action"
+          git fetch origin gh-pages
+          git checkout --track origin/gh-pages
+          git clean -f -f -d -x
+          git rm -r *
 
-        git config --local user.email "webviz-github-action"
-        git config --local user.name "webviz-github-action"
-        git fetch origin gh-pages
-        git checkout --track origin/gh-pages
-        git clean -f -f -d -x
-        git rm -r *
+          cp -R ../docs_build/* .
 
-        cp -R ../docs_build/* .
+          git add .
 
-        git add .
+          if git diff-index --quiet HEAD; then
+            echo "No changes in documentation. Skip documentation deploy."
+          else
+            git commit -m "Update Github Pages"
+            git push "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
+          fi
 
-        if git diff-index --quiet HEAD; then
-          echo "No changes in documentation. Skip documentation deploy."
-        else
-          git commit -m "Update Github Pages"
-          git push "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
-        fi
+  webviz-subsurface-windows:
+    # Run on all events defined above, except pushes which are neither to master nor with a substring [deploy test] in commit message
+    if: github.event_name != 'push' || github.ref == 'refs/heads/master' || contains(github.event.head_commit.message, '[deploy test]')
+    runs-on: windows-latest
+    env:
+      PYTHONWARNINGS: default # We want to see e.g. DeprecationWarnings
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+
+    steps:
+      - name: 📖 Checkout commit locally
+        uses: actions/checkout@v2
+
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: 📦 Install webviz-subsurface with dependencies
+        run: |
+          pip install --upgrade pip
+          pip install "bleach<5"  # https://github.com/equinor/webviz-config/issues/586
+          pip install "werkzeug<2.1"  # ...while waiting for https://github.com/plotly/dash/issues/1992
+          pip install "selenium<4.3"  # breaking change in selenium==4.3
+          pip install "scipy<1.9.3"   # breaking change in scipy==1.9.3
+          pip install "pytest<7.2.0"
+          pip install "pytest-xdist<3.0"
+          pip install "xtgeo<2.20.2"
+          pip install .
+
+      - name: Test import
+        run: |
+          import webviz_subsurface
+        shell: python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Changed
+- [#1122](https://github.com/equinor/webviz-subsurface/pull/1122) - `opm` and `ecl2df` are now optional, making `windows-subsurface` possible to install and import on non-unix based systems. **NOTE:** a lot of the functionality in `webviz-subsurface` is built on `opm` and `ecl2df`, and issues are therefore expected on eg Windows and macOS. Use with care. 
+
 ## [0.2.16] - 2022-11-09
 
 ### Changed

--- a/tests/unit_tests/provider_tests/test_ensemble_summary_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_summary_provider.py
@@ -4,7 +4,18 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
-from fmu.ensemble import ScratchEnsemble
+
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from fmu.ensemble import ScratchEnsemble
+except ImportError:
+    pass
 
 from webviz_subsurface._providers import (
     EnsembleSummaryProviderFactory,

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
@@ -42,8 +42,19 @@ from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
-from opm.io.ecl import EclFile
 from scipy import interpolate
+
+# opm is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from opm.io.ecl import EclFile
+except ImportError:
+    pass
 
 from ..eclipse_unit import ConvertUnits, EclUnitEnum, EclUnits
 from ..units import Unit

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
@@ -39,7 +39,18 @@
 from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
-from opm.io.ecl import EclFile
+
+# opm is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from opm.io.ecl import EclFile
+except ImportError:
+    pass
 
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
@@ -39,7 +39,18 @@
 from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
-from opm.io.ecl import EclFile
+
+# opm is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from opm.io.ecl import EclFile
+except ImportError:
+    pass
 
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_water.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_water.py
@@ -39,7 +39,18 @@
 from typing import Any, Callable, List, Optional, Union
 
 import numpy as np
-from opm.io.ecl import EclFile
+
+# opm is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from opm.io.ecl import EclFile
+except ImportError:
+    pass
 
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (

--- a/webviz_subsurface/_datainput/fmu_input.py
+++ b/webviz_subsurface/_datainput/fmu_input.py
@@ -4,9 +4,20 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import pandas as pd
-from fmu.ensemble import EnsembleSet, ScratchEnsemble
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
+
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from fmu.ensemble import EnsembleSet, ScratchEnsemble
+except ImportError:
+    pass
 
 
 @CACHE.memoize(timeout=CACHE.TIMEOUT)

--- a/webviz_subsurface/_datainput/history_match.py
+++ b/webviz_subsurface/_datainput/history_match.py
@@ -1,9 +1,20 @@
 from pathlib import Path
 
-import fmu.ensemble
 import pandas as pd
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
+
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    import fmu.ensemble
+except ImportError:
+    pass
 
 from .fmu_input import load_ensemble_set
 

--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -6,7 +6,18 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-from ecl2df import EclFiles, common
+
+# opm and ecl2df are only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from ecl2df import EclFiles, common
+except ImportError:
+    pass
 
 from .fmu_input import scratch_ensemble
 

--- a/webviz_subsurface/_models/ensemble_model.py
+++ b/webviz_subsurface/_models/ensemble_model.py
@@ -4,9 +4,20 @@ import re
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
-from fmu.ensemble import ScratchEnsemble
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore
+
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from fmu.ensemble import ScratchEnsemble
+except ImportError:
+    pass
 
 
 class EnsembleModel:

--- a/webviz_subsurface/_providers/ensemble_fault_polygons_provider/_fault_polygons_discovery.py
+++ b/webviz_subsurface/_providers/ensemble_fault_polygons_provider/_fault_polygons_discovery.py
@@ -5,7 +5,17 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from fmu.ensemble import ScratchEnsemble
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from fmu.ensemble import ScratchEnsemble
+except ImportError:
+    pass
 
 
 @dataclass(frozen=True)

--- a/webviz_subsurface/_providers/ensemble_summary_provider/_csv_import.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/_csv_import.py
@@ -3,7 +3,18 @@ from pathlib import Path
 from typing import Optional
 
 import pandas as pd
-from fmu.ensemble import ScratchEnsemble
+
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from fmu.ensemble import ScratchEnsemble
+except ImportError:
+    pass
 
 from webviz_subsurface._utils.perf_timer import PerfTimer
 

--- a/webviz_subsurface/_providers/ensemble_surface_provider/_surface_discovery.py
+++ b/webviz_subsurface/_providers/ensemble_surface_provider/_surface_discovery.py
@@ -5,7 +5,17 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from fmu.ensemble import ScratchEnsemble
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from fmu.ensemble import ScratchEnsemble
+except ImportError:
+    pass
 
 
 @dataclass(frozen=True)

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
@@ -6,10 +6,21 @@ from pathlib import Path
 from typing import Dict
 
 import pandas as pd
-from fmu.ensemble import ScratchEnsemble
 from webviz_config.webviz_factory import WebvizFactory
 from webviz_config.webviz_factory_registry import WEBVIZ_FACTORY_REGISTRY
 from webviz_config.webviz_instance_info import WebvizRunMode
+
+# The fmu.ensemble dependency ecl is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+try:
+    from fmu.ensemble import ScratchEnsemble
+except ImportError:
+    pass
 
 from webviz_subsurface._utils.perf_timer import PerfTimer
 


### PR DESCRIPTION

- [X] :tada: This PR closes #520 (at least as far as we get for now, a lot of functionality is lost due to opm, ecl2df and fmu-ensemble not being compatible. It is thus possible to install `webviz-subsurface` and import `webviz_subsurface`, but the likelyhood of crashes due to using functionality that is dependent of these packages is **high**
- [X] :scroll: I have broken down my PR into the following tasks:
   - [X] Wrap imports of `opm`, `ecl2df` and `fmu.ensemble` in `try/except`
- [X] :robot:  Added a test to install and import on `windows-latest` in `Github Actions` (also I let the `yaml` extension from `RedHat` in `vscode` autoformat the workflow file
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
