### PR TITLE
Remove `vtk` from dependencies

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -55,10 +55,14 @@ jobs:
           pip install "pytest<7.2.0"
           pip install "pytest-xdist<3.0"
           pip install "xtgeo<2.20.2"
-          pip install .[vtk]
+          pip install .
 
           # Testing against our latest release (including pre-releases)
           pip install --pre --upgrade webviz-config webviz-core-components webviz-subsurface-components
+
+          # Install additional packages required for experimental plugin:
+          pip install "vtk>=9.2.2"
+          pip install "webviz_vtk@git+https://github.com/equinor/webviz-vtk"
 
       - name: 📦 Install test dependencies
         run: |

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ TESTS_REQUIRE = [
     "types-pyyaml",
 ]
 
-VTK_REQUIRE = [
-    "vtk>=9.2.2",
-    "webviz_vtk@git+https://github.com/equinor/webviz-vtk",
-]
 # pylint: disable=line-too-long
 setup(
     name="webviz-subsurface",
@@ -111,7 +107,7 @@ setup(
         "webviz-core-components>=0.6",
         "webviz-subsurface-components>=0.4.14",
     ],
-    extras_require={"tests": TESTS_REQUIRE, "vtk": VTK_REQUIRE},
+    extras_require={"tests": TESTS_REQUIRE},
     setup_requires=["setuptools_scm~=3.2"],
     python_requires="~=3.8",
     use_scm_version=True,

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/_plugin.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/_plugin.py
@@ -85,7 +85,8 @@ class EXPERIMENTALGridViewerFMU(WebvizPluginABC):
         if not VTK_INSTALLED:
             raise ImportError(
                 "To run this experimental plugin you must install the extra vtk "
-                "packages with `pip install webviz-subsurface[vtk]`."
+                "packages with `pip install vtk>=9.2.2` and "
+                "`pip install webviz_vtk@git+https://github.com/equinor/webviz-vtk`."
             )
         super().__init__(stretch=True)
 


### PR DESCRIPTION
Due to `webviz_vtk` not being a `PyPi` package. Follow up after attempt of having it as an `extras_require` in #1166 which turned out to not be enough