### PR TITLE
Replace wcc.LabeledContainer with wcc.Selectors for `Delta Ensembles` in `SimulationTimeSeries`

### DIFF
--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
@@ -53,7 +53,7 @@ class EnsemblesSettings(SettingsGroupABC):
                 ],
                 value=None if len(self._ensembles) <= 0 else [self._ensembles[0]],
             ),
-            wcc.LabeledContainer(
+            wcc.Selectors(
                 label="Delta Ensembles",
                 id=self.register_component_unique_id(
                     EnsemblesSettings.Ids.DELTA_ENSEMBLE


### PR DESCRIPTION
Place the `Delta Ensembles` in a `wcc.Selectors` component rather than a `wcc.LabeledContainer` to obtain open/close functionality. 

Requested by users: `wcc.Selectors` rather than `Delta Ensembles` as a separate `WebvizSettingsGroup` in the settings drawer for `WLF` - to keep the `Delta Ensemble` functionality grouped with the `Ensembles`.

Closes: #1151 