### PR TITLE
ParameterResponseCorrelation empty column_keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Changed
+- [#1182](https://github.com/equinor/webviz-subsurface/pull/1182) - `ParameterResponseCorrelation` can now allow default None column_keys when using arrow file as input
 - [#1122](https://github.com/equinor/webviz-subsurface/pull/1122) - `opm` and `ecl2df` are now optional, making `windows-subsurface` possible to install and import on non-unix based systems. **NOTE:** a lot of the functionality in `webviz-subsurface` is built on `opm` and `ecl2df`, and issues are therefore expected on eg Windows and macOS. Use with care.
 - [#1146](https://github.com/equinor/webviz-subsurface/pull/1146) - Converted the `BhpQc` plugin to WLF (Webviz Layout Framework).
 

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -795,7 +795,10 @@ def create_df_from_summary_provider(
     """Aggregates summary data from all ensembles into a common dataframe."""
     dfs = []
     for ens_name, provider in provider_set.items():
-        matching_sumvecs = get_matching_vector_names(provider, column_keys)
+        if column_keys is None:
+            matching_sumvecs = provider.vector_names()
+        else:
+            matching_sumvecs = get_matching_vector_names(provider, column_keys)
         if not matching_sumvecs:
             raise ValueError(
                 f"No vectors matching the given column_keys: {column_keys} for ensemble: {ens_name}"


### PR DESCRIPTION
When we switch from csv file `response_file` to arrow file `rel_file_pattern`, we get an error which basically requires us to specify the column_keys instead of set it to default `None` 

Specifying all the column_keys in advance could be tedious and in-practical in some cases. So, it is desired to keep the same behavior (load all columns) as when we are using csv file as input.

---

### Contributor checklist

- [x] :tada: This PR closes #1181.
