### PR TITLE
Improve CO2 containment plots

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
@@ -1,6 +1,6 @@
 import itertools
 from enum import Enum
-from typing import List
+from typing import Any, Dict, List
 
 import numpy as np
 import pandas
@@ -8,6 +8,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 from webviz_subsurface._providers import EnsembleTableProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2Scale
 
 
 class _Columns(Enum):
@@ -18,62 +19,90 @@ class _Columns(Enum):
 
 
 def _read_dataframe(
-    table_provider: EnsembleTableProvider, realization: int
+    table_provider: EnsembleTableProvider,
+    realization: int,
+    scale: Co2Scale,
 ) -> pandas.DataFrame:
-    return table_provider.get_column_data(
-        ["date", "co2_inside", "co2_outside"], [realization]
-    )
+    df = table_provider.get_column_data(table_provider.column_names(), [realization])
+    if scale == Co2Scale.KG:
+        return df
+    if scale == scale.MTONS:
+        value = 1e9
+    else:
+        value = df["total"].max()
+    for col in df.columns:
+        if col.startswith("total"):
+            df[col] /= value
+    return df
 
 
 def _read_terminal_co2_volumes(
-    table_provider: EnsembleTableProvider, realizations: List[int]
+    table_provider: EnsembleTableProvider, realizations: List[int], scale: Co2Scale
 ) -> pandas.DataFrame:
-    records = []
+    records: Dict[str, List[Any]] = {
+        "real": [],
+        "amount": [],
+        "containment": [],
+        "phase": [],
+        "sort_key": [],
+    }
     for real in realizations:
-        df = _read_dataframe(table_provider, real)
+        df = _read_dataframe(table_provider, real, scale)
         last = df.iloc[np.argmax(df["date"])]
         label = str(real)
