### PR TITLE
Remove `deck.gl` bounds and use only relevant ensembles in CO₂ plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#1171](https://github.com/equinor/webviz-subsurface/pull/1171) - Fixed bug in `WellAnalysis` that caused an error if the selected date did not not exist in some selected ensembles.
+- [#1158](https://github.com/equinor/webviz-subsurface/pull/1158) - `CO2Leakage` - Remove deckgl bounds and use only relevant ensembles.
+
 
 ## [0.2.16] - 2022-11-09
 
@@ -26,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#1114](https://github.com/equinor/webviz-subsurface/pull/1114) - Added a flag in config for `MapViewerFMU` to set initial state of hillshading.
 - [#1111](https://github.com/equinor/webviz-subsurface/pull/1111) - `EXPERIMENTALGridViewerFMU` - New experimental plugin to visualize grid models.
->>>>>>> Add grid viewer
 - [#1058](https://github.com/equinor/webviz-subsurface/pull/1058) - `WellCompletion` - New implementation of the `WellCompletions` plugin, which is faster, has more functionality (single realization) and utilizes the webviz layout framework (WLF).
 
 

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional, Tuple
 
-import dash
 import plotly.graph_objects as go
 from dash import Dash, Input, Output, State, callback, html
 from dash.exceptions import PreventUpdate
@@ -31,7 +30,6 @@ from webviz_subsurface.plugins._co2_leakage._utilities.initialization import (
     init_well_pick_provider,
 )
 from webviz_subsurface.plugins._co2_leakage.views.mainview.mainview import (
-    INITIAL_BOUNDS,
     MainView,
     MapViewElement,
 )
@@ -88,7 +86,12 @@ class CO2Leakage(WebvizPluginABC):
 
         self._boundary_file = boundary_file
         try:
-            self._ensemble_paths = webviz_settings.shared_settings["scratch_ensembles"]
+            self._ensemble_paths = {
+                ensemble_name: webviz_settings.shared_settings["scratch_ensembles"][
+                    ensemble_name
+                ]
+                for ensemble_name in ensembles
+            }
             self._surface_server = SurfaceServer.instance(app)
             self._polygons_server = FaultPolygonsServer.instance(app)
 
@@ -209,7 +212,6 @@ class CO2Leakage(WebvizPluginABC):
         # pylint: disable=too-many-arguments,too-many-locals
         @callback(
             Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "layers"),
-            Output(self._view_component(MapViewElement.Ids.DECKGL_MAP), "bounds"),
             Input(self._settings_component(ViewSettings.Ids.PROPERTY), "value"),
             Input(self._view_component(MapViewElement.Ids.DATE_SLIDER), "value"),
             Input(self._settings_component(ViewSettings.Ids.FORMATION), "value"),
@@ -223,7 +225,6 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.PLUME_THRESHOLD), "value"),
             Input(self._settings_component(ViewSettings.Ids.PLUME_SMOOTHING), "value"),
             State(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
-            State(self._view_component(MapViewElement.Ids.DECKGL_MAP), "bounds"),
         )
         def update_map_attribute(
             attribute: MapAttribute,
@@ -239,8 +240,7 @@ class CO2Leakage(WebvizPluginABC):
             plume_threshold: Optional[float],
             plume_smoothing: Optional[float],
             ensemble: str,
-            current_bounds: List[float],
-        ) -> Tuple[List[Dict[str, Any]], Optional[List[float]]]:
+        ) -> List[Dict[str, Any]]:
             attribute = MapAttribute(attribute)
             if len(realization) == 0:
                 raise PreventUpdate
@@ -288,7 +288,7 @@ class CO2Leakage(WebvizPluginABC):
                     contour_data,
                 )
             # Create layers and view bounds
-            layers, viewport_bounds = create_map_layers(
+            layers = create_map_layers(
                 formation=formation,
                 surface_data=surf_data,
                 fault_polygon_url=(
@@ -301,6 +301,5 @@ class CO2Leakage(WebvizPluginABC):
                 well_pick_provider=self._well_pick_provider,
                 plume_extent_data=plume_polygon,
             )
-            if tuple(current_bounds) != INITIAL_BOUNDS or viewport_bounds is None:
-                viewport_bounds = dash.no_update
-            return layers, viewport_bounds
+
+            return layers

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -173,9 +173,8 @@ def create_map_layers(
     license_boundary_file: Optional[str],
     well_pick_provider: Optional[WellPickProvider],
     plume_extent_data: Optional[geojson.FeatureCollection],
-) -> Tuple[List[Dict], Optional[List[float]]]:
+) -> List[Dict]:
     layers = []
-    viewport_bounds = None
     if surface_data is not None:
         # Update ColormapLayer
         layers.append(
@@ -191,12 +190,7 @@ def create_map_layers(
                 "rotDeg": surface_data.meta_data.deckgl_rot_deg,
             }
         )
-        viewport_bounds = [
-            surface_data.meta_data.x_min,
-            surface_data.meta_data.y_min,
-            surface_data.meta_data.x_max,
-            surface_data.meta_data.y_max,
-        ]
+
     if fault_polygon_url is not None:
         layers.append(
             {
@@ -239,7 +233,7 @@ def create_map_layers(
                 "getLineColor": [150, 150, 150, 255],
             }
         )
-    return layers, viewport_bounds
+    return layers
 
 
 def _parse_polygon_file(filename: str) -> Dict[str, Any]:

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -8,8 +8,6 @@ from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewABC, ViewElementABC
 from webviz_subsurface_components import DeckGLMap
 
-INITIAL_BOUNDS = (0, 0, 1, 1)
-
 
 class MainView(ViewABC):
     class Ids(StrEnum):
@@ -48,13 +46,11 @@ class MapViewElement(ViewElementABC):
                                         self.Ids.DECKGL_MAP
                                     ),
                                     layers=[],
-                                    bounds=INITIAL_BOUNDS,
                                     coords={"visible": True},
                                     scale={"visible": True},
                                     toolbar={"visible": True},
                                     coordinateUnit="m",
                                     colorTables=self._color_scales,
-                                    zoom=-5,
                                 ),
                             ],
                             style={


### PR DESCRIPTION
Minor fixes to Co2 plugin
---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Do not specify deckgl bounds and zoom (calculated automatically in latest DeckGLMap release)
   - [ ] Only use relevant ensembles 
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
