### PR TITLE
`vtk` modules are added to `extras_require`

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -55,7 +55,7 @@ jobs:
           pip install "pytest<7.2.0"
           pip install "pytest-xdist<3.0"
           pip install "xtgeo<2.20.2"
-          pip install .
+          pip install .[vtk]
 
           # Testing against our latest release (including pre-releases)
           pip install --pre --upgrade webviz-config webviz-core-components webviz-subsurface-components

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ TESTS_REQUIRE = [
     "types-pyyaml",
 ]
 
+VTK_REQUIRE = [
+    "vtk>=9.2.2",
+    "webviz_vtk@git+https://github.com/equinor/webviz-vtk",
+]
 # pylint: disable=line-too-long
 setup(
     name="webviz-subsurface",
@@ -103,13 +107,11 @@ setup(
         "scipy>=1.2",
         "statsmodels>=0.12.1",  # indirect dependency through https://plotly.com/python/linear-fits/
         "xtgeo>=2.20.0",
-        "vtk>=9.2.2",
-        "webviz_vtk@git+https://github.com/equinor/webviz-vtk",
         "webviz-config>=0.5",
         "webviz-core-components>=0.6",
         "webviz-subsurface-components>=0.4.14",
     ],
-    extras_require={"tests": TESTS_REQUIRE},
+    extras_require={"tests": TESTS_REQUIRE, "vtk": VTK_REQUIRE},
     setup_requires=["setuptools_scm~=3.2"],
     python_requires="~=3.8",
     use_scm_version=True,

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/_plugin.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/_plugin.py
@@ -11,8 +11,10 @@ try:
 
     from ._layout_elements import ElementIds
     from .views.view_3d._view_3d import View3D
+
+    VTK_INSTALLED = True
 except ImportError:
-    pass
+    VTK_INSTALLED = False
 
 
 class EXPERIMENTALGridViewerFMU(WebvizPluginABC):
@@ -80,6 +82,11 @@ class EXPERIMENTALGridViewerFMU(WebvizPluginABC):
         eclipse_restart_parameters: List[str] = None,
         initial_ijk_filter: Dict[str, int] = None,
     ):
+        if not VTK_INSTALLED:
+            raise ImportError(
+                "To run this experimental plugin you must install the extra vtk "
+                "packages with `pip install webviz-subsurface[vtk]`."
+            )
         super().__init__(stretch=True)
 
         self.ensemble = webviz_settings.shared_settings["scratch_ensembles"][ensemble]

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/_plugin.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/_plugin.py
@@ -2,14 +2,17 @@ from typing import Dict, List
 
 from webviz_config import WebvizPluginABC, WebvizSettings
 
-from webviz_subsurface._providers.ensemble_grid_provider import (
-    EnsembleGridProvider,
-    EnsembleGridProviderFactory,
-    GridVizService,
-)
+try:
+    from webviz_subsurface._providers.ensemble_grid_provider import (
+        EnsembleGridProvider,
+        EnsembleGridProviderFactory,
+        GridVizService,
+    )
 
-from ._layout_elements import ElementIds
-from .views.view_3d._view_3d import View3D
+    from ._layout_elements import ElementIds
+    from .views.view_3d._view_3d import View3D
+except ImportError:
+    pass
 
 
 class EXPERIMENTALGridViewerFMU(WebvizPluginABC):


### PR DESCRIPTION
`webviz_vtk` is not yet a `PyPi` package and can therefore not be part of the regular release (not sure if it will be a problem to have it in `extras_require` too? But guess the easiest way to find out is to test.

