### PR TITLE
Bugfix in ParameterFilter in `ParamAnalysis` and `RftPlotter`

### DIFF
--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -599,7 +599,10 @@ class ParameterResponseView(ViewABC):
         @callback(
             Output(
                 {
-                    "id": ParamRespParameterFilter.Ids.PARAM_FILTER,
+                    "id": self.settings_group_unique_id(
+                        self.Ids.PARAMETER_FILTER,
+                        ParamRespParameterFilter.Ids.PARAM_FILTER,
+                    ),
                     "type": "ensemble-update",
                 },
                 "data",

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_view.py
@@ -304,7 +304,10 @@ class ParameterResponseView(ViewABC):
         @callback(
             Output(
                 {
-                    "id": ParameterFilterSettings.Ids.PARAM_FILTER,
+                    "id": self.settings_group_unique_id(
+                        self.Ids.PARAMETER_FILTER,
+                        ParameterFilterSettings.Ids.PARAM_FILTER,
+                    ),
                     "type": "ensemble-update",
                 },
                 "data",


### PR DESCRIPTION
The uuid of the parameter filter in `ParamAnalysis` and `RftPlotter` was not handled in the correct way. This PR fixes that bug:

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