-        records += [
-            (label, last["co2_inside"], "inside", 0.0),
-            (label, last["co2_outside"], "outside", last["co2_outside"]),
+        records["real"] += [label] * 4
+        records["amount"] += [
+            last["total_aqueous_inside"],
+            last["total_gas_inside"],
+            last["total_aqueous_outside"],
+            last["total_gas_outside"],
         ]
-    df = pandas.DataFrame.from_records(
-        records,
-        columns=[
-            _Columns.REALIZATION.value,
-            _Columns.VOLUME.value,
-            _Columns.CONTAINMENT.value,
-            _Columns.VOLUME_OUTSIDE.value,
-        ],
-    )
-    df.sort_values(_Columns.VOLUME_OUTSIDE.value, inplace=True, ascending=True)
+        records["containment"] += ["inside", "inside", "outside", "outside"]
+        records["phase"] += ["aqueous", "gas", "aqueous", "gas"]
+        records["sort_key"] += [last["total_gas_outside"]] * 4
+    df = pandas.DataFrame.from_dict(records)
+    df.sort_values("sort_key", inplace=True, ascending=True)
     return df
 
 
 def _read_co2_volumes(
-    table_provider: EnsembleTableProvider, realizations: List[int]
+    table_provider: EnsembleTableProvider, realizations: List[int], scale: Co2Scale
 ) -> pandas.DataFrame:
     return pandas.concat(
         [
-            _read_dataframe(table_provider, real).assign(realization=real)
+            _read_dataframe(table_provider, real, scale).assign(realization=real)
             for real in realizations
         ]
     )
 
 
+def _adjust_figure(fig: go.Figure) -> None:
+    fig.layout.title.x = 0.5
+    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
+    fig.layout.margin.b = 10
+    fig.layout.margin.t = 60
+    fig.layout.margin.l = 10
+    fig.layout.margin.r = 10
+
+
 def generate_co2_volume_figure(
     table_provider: EnsembleTableProvider,
     realizations: List[int],
+    scale: Co2Scale,
 ) -> go.Figure:
-    df = _read_terminal_co2_volumes(table_provider, realizations)
+    df = _read_terminal_co2_volumes(table_provider, realizations, scale)
     fig = px.bar(
         df,
-        y=_Columns.REALIZATION.value,
-        x=_Columns.VOLUME.value,
-        color=_Columns.CONTAINMENT.value,
+        y="real",
+        x="amount",
+        color="containment",
+        pattern_shape="phase",
         title="End-state CO2 containment",
         orientation="h",
-        category_orders={_Columns.CONTAINMENT.value: ["outside", "inside"]},
+        category_orders={
+            "containment": ["outside", "inside"],
+            "phase": ["gas", "aqueous"],
+        },
         color_discrete_sequence=["#dd4300", "#006ddd"],
     )
     fig.layout.legend.title.text = ""
@@ -81,25 +110,18 @@ def generate_co2_volume_figure(
     fig.layout.legend.y = -0.3
     fig.layout.yaxis.title = "Realization"
     fig.layout.xaxis.exponentformat = "power"
-    fig.layout.xaxis.title = "Mass [kg]"
-    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
-    fig.layout.margin.b = 10
-    fig.layout.margin.t = 60
-    fig.layout.margin.l = 10
-    fig.layout.margin.r = 10
+    fig.layout.xaxis.title = scale.value
+    _adjust_figure(fig)
     return fig
 
 
 def generate_co2_time_containment_figure(
     table_provider: EnsembleTableProvider,
     realizations: List[int],
+    scale: Co2Scale,
 ) -> go.Figure:
-    df = _read_co2_volumes(table_provider, realizations)
+    df = _read_co2_volumes(table_provider, realizations, scale)
     df.sort_values(by="date", inplace=True)
-    df["date"] = df["date"].astype(str)
-    dates = df["date"].str[:4] + "-" + df["date"].str[4:6] + "-" + df["date"].str[6:]
-    df["dt"] = dates
-    df["co2_total"] = df["co2_inside"] + df["co2_outside"]
     fig = go.Figure()
     colors = px.colors.qualitative.Plotly
     # Generate dummy scatters for legend entries
@@ -111,26 +133,39 @@ def generate_co2_time_containment_figure(
     for rlz, color in zip(realizations, itertools.cycle(colors)):
         sub_df = df[df["realization"] == rlz]
         common_args = dict(
-            x=sub_df["dt"],
+            x=sub_df["date"],
             hovertemplate="%{x}: %{y}<br>Realization: %{meta[0]}",
             meta=[rlz],
             marker_color=color,
             showlegend=False,
         )
-        fig.add_scatter(y=sub_df["co2_outside"], **outside_args, **common_args)
-        fig.add_scatter(y=sub_df["co2_total"], **total_args, **common_args)
+        fig.add_scatter(y=sub_df["total_outside"], **outside_args, **common_args)
+        fig.add_scatter(y=sub_df["total"], **total_args, **common_args)
     fig.layout.legend.orientation = "h"
     fig.layout.legend.title.text = ""
-    fig.layout.legend.yanchor = "bottom"
-    fig.layout.legend.y = 1.02
-    fig.layout.legend.xanchor = "right"
-    fig.layout.legend.x = 1
-    fig.layout.xaxis.title = "Time (date)"
-    fig.layout.yaxis.title = "Mass [kg]"
-    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
-    fig.layout.margin.b = 10
-    fig.layout.margin.t = 60
-    fig.layout.margin.l = 10
-    fig.layout.margin.r = 10
-    fig.layout.yaxis.range = (0, 1.05 * df["co2_total"].max())
+    fig.layout.legend.y = -0.3
+    fig.layout.title = "Contained CO2"
+    fig.layout.xaxis.title = "Time"
+    fig.layout.yaxis.title = scale.value
+    fig.layout.yaxis.exponentformat = "none"
+    fig.layout.yaxis.range = (0, 1.05 * df["total"].max())
+    _adjust_figure(fig)
+    return fig
+
+
+def generate_co2_mobile_phase_figure(
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    scale: Co2Scale,
+) -> go.Figure:
+    df = _read_co2_volumes(table_provider, realizations, scale)
+    df.sort_values(by="date", inplace=True)
+    y_col = "total_gas_outside"
+    df[df[y_col] < 1e-12] = np.nan
+    fig = px.line(df, x="date", y=y_col, line_group="realization")
+    fig.layout.title = "Mobile gas outside boundary"
+    fig.layout.yaxis.title = scale.value
+    fig.layout.yaxis.exponentformat = "none"
+    fig.layout.xaxis.title = "Time"
+    _adjust_figure(fig)
     return fig

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from webviz_config.utils import StrEnum
+
 
 class MapAttribute(Enum):
     MIGRATION_TIME = "Migration Time"
@@ -7,3 +9,14 @@ class MapAttribute(Enum):
     MAX_AMFG = "Maximum AMFG"
     SGAS_PLUME = "Plume (SGAS)"
     AMFG_PLUME = "Plume (AMFG)"
+
+
+class Co2Scale(StrEnum):
+    NORMALIZE = "Fraction"
+    MTONS = "M tons"
+    KG = "Kg"
+
+
+class GraphSource(StrEnum):
+    UNSMRY = "UNSMRY"
+    CONTAINMENT = "Containment Data"

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
@@ -1,0 +1,113 @@
+import dataclasses
+from typing import Iterable, List
+
+import pandas as pd
+import plotly.colors
+import plotly.graph_objects as go
+
+from webviz_subsurface._providers import EnsembleTableProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2Scale
+
+
+def generate_summary_figure(
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    scale: Co2Scale,
+) -> go.Figure:
+    columns = _column_subset(table_provider)
+    df = _read_dataframe(table_provider, realizations, columns, scale)
+    fig = go.Figure()
+    showlegend = True
+    for _, sub_df in df.groupby("realization"):
+        colors = plotly.colors.qualitative.Plotly
+        fig.add_scatter(
+            x=sub_df[columns.time],
+            y=sub_df[columns.dissolved],
+            name=f"Dissolved ({columns.dissolved})",
+            legendgroup="Dissolved",
+            showlegend=showlegend,
+            marker_color=colors[0],
+        )
+        fig.add_scatter(
+            x=sub_df[columns.time],
+            y=sub_df[columns.trapped],
+            name=f"Trapped ({columns.trapped})",
+            legendgroup="Trapped",
+            showlegend=showlegend,
+            marker_color=colors[1],
+        )
+        fig.add_scatter(
+            x=sub_df[columns.time],
+            y=sub_df[columns.mobile],
+            name=f"Mobile ({columns.mobile})",
+            legendgroup="Mobile",
+            showlegend=showlegend,
+            marker_color=colors[2],
+        )
+        fig.add_scatter(
+            x=sub_df[columns.time],
+            y=sub_df["total"],
+            name="Total",
+            legendgroup="Total",
+            showlegend=showlegend,
+            marker_color=colors[3],
+        )
+        showlegend = False
+    fig.layout.xaxis.title = "Time"
+    fig.layout.yaxis.title = f"Amount CO2 [{scale.value}]"
+    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
+    fig.layout.margin.b = 10
+    fig.layout.margin.t = 60
+    fig.layout.margin.l = 10
+    fig.layout.margin.r = 10
+    return fig
+
+
+@dataclasses.dataclass
+class _ColumnNames:
+    time: str
+    dissolved: str
+    trapped: str
+    mobile: str
+
+    def values(self) -> Iterable[str]:
+        return dataclasses.asdict(self).values()
+
+
+def _read_dataframe(
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    columns: _ColumnNames,
+    co2_scale: Co2Scale,
+) -> pd.DataFrame:
+    full = pd.concat(
+        [
+            table_provider.get_column_data(list(columns.values()), [real]).assign(
+                realization=real
+            )
+            for real in realizations
+        ]
+    )
+    full["total"] = (
+        full[columns.dissolved] + full[columns.trapped] + full[columns.mobile]
+    )
+    for col in [columns.dissolved, columns.trapped, columns.mobile, "total"]:
+        if co2_scale == Co2Scale.MTONS:
+            full[col] = full[col] / 1e9
+        elif co2_scale == Co2Scale.NORMALIZE:
+            full[col] = full[col] / full["total"].max()
+    return full
+
+
+def _column_subset(table_provider: EnsembleTableProvider) -> _ColumnNames:
+    existing = set(table_provider.column_names())
+    assert "DATE" in existing
+    # Try PFLOTRAN names
+    col_names = _ColumnNames("DATE", "FGMDS", "FGMTR", "FGMGP")
+    if set(col_names.values()).issubset(existing):
+        return col_names
+    # Try Eclipse names
+    col_names = _ColumnNames("DATE", "FWCD", "FGCDI", "FGCDM")
+    if set(col_names.values()).issubset(existing):
+        return col_names
+    raise KeyError(f"Could not find suitable data columns among: {', '.join(existing)}")

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -26,6 +26,7 @@ class MapViewElement(ViewElementABC):
         DATE_WRAPPER = "date-wrapper"
         BAR_PLOT = "bar-plot"
         TIME_PLOT = "time-plot"
+        MOBILE_CO2_PLOT = "mobile-phase-plot"
 
     def __init__(self, color_scales: List[Dict[str, Any]]) -> None:
         super().__init__()
@@ -83,10 +84,11 @@ class MapViewElement(ViewElementABC):
                         "flexDirection": "row",
                         "justifyContent": "space-evenly",
                     },
-                    children=SummaryGraphLayout(
+                    children=_summary_graph_layout(
                         self.register_component_unique_id(self.Ids.BAR_PLOT),
                         self.register_component_unique_id(self.Ids.TIME_PLOT),
-                    ).children,
+                        self.register_component_unique_id(self.Ids.MOBILE_CO2_PLOT),
+                    ),
                 ),
             ],
             style={
@@ -97,24 +99,31 @@ class MapViewElement(ViewElementABC):
         )
 
 
