### PR TITLE
Set `implicit_optional=True` for `mypy`

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -56,7 +56,6 @@ jobs:
         pip install "pytest<7.2.0"
         pip install "pytest-xdist<3.0"
         pip install "xtgeo<2.20.2"
-        pip install "mypy<0.990"
         pip install .
 
         # Testing against our latest release (including pre-releases)

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,13 @@ ignore_missing_imports = True
 disallow_untyped_defs = True
 show_error_codes = True
 
+# Temporarily allow implicit optional until pydantic handles JSON schema generation.
+# mypy >= 0.990 has changed its default to no_implicit_optional=True.
+# When removed - utilize the following make the code base implicit optional
+# type hints PEP 484 compliant:
+# https://github.com/hauntsaninja/no_implicit_optional
+implicit_optional = True
+
 # TODO(Sigurd)
 # Temporarily disable mypy for the following modules until incorpoartion
 # of type hints have been completed.


### PR DESCRIPTION
`mypy` with version `>= 0.990` has changed its default to `no_implicit_optional=True`. This implies error for all missing `Optional` or `Union[..., None]` where default value is set to `None`.

Temporary solution is to set `implicit_optional=True` in `mypy.ini` as plugin `__init__`-functions cannot handle usage of `Optional` when JSON Schema is generated using typehints runtime.


Closes: #1154 