### PR TITLE
Use view annotations in mapviewerfmu

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -75,7 +75,7 @@ jobs:
       - name: 🕵️ Check code style & linting
         run: |
           black --check webviz_subsurface tests setup.py
-          # pylint webviz_subsurface tests setup.py
+          pylint webviz_subsurface tests setup.py
           bandit -r -c ./bandit.yml webviz_subsurface tests setup.py
           isort --check-only webviz_subsurface tests setup.py
           mypy --package webviz_subsurface
@@ -92,7 +92,7 @@ jobs:
           git clone --depth 1 --branch $TESTDATA_REPO_BRANCH https://github.com/$TESTDATA_REPO_OWNER/webviz-subsurface-testdata.git
           # Copy any clientside script to the test folder before running tests
           mkdir ./tests/assets && cp ./webviz_subsurface/_assets/js/* ./tests/assets
-          # pytest ./tests --headless --forked --testdata-folder ./webviz-subsurface-testdata
+          pytest ./tests --headless --forked --testdata-folder ./webviz-subsurface-testdata
           rm -rf ./tests/assets
           webviz docs --portable ./docs_build --skip-open
 

--- a/webviz_subsurface/_providers/ensemble_surface_provider/surface_array_server.py
+++ b/webviz_subsurface/_providers/ensemble_surface_provider/surface_array_server.py
@@ -153,7 +153,7 @@ class SurfaceArrayServer:
 
     def _setup_url_rule(self, app: Dash) -> None:
         @app.server.route(_ROOT_URL_PATH + "/<full_surf_address_str>")
-        def _handle_surface_request(full_surf_address_str: str) -> flask.Response:
+        def _handle_surface_array_request(full_surf_address_str: str) -> flask.Response:
             LOGGER.debug(
                 f"Handling surface_request: "
                 f"full_surf_address_str={full_surf_address_str} "

--- a/webviz_subsurface/_providers/ensemble_surface_provider/surface_image_server.py
+++ b/webviz_subsurface/_providers/ensemble_surface_provider/surface_image_server.py
@@ -149,7 +149,7 @@ class SurfaceImageServer:
 
     def _setup_url_rule(self, app: Dash) -> None:
         @app.server.route(_ROOT_URL_PATH + "/<full_surf_address_str>")
-        def _handle_surface_request(full_surf_address_str: str) -> flask.Response:
+        def _handle_surface_image_request(full_surf_address_str: str) -> flask.Response:
             LOGGER.debug(
                 f"Handling surface_request: "
                 f"full_surf_address_str={full_surf_address_str} "

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -245,7 +245,7 @@ class CO2Leakage(WebvizPluginABC):
             plume_threshold: Optional[float],
             plume_smoothing: Optional[float],
             ensemble: str,
-        ) -> List[Dict[str, Any]]:
+        ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
             attribute = MapAttribute(attribute)
             if len(realization) == 0:
                 raise PreventUpdate

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -9,8 +9,8 @@ from webviz_config.utils import StrEnum
 from webviz_subsurface._providers import FaultPolygonsServer, SurfaceImageServer
 from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import (
     SurfaceData,
-    create_map_layers,
     create_map_annotations,
+    create_map_layers,
     create_map_viewports,
     derive_surface_address,
     get_plume_polygon,

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import geojson
 import numpy as np
+import webviz_subsurface_components as wsc
 
 from webviz_subsurface._providers import (
     EnsembleSurfaceProvider,
@@ -164,6 +165,54 @@ def get_plume_polygon(
         smoothing=smoothing,
         simplify_factor=0.12 * smoothing,  # Experimental
     )
+
+
+def create_map_annotations(
+    formation: str,
+    surface_data: Optional[SurfaceData],
+    colortables: List[Dict[str, Any]],
+) -> List[wsc.ViewAnnotation]:
+    annotations = []
+    if surface_data is not None:
+        annotations.append(
+            wsc.ViewAnnotation(
+                id="1_view",
+                children=[
+                    wsc.WebVizColorLegend(
+                        min=surface_data.color_map_range[0],
+                        max=surface_data.color_map_range[1],
+                        colorName=surface_data.color_map_name,
+                        cssLegendStyles={"top": "0", "right": "0"},
+                        openColorSelector=False,
+                        legendScaleSize=0.1,
+                        legendFontSize=30,
+                        colorTables=colortables,
+                    ),
+                    wsc.ViewFooter(children=formation),
+                ],
+            )
+        )
+    return annotations
+
+
+def create_map_viewports() -> Dict:
+    return {
+        "layout": [1, 1],
+        "viewports": [
+            {
+                "id": "1_view",
+                "show3D": False,
+                "isSync": True,
+                "layerIds": [
+                    "colormap-layer",
+                    "fault-polygons-layer",
+                    "license-boundary-layer",
+                    "well-picks-layer",
+                    "plume-polygon-layer",
+                ],
+            }
+        ],
+    }
 
 
 def create_map_layers(

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -6,7 +6,7 @@ from dash import html
 from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewABC, ViewElementABC
-from webviz_subsurface_components import DeckGLMap
+from webviz_subsurface_components import DashSubsurfaceViewer
 
 
 class MainView(ViewABC):
@@ -41,14 +41,13 @@ class MapViewElement(ViewElementABC):
                     children=[
                         html.Div(
                             [
-                                DeckGLMap(
+                                DashSubsurfaceViewer(
                                     id=self.register_component_unique_id(
                                         self.Ids.DECKGL_MAP
                                     ),
                                     layers=[],
                                     coords={"visible": True},
                                     scale={"visible": True},
-                                    toolbar={"visible": True},
                                     coordinateUnit="m",
                                     colorTables=self._color_scales,
                                 ),

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
@@ -3,10 +3,11 @@ from typing import Dict, List, Optional, Tuple
 
 import jwt
 import numpy as np
+import webviz_subsurface_components as wsc
 from dash import Input, Output, State, callback, html, no_update
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewABC
-import webviz_subsurface_components as wsc
+
 from webviz_subsurface._providers.ensemble_grid_provider import (
     CellFilter,
     EnsembleGridProvider,

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
@@ -295,7 +295,7 @@ class View3D(ViewABC):
                 color_range = actual_value_range
             children = [
                 wsc.ViewAnnotation(
-                    id=f"view_1",
+                    id="view_1",
                     children=[
                         wsc.WebVizColorLegend(
                             min=color_range[0],

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
@@ -258,7 +258,7 @@ class View3D(ViewABC):
             grid_range: List[List[int]],
             colormap: str,
             proptype: str,
-        ) -> list:
+        ) -> Tuple[List, List]:
             """Updates the information box with information on the visualized data."""
             if PROPERTYTYPE(proptype) == PROPERTYTYPE.STATIC:
                 property_spec = PropertySpec(prop_name=properties[0], prop_date=None)

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/view_elements/_vtk_view_3d_element.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/view_elements/_vtk_view_3d_element.py
@@ -2,7 +2,7 @@ from dash import dcc, html
 from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
-from webviz_subsurface_components import DeckGLMap
+from webviz_subsurface_components import DashSubsurfaceViewer
 
 
 class VTKView3D(ViewElementABC):
@@ -45,7 +45,7 @@ class VTKView3D(ViewElementABC):
                 html.Div(
                     style={"position": "absolute", "width": "100%", "height": "90%"},
                     children=[
-                        DeckGLMap(
+                        DashSubsurfaceViewer(
                             id=self.register_component_unique_id(VTKView3D.Ids.VIEW),
                             layers=[
                                 {
@@ -64,11 +64,7 @@ class VTKView3D(ViewElementABC):
                                     "@@type": "Grid3DLayer",
                                     "id": "Grid3DLayer",
                                     "material": True,
-                                    "colorMapName": "Physics reverse",
                                     "scaleZ": 1,
-                                    "pointsUrl": "/grid/points/test",
-                                    "polysUrl": "/grid/polys/test",
-                                    "propertiesUrl": "/grid/scalar/test",
                                 },
                             ],
                             views={

--- a/webviz_subsurface/plugins/_map_viewer_fmu/callbacks.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/callbacks.py
@@ -7,11 +7,11 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+import webviz_subsurface_components as wsc
 from dash import ALL, MATCH, Input, Output, State, callback, callback_context, no_update
 from dash.exceptions import PreventUpdate
 from webviz_config import EncodedFile
 from webviz_config.utils._dash_component_utils import calculate_slider_step
-import webviz_subsurface_components as wsc
 
 from webviz_subsurface._providers import (
     EnsembleFaultPolygonsProvider,

--- a/webviz_subsurface/plugins/_map_viewer_fmu/layout.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/layout.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Union
 
 import webviz_core_components as wcc
 from dash import dcc, html
-from webviz_subsurface_components import DeckGLMap  # type: ignore
+from webviz_subsurface_components import DashSubsurfaceViewer  # type: ignore
 
 from ._types import LayerNames, LayerTypes, SurfaceMode
 
@@ -256,7 +256,7 @@ class MapViewLayout(FullScreen):
     def __init__(self, tab: Tabs, get_uuid: Callable, color_tables: List[Dict]) -> None:
         super().__init__(
             children=html.Div(
-                DeckGLMap(
+                DashSubsurfaceViewer(
                     id={"id": get_uuid(LayoutElements.DECKGLMAP), "tab": tab},
                     layers=update_map_layers(1),
                     colorTables=color_tables,


### PR DESCRIPTION
Fix `DeckGLMap` renamed to `DashSubsurfaceViewer`.

Use the `children` prop to display view annotations for label and color legends.