-class SummaryGraphLayout(html.Div):
-    def __init__(self, bar_plot_id: str, time_plot_id: str, **kwargs: Dict) -> None:
-        super().__init__(
-            children=[
-                wcc.Graph(
-                    id=bar_plot_id,
-                    figure=go.Figure(),
-                    config={
-                        "displayModeBar": False,
-                    },
-                ),
-                wcc.Graph(
-                    id=time_plot_id,
-                    figure=go.Figure(),
-                    config={
-                        "displayModeBar": False,
-                    },
-                ),
-            ],
-            **kwargs,
-        )
+def _summary_graph_layout(
+    bar_plot_id: str,
+    time_plot_id: str,
+    mob_phase_plot_id: str,
+) -> List:
+    return [
+        wcc.Graph(
+            id=bar_plot_id,
+            figure=go.Figure(),
+            config={
+                "displayModeBar": False,
+            },
+        ),
+        wcc.Graph(
+            id=time_plot_id,
+            figure=go.Figure(),
+            config={
+                "displayModeBar": False,
+            },
+        ),
+        wcc.Graph(
+            id=mob_phase_plot_id,
+            figure=go.Figure(),
+            config={
+                "displayModeBar": False,
+            },
+        ),
+    ]

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -12,7 +12,11 @@ from webviz_subsurface._providers.ensemble_surface_provider.ensemble_surface_pro
     SurfaceStatistic,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import property_origin
