### PR TITLE
`GroupTree`: Improved terminal_node filtering

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -56,6 +56,7 @@ jobs:
         pip install "pytest<7.2.0"
         pip install "pytest-xdist<3.0"
         pip install "xtgeo<2.20.2"
+        pip install "mypy<0.990"
         pip install .
 
         # Testing against our latest release (including pre-releases)

--- a/webviz_subsurface/_models/gruptree_model.py
+++ b/webviz_subsurface/_models/gruptree_model.py
@@ -79,9 +79,9 @@ class GruptreeModel:
                     f"Terminal node '{terminal_node}' not found in 'CHILD' column "
                     "of the gruptree data."
                 )
-
-            branch_nodes = self._get_branch_nodes(terminal_node)
-            df = self._dataframe[self._dataframe["CHILD"].isin(branch_nodes)]
+            if terminal_node != "FIELD":
+                branch_nodes = self._get_branch_nodes(terminal_node)
+                df = self._dataframe[self._dataframe["CHILD"].isin(branch_nodes)]
 
         def filter_wells(
             dframe: pd.DataFrame, well_name_criteria: Callable
@@ -116,7 +116,10 @@ class GruptreeModel:
         """
         branch_nodes = [terminal_node]
 
-        children = self._dataframe[self._dataframe["PARENT"] == terminal_node]
+        children = self._dataframe[
+            self._dataframe["PARENT"] == terminal_node
+        ].drop_duplicates(subset=["CHILD"], keep="first")
+
         for _, childrow in children.iterrows():
             branch_nodes.extend(self._get_branch_nodes(childrow["CHILD"]))
         return branch_nodes


### PR DESCRIPTION
The terminal node filtering of the gruptree dataframe was taking a lot of time if there was many timesteps and realizations. This fixes it by dropping duplicate child nodes and not filtering if the terminal_node is `FIELD`.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
