### PR TITLE
Metadata functionality in `EnsembleTableProvider`

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -55,6 +55,7 @@ jobs:
         pip install "scipy<1.9.3"   # breaking change in scipy==1.9.3
         pip install "pytest<7.2.0"
         pip install "pytest-xdist<3.0"
+        pip install "xtgeo<2.20.2"
         pip install .
 
         # Testing against our latest release (including pre-releases)

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "pillow>=6.1",
         "pyarrow>=5.0.0",
         "pyscal>=0.7.5",
-        "scipy<=1.9.2",
+        "scipy>=1.2",
         "statsmodels>=0.12.1",  # indirect dependency through https://plotly.com/python/linear-fits/
         "webviz-config>=0.5",
         "webviz-core-components>=0.6",

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
         "pillow>=6.1",
         "pyarrow>=5.0.0",
         "pyscal>=0.7.5",
-        "scipy>=1.2",
+        "scipy<=1.9.2",
         "statsmodels>=0.12.1",  # indirect dependency through https://plotly.com/python/linear-fits/
         "webviz-config>=0.5",
         "webviz-core-components>=0.6",

--- a/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
@@ -6,7 +6,7 @@ import pandas as pd
 from webviz_subsurface._providers import (
     EnsembleTableProvider,
     EnsembleTableProviderFactory,
-    TableVectorMetadata
+    TableVectorMetadata,
 )
 from webviz_subsurface._providers.ensemble_table_provider import (
     EnsembleTableProviderImplArrow,

--- a/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
@@ -88,9 +88,9 @@ def test_create_from_aggregated_csv_file_smry_csv(
     assert valdf.columns[1] == "YEARS"
     assert valdf["REAL"].nunique() == 3
 
+    # No metadata in csv files
     meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOPR")
-    assert meta is not None
-    assert meta.unit == "SM3/DAY"
+    assert meta is None
 
 
 def test_create_from_per_realization_csv_file(
@@ -132,6 +132,11 @@ def test_create_from_per_realization_arrow_file(
     assert valdf.shape[0] == 25284
     assert "FOPT" in valdf.columns
     assert valdf["REAL"].nunique() == 100
+
+    # Test metadata in arrow files
+    meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOPR")
+    assert meta is not None
+    assert meta.unit == "SM3/DAY"
 
 
 def test_create_from_per_realization_parameter_file(

--- a/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
@@ -6,6 +6,7 @@ import pandas as pd
 from webviz_subsurface._providers import (
     EnsembleTableProvider,
     EnsembleTableProviderFactory,
+    TableVectorMetadata
 )
 from webviz_subsurface._providers.ensemble_table_provider import (
     EnsembleTableProviderImplArrow,
@@ -58,6 +59,8 @@ def test_synthetic_get_column_data(testdata_folder: Path) -> None:
     assert df.shape == (4, 2)
     assert df.columns.tolist() == ["REAL", "STR"]
 
+    assert model.vector_metadata("REAL") is None
+
 
 def test_create_from_aggregated_csv_file_smry_csv(
     testdata_folder: Path, tmp_path: Path
@@ -84,6 +87,10 @@ def test_create_from_aggregated_csv_file_smry_csv(
     assert valdf.columns[0] == "REAL"
     assert valdf.columns[1] == "YEARS"
     assert valdf["REAL"].nunique() == 3
+
+    meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOPR")
+    assert meta is not None
+    assert meta.unit == "SM3/DAY"
 
 
 def test_create_from_per_realization_csv_file(

--- a/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
@@ -117,6 +117,10 @@ def test_create_from_per_realization_csv_file(
     assert valdf["CONIDX"].nunique() == 24
     assert sorted(valdf["CONIDX"].unique()) == list(range(1, 25))
 
+    # No metadata in csv files
+    meta: Optional[TableVectorMetadata] = provider.vector_metadata("CONIDX")
+    assert meta is None
+
 
 def test_create_from_per_realization_arrow_file(
     testdata_folder: Path, tmp_path: Path
@@ -133,10 +137,14 @@ def test_create_from_per_realization_arrow_file(
     assert "FOPT" in valdf.columns
     assert valdf["REAL"].nunique() == 100
 
-    # Test metadata in arrow files
+    # Test metadata
     meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOPR")
     assert meta is not None
     assert meta.unit == "SM3/DAY"
+
+    # Test metadata for non-existen column
+    meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOOBAR")
+    assert meta is None
 
 
 def test_create_from_per_realization_parameter_file(
@@ -151,6 +159,12 @@ def test_create_from_per_realization_parameter_file(
     valdf = provider.get_column_data(provider.column_names())
     assert "GLOBVAR:FAULT_SEAL_SCALING" in valdf.columns
     assert valdf["REAL"].nunique() == 100
+
+    # No metadata in parameter files
+    meta: Optional[TableVectorMetadata] = provider.vector_metadata(
+        "GLOBVAR:FAULT_SEAL_SCALING"
+    )
+    assert meta is None
 
 
 def test_create_provider_set_from_aggregated_csv_file(tmp_path: Path) -> None:
@@ -177,3 +191,7 @@ def test_create_provider_set_from_aggregated_csv_file(tmp_path: Path) -> None:
             "STOIIP_OIL",
             "SOURCE",
         }.issubset(set(provider.column_names()))
+
+        # No metadata in csv files
+        meta: Optional[TableVectorMetadata] = provider.vector_metadata("ZONE")
+        assert meta is None

--- a/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
@@ -142,10 +142,6 @@ def test_create_from_per_realization_arrow_file(
     assert meta is not None
     assert meta.unit == "SM3/DAY"
 
-    # Test metadata for non-existen column
-    meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOOBAR")
-    assert meta is None
-
 
 def test_create_from_per_realization_parameter_file(
     testdata_folder: Path, tmp_path: Path

--- a/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
+++ b/tests/unit_tests/provider_tests/test_ensemble_table_provider.py
@@ -4,9 +4,9 @@ from typing import Dict, Optional
 import pandas as pd
 
 from webviz_subsurface._providers import (
+    ColumnMetadata,
     EnsembleTableProvider,
     EnsembleTableProviderFactory,
-    TableVectorMetadata,
 )
 from webviz_subsurface._providers.ensemble_table_provider import (
     EnsembleTableProviderImplArrow,
@@ -59,7 +59,7 @@ def test_synthetic_get_column_data(testdata_folder: Path) -> None:
     assert df.shape == (4, 2)
     assert df.columns.tolist() == ["REAL", "STR"]
 
-    assert model.vector_metadata("REAL") is None
+    assert model.column_metadata("REAL") is None
 
 
 def test_create_from_aggregated_csv_file_smry_csv(
@@ -89,7 +89,7 @@ def test_create_from_aggregated_csv_file_smry_csv(
     assert valdf["REAL"].nunique() == 3
 
     # No metadata in csv files
-    meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOPR")
+    meta: Optional[ColumnMetadata] = provider.column_metadata("FOPR")
     assert meta is None
 
 
@@ -118,7 +118,7 @@ def test_create_from_per_realization_csv_file(
     assert sorted(valdf["CONIDX"].unique()) == list(range(1, 25))
 
     # No metadata in csv files
-    meta: Optional[TableVectorMetadata] = provider.vector_metadata("CONIDX")
+    meta: Optional[ColumnMetadata] = provider.column_metadata("CONIDX")
     assert meta is None
 
 
@@ -138,7 +138,7 @@ def test_create_from_per_realization_arrow_file(
     assert valdf["REAL"].nunique() == 100
 
     # Test metadata
-    meta: Optional[TableVectorMetadata] = provider.vector_metadata("FOPR")
+    meta: Optional[ColumnMetadata] = provider.column_metadata("FOPR")
     assert meta is not None
     assert meta.unit == "SM3/DAY"
 
@@ -157,7 +157,7 @@ def test_create_from_per_realization_parameter_file(
     assert valdf["REAL"].nunique() == 100
 
     # No metadata in parameter files
-    meta: Optional[TableVectorMetadata] = provider.vector_metadata(
+    meta: Optional[ColumnMetadata] = provider.column_metadata(
         "GLOBVAR:FAULT_SEAL_SCALING"
     )
     assert meta is None
@@ -189,5 +189,5 @@ def test_create_provider_set_from_aggregated_csv_file(tmp_path: Path) -> None:
         }.issubset(set(provider.column_names()))
 
         # No metadata in csv files
-        meta: Optional[TableVectorMetadata] = provider.vector_metadata("ZONE")
+        meta: Optional[ColumnMetadata] = provider.column_metadata("ZONE")
         assert meta is None

--- a/webviz_subsurface/_providers/__init__.py
+++ b/webviz_subsurface/_providers/__init__.py
@@ -30,5 +30,6 @@ from .ensemble_table_provider import (
     EnsembleTableProvider,
     EnsembleTableProviderFactory,
     EnsembleTableProviderImplArrow,
+    TableVectorMetadata,
 )
 from .well_provider import WellProvider, WellProviderFactory, WellServer

--- a/webviz_subsurface/_providers/__init__.py
+++ b/webviz_subsurface/_providers/__init__.py
@@ -27,9 +27,9 @@ from .ensemble_surface_provider import (
     SurfaceServer,
 )
 from .ensemble_table_provider import (
+    ColumnMetadata,
     EnsembleTableProvider,
     EnsembleTableProviderFactory,
     EnsembleTableProviderImplArrow,
-    TableVectorMetadata,
 )
 from .well_provider import WellProvider, WellProviderFactory, WellServer

--- a/webviz_subsurface/_providers/ensemble_table_provider/__init__.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/__init__.py
@@ -1,3 +1,3 @@
-from .ensemble_table_provider import EnsembleTableProvider
+from .ensemble_table_provider import EnsembleTableProvider, TableVectorMetadata
 from .ensemble_table_provider_factory import EnsembleTableProviderFactory
 from .ensemble_table_provider_impl_arrow import EnsembleTableProviderImplArrow

--- a/webviz_subsurface/_providers/ensemble_table_provider/__init__.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/__init__.py
@@ -1,3 +1,3 @@
-from .ensemble_table_provider import EnsembleTableProvider, TableVectorMetadata
+from .ensemble_table_provider import ColumnMetadata, EnsembleTableProvider
 from .ensemble_table_provider_factory import EnsembleTableProviderFactory
 from .ensemble_table_provider_impl_arrow import EnsembleTableProviderImplArrow

--- a/webviz_subsurface/_providers/ensemble_table_provider/_field_metadata.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/_field_metadata.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+import pyarrow as pa
+
+from .ensemble_table_provider import TableVectorMetadata
+
+
+def create_vector_metadata_from_field_meta(
+    field: pa.Field,
+) -> Optional[TableVectorMetadata]:
+    """Create VectorMetadata from keywords stored in the field's metadata"""
+
+    meta_dict = field.metadata
+    if not meta_dict:
+        return None
+
+    try:
+        unit_bytestr = meta_dict[b"unit"]
+    except KeyError:
+        return None
+
+    return TableVectorMetadata(
+        unit=unit_bytestr.decode("ascii"),
+    )

--- a/webviz_subsurface/_providers/ensemble_table_provider/_field_metadata.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/_field_metadata.py
@@ -2,12 +2,12 @@ from typing import Optional
 
 import pyarrow as pa
 
-from .ensemble_table_provider import TableVectorMetadata
+from .ensemble_table_provider import ColumnMetadata
 
 
-def create_vector_metadata_from_field_meta(
+def create_column_metadata_from_field_meta(
     field: pa.Field,
-) -> Optional[TableVectorMetadata]:
+) -> Optional[ColumnMetadata]:
     """Create VectorMetadata from keywords stored in the field's metadata"""
 
     meta_dict = field.metadata
@@ -17,8 +17,8 @@ def create_vector_metadata_from_field_meta(
     try:
         unit_bytestr = meta_dict[b"unit"]
     except KeyError:
-        return None
+        return ColumnMetadata(unit=None)
 
-    return TableVectorMetadata(
+    return ColumnMetadata(
         unit=unit_bytestr.decode("ascii"),
     )

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider.py
@@ -28,5 +28,6 @@ class EnsembleTableProvider(abc.ABC):
     @abc.abstractmethod
     def vector_metadata(self, vector_name: str) -> Optional[TableVectorMetadata]:
         """Returns metadata for the specified vector. Returns None if no metadata
-        exists or if any of the non-optional properties of `VectorMetadata` are missing.
+        exists or if any of the non-optional properties of `TableVectorMetadata`
+        are missing.
         """

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider.py
@@ -1,7 +1,13 @@
 import abc
+from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
 import pandas as pd
+
+
+@dataclass(frozen=True)
+class TableVectorMetadata:
+    unit: Optional[str]
 
 
 class EnsembleTableProvider(abc.ABC):
@@ -18,3 +24,9 @@ class EnsembleTableProvider(abc.ABC):
         self, column_names: Sequence[str], realizations: Optional[Sequence[int]] = None
     ) -> pd.DataFrame:
         ...
+
+    @abc.abstractmethod
+    def vector_metadata(self, vector_name: str) -> Optional[TableVectorMetadata]:
+        """Returns metadata for the specified vector. Returns None if no metadata
+        exists or if any of the non-optional properties of `VectorMetadata` are missing.
+        """

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 
 @dataclass(frozen=True)
-class TableVectorMetadata:
+class ColumnMetadata:
     unit: Optional[str]
 
 
@@ -26,8 +26,10 @@ class EnsembleTableProvider(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def vector_metadata(self, vector_name: str) -> Optional[TableVectorMetadata]:
-        """Returns metadata for the specified vector. Returns None if no metadata
-        exists or if any of the non-optional properties of `TableVectorMetadata`
-        are missing.
+    def column_metadata(self, column_name: str) -> Optional[ColumnMetadata]:
+        """Returns metadata for the specified column.
+
+        Returns None if no metadata is found for the column.
+        Returns a empty ColumnMetadata object if there is metadata, but it's
+        not the columns specified in ColumnMetadata.
         """

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_impl_arrow.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_impl_arrow.py
@@ -13,8 +13,8 @@ from ..ensemble_summary_provider._table_utils import (
     add_per_vector_min_max_to_table_schema_metadata,
     find_min_max_for_numeric_table_columns,
 )
-from ._field_metadata import create_vector_metadata_from_field_meta
-from .ensemble_table_provider import EnsembleTableProvider, TableVectorMetadata
+from ._field_metadata import create_column_metadata_from_field_meta
+from .ensemble_table_provider import ColumnMetadata, EnsembleTableProvider
 
 # Since PyArrow's actual compute functions are not seen by pylint
 # pylint: disable=no-member
@@ -224,7 +224,7 @@ class EnsembleTableProviderImplArrow(EnsembleTableProvider):
 
         return df
 
-    def vector_metadata(self, vector_name: str) -> Optional[TableVectorMetadata]:
+    def column_metadata(self, column_name: str) -> Optional[ColumnMetadata]:
         schema = self._get_or_read_schema()
-        field = schema.field(vector_name)
-        return create_vector_metadata_from_field_meta(field)
+        field = schema.field(column_name)
+        return create_column_metadata_from_field_meta(field)


### PR DESCRIPTION
Implements the possibility to extract column metadata from the `EnsembleTableProvider`. It is needed in the `WellCompletion` plugin to get the KH unit.

Only unit is so far implemented, but it is easily extended to other column metadata

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
