### PR TITLE
Option to remove header from parameter filter

### DIFF
--- a/webviz_subsurface/_components/parameter_filter.py
+++ b/webviz_subsurface/_components/parameter_filter.py
@@ -25,7 +25,11 @@ class ParameterFilter:
     """Component that can be added to a plugin to filter parameters"""
 
     def __init__(
-        self, uuid: str, dframe: pd.DataFrame, reset_on_ensemble_update: bool = False
+        self,
+        uuid: str,
+        dframe: pd.DataFrame,
+        reset_on_ensemble_update: bool = False,
+        display_header: bool = True,
     ) -> None:
         """
         * **`uuid`:** Unique id (use the plugin id).
@@ -33,6 +37,7 @@ class ParameterFilter:
 
         self._uuid = uuid
         self._reset_on_ensemble_update = reset_on_ensemble_update
+        self._display_header = display_header
         self._pmodel = ParametersModel(
             dataframe=dframe,
             drop_constants=True,
@@ -138,18 +143,20 @@ class ParameterFilter:
 
     @property
     def layout(self) -> html.Div:
+        children = [
+            self.buttons,
+            self.settings_layout,
+            self.realizations_removed_layout,
+            self.active_filters_layout,
+            self.parameter_filter_layout,
+        ]
+
+        if self._display_header:
+            children = [self.header] + children
+
         return html.Div(
             children=[
-                html.Div(
-                    children=[
-                        self.header,
-                        self.buttons,
-                        self.settings_layout,
-                        self.realizations_removed_layout,
-                        self.active_filters_layout,
-                        self.parameter_filter_layout,
-                    ]
-                ),
+                html.Div(children=children),
                 dcc.Store(
                     id={"id": self._uuid, "type": "data-store"},
                     data=self._initial_store,

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
@@ -24,4 +24,5 @@ class ParameterFilterSettings(SettingsGroupABC):
                 self._parameter_df["ENSEMBLE"].isin(self._mc_ensembles)
             ].copy(),
             reset_on_ensemble_update=True,
+            display_header=False,
         ).layout


### PR DESCRIPTION
The header in the Parameter filter is not needed when it is used in a WLF settings group, because it has it's own name. This makes the header optional. But the default behavior is as before.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