-from webviz_subsurface.plugins._co2_leakage._utilities.generic import MapAttribute
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    Co2Scale,
+    GraphSource,
+    MapAttribute,
+)
 
 
 class ViewSettings(SettingsGroupABC):
@@ -28,6 +32,9 @@ class ViewSettings(SettingsGroupABC):
         CM_MAX = "cm-max"
         CM_MIN_AUTO = "cm-min-auto"
         CM_MAX_AUTO = "cm-max-auto"
+
+        GRAPH_SOURCE = "graph-source"
+        CO2_SCALE = "co2-scale"
 
         PLUME_THRESHOLD = "plume-threshold"
         PLUME_SMOOTHING = "plume-smoothing"
@@ -64,6 +71,10 @@ class ViewSettings(SettingsGroupABC):
                 self.register_component_unique_id(self.Ids.CM_MAX),
                 self.register_component_unique_id(self.Ids.CM_MIN_AUTO),
                 self.register_component_unique_id(self.Ids.CM_MAX_AUTO),
+            ),
+            GraphSelectorsLayout(
+                self.register_component_unique_id(self.Ids.GRAPH_SOURCE),
+                self.register_component_unique_id(self.Ids.CO2_SCALE),
             ),
             ExperimentalFeaturesLayout(
                 self.register_component_unique_id(self.Ids.PLUME_THRESHOLD),
@@ -235,6 +246,30 @@ class MapSelectorLayout(wcc.Selectors):
                         ),
                     ],
                 )
+            ],
+        )
+
+
+class GraphSelectorsLayout(wcc.Selectors):
+    def __init__(self, graph_source_id: str, co2_scale_id: str):
+        super().__init__(
+            label="Graph Settings",
+            open_details=False,
+            children=[
+                "Source",
+                wcc.Dropdown(
+                    id=graph_source_id,
+                    options=list(GraphSource),
+                    value=GraphSource.CONTAINMENT,
+                    clearable=False,
+                ),
+                "Unit",
+                wcc.Dropdown(
+                    id=co2_scale_id,
+                    options=list(Co2Scale),
+                    value=Co2Scale.MTONS,
+                    clearable=False,
+                ),
             ],
         )
 


### PR DESCRIPTION
The script generating CO2 containment data was updated and this PR ensures that the new format is parsed and presented properly. This includes:
- Hide plots if the data fails to load or is missing
- CO2 amounts can be scaled to Mtons/fraction
- Updated default 'map_attributes_names' to be consistent with recent changes in xtgeoapp_grd3dmaps
- Parsing and visualization of boundary polygon has been improved
- New "UNSMRY" plot aimed to show unified summary data from Pflotran or Eclipse
- Support for visualizing multi polygon boundary files

The main visual effect of the changes are updates to the plots towards the bottom:

![Screenshot 2022-12-22 111031](https://user-images.githubusercontent.com/4113457/209111257-e6c3d64e-053a-4603-9eef-a8eb37c1e0af.png)
