### PR TITLE
Bugfix in `WellAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#1162](https://github.com/equinor/webviz-subsurface/pull/1162) - `RelativePermeability` can now be initialized with only `pyscal` formatted input files instead of paths to ensembles using a new `scal_scenarios` input option.
 
+### Fixed
+- [#1171](https://github.com/equinor/webviz-subsurface/pull/1171) - Fixed bug in `WellAnalysis` that caused an error if the selected date did not not exist in some selected ensembles.
+
 ## [0.2.16] - 2022-11-09
 
 ### Changed

--- a/webviz_subsurface/plugins/_well_analysis/_utils/_ensemble_well_analysis_data.py
+++ b/webviz_subsurface/plugins/_well_analysis/_utils/_ensemble_well_analysis_data.py
@@ -129,6 +129,11 @@ class EnsembleWellAnalysisData:
         df = df[df["DATE"] == max_date]
 
         if prod_after_date is not None:
+            # Since the prod_after_dates can be chosen from the union of the date
+            # ranges from many ensembles, it can happen that the selecte date is
+            # > than the max_date for this ensemble. In that case we set it equal
+            # to the max date. The resulting sumvec value will then be zero for
+            # all wells.
             prod_after_date = (
                 max_date if prod_after_date > max_date else prod_after_date
             )

--- a/webviz_subsurface/plugins/_well_analysis/_utils/_ensemble_well_analysis_data.py
+++ b/webviz_subsurface/plugins/_well_analysis/_utils/_ensemble_well_analysis_data.py
@@ -125,9 +125,13 @@ class EnsembleWellAnalysisData:
         """
         sumvecs = [f"{well_sumvec}:{well}" for well in self._wells]
         df = self._smry[["REAL", "DATE"] + sumvecs]
-        df = df[df["DATE"] == df["DATE"].max()]
+        max_date = df["DATE"].max()
+        df = df[df["DATE"] == max_date]
 
         if prod_after_date is not None:
+            prod_after_date = (
+                max_date if prod_after_date > max_date else prod_after_date
+            )
             df_date = self._smry[["REAL", "DATE"] + sumvecs]
             df_date = df_date[df_date["DATE"] >= prod_after_date]
             df_date = df_date[df_date["DATE"] == df_date["DATE"].min()]


### PR DESCRIPTION
Fixes a bug in `WellAnalysis`.

Since the dates in the `only production after date` dropdown is the union of dates in all ensembles, it can happen that the selected date is > all dates in a selected ensemble. In that case the date is now set equal to the max date for the given ensemble.

---

### Contributor checklist

- [x] :tada: This PR closes #1139.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
