### PR TITLE
New functionality in `ParameterAnalysis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1195](https://github.com/equinor/webviz-subsurface/pull/1195) - `RftPlotter` faultlines argument can now use fault polygons csv file with *X, Y, ID* header (fmu-dataio default)
 - [#1196](https://github.com/equinor/webviz-subsurface/pull/1196) - `SwatinitQC` faultlines argument can now use fault polygons csv file with *X, Y, ID* header (fmu-dataio default)
-- [#1201](https://github.com/equinor/webviz-subsurface/pull/1196) - `ParameterAnalysis` plugin converted to WLF (Webviz Layout Framework). Removed auto-detection of sensitivity ensembles.
+- [#1201](https://github.com/equinor/webviz-subsurface/pull/1201) - `ParameterAnalysis` plugin converted to WLF (Webviz Layout Framework). Removed auto-detection of sensitivity ensembles.
 
 ### Added
 - [#1199](https://github.com/equinor/webviz-subsurface/pull/1199) - Added more statistical options to the WellOverview tab in `WellAnalysis`, and the possibility to see injection rates.
+- [#1207](https://github.com/equinor/webviz-subsurface/pull/1207) - New functionality in `ParameterAnalysis`: observations, resampling frequency and sensitivity filter.
 
 ## [0.2.17] - 2023-01-18
 

--- a/tests/integration_tests/test_parameter_filter.py
+++ b/tests/integration_tests/test_parameter_filter.py
@@ -4,12 +4,25 @@ from webviz_subsurface._components.parameter_filter import ParameterFilter
 
 
 def test_dataframe(testdata_folder) -> None:
+    # pylint: disable=protected-access
     dframe = pd.read_csv(
         testdata_folder / "reek_test_data" / "aggregated_data" / "parameters.csv"
     )
-    component = ParameterFilter("test", dframe)
-    # pylint: disable=protected-access
+
+    expected_discrete_parameters = [
+        "FWL",
+        "MULTFLT_F1",
+        "INTERPOLATE_WO",
+        "COHIBA_MODEL_MODE",
+        "RMS_SEED",
+    ]
+
+    component = ParameterFilter("test", dframe, include_sens_filter=False)
+    assert set(component._discrete_parameters) == set(expected_discrete_parameters)
+
+    component = ParameterFilter("test", dframe, include_sens_filter=True)
     assert set(component._discrete_parameters) == set(
-        ["FWL", "MULTFLT_F1", "INTERPOLATE_WO", "COHIBA_MODEL_MODE", "RMS_SEED"]
+        expected_discrete_parameters + ["SENSNAME"]
     )
+
     assert component.is_sensitivity_run is True

--- a/webviz_subsurface/_components/parameter_filter.py
+++ b/webviz_subsurface/_components/parameter_filter.py
@@ -43,6 +43,7 @@ class ParameterFilter:
             drop_constants=True,
             keep_numeric_only=False,
             drop_parameters_with_nan=True,
+            include_sens_filter=True,
         )
         self._dframe = self._pmodel.dataframe
         self._range_parameters = self._get_range_parameters()
@@ -361,7 +362,15 @@ class ParameterFilter:
             ens_df = self._dframe[self._dframe["ENSEMBLE"].isin(ensembles)]
 
             children = []
-            for col in self._pmodel.get_parameters_for_ensembles(ensembles):
+            ens_parameters = self._pmodel.get_parameters_for_ensembles(ensembles)
+
+            # if SENSNAME is among the parameters we want to place it first
+            if "SENSNAME" in ens_parameters:
+                ens_parameters = ["SENSNAME"] + [
+                    p for p in ens_parameters if p != "SENSNAME"
+                ]
+
+            for col in ens_parameters:
                 if col in self._range_parameters:
                     children.append(
                         make_range_slider(

--- a/webviz_subsurface/_components/parameter_filter.py
+++ b/webviz_subsurface/_components/parameter_filter.py
@@ -30,6 +30,7 @@ class ParameterFilter:
         dframe: pd.DataFrame,
         reset_on_ensemble_update: bool = False,
         display_header: bool = True,
+        include_sens_filter: bool = False,
     ) -> None:
         """
         * **`uuid`:** Unique id (use the plugin id).
@@ -43,7 +44,7 @@ class ParameterFilter:
             drop_constants=True,
             keep_numeric_only=False,
             drop_parameters_with_nan=True,
-            include_sens_filter=True,
+            include_sens_filter=include_sens_filter,
         )
         self._dframe = self._pmodel.dataframe
         self._range_parameters = self._get_range_parameters()

--- a/webviz_subsurface/_figures/timeseries_figure.py
+++ b/webviz_subsurface/_figures/timeseries_figure.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd

--- a/webviz_subsurface/_figures/timeseries_figure.py
+++ b/webviz_subsurface/_figures/timeseries_figure.py
@@ -30,7 +30,7 @@ class TimeSeriesFigure:
         ensemble: str,
         color_col: Optional[str],
         line_shape_fallback: str,
-        observations: Dict,
+        observations: Optional[Dict],
         historical_vector_df: Optional[pd.DataFrame] = None,
         dateline: Optional[datetime.datetime] = None,
     ):
@@ -41,7 +41,7 @@ class TimeSeriesFigure:
         self.visualization = visualization
         self.historical_vector_df = historical_vector_df
         self.date = dateline
-        self.observations = observations
+        self.observations = observations if observations is not None else {}
         self.line_shape = self.get_line_shape(line_shape_fallback)
 
         self.create_traces()

--- a/webviz_subsurface/_figures/timeseries_figure.py
+++ b/webviz_subsurface/_figures/timeseries_figure.py
@@ -30,7 +30,7 @@ class TimeSeriesFigure:
         ensemble: str,
         color_col: Optional[str],
         line_shape_fallback: str,
-        observations: Optional[Dict],
+        observations: Optional[Dict] = None,
         historical_vector_df: Optional[pd.DataFrame] = None,
         dateline: Optional[datetime.datetime] = None,
     ):

--- a/webviz_subsurface/_models/parameter_model.py
+++ b/webviz_subsurface/_models/parameter_model.py
@@ -24,7 +24,8 @@ class ParametersModel:
             "SENSNAME_CASE",
         ]
 
-        if include_sens_filter:
+        if include_sens_filter and "SENSNAME" in self._dataframe.columns:
+            # Remove SENSNAME from possible selectors
             self._possible_selectors = [
                 col for col in self._possible_selectors if col != "SENSNAME"
             ]

--- a/webviz_subsurface/_models/parameter_model.py
+++ b/webviz_subsurface/_models/parameter_model.py
@@ -5,28 +5,36 @@ import pandas as pd
 class ParametersModel:
     """Class to process ensemble parameter data"""
 
-    POSSIBLE_SELECTORS = [
-        "ENSEMBLE",
-        "REAL",
-        "SENSNAME",
-        "SENSCASE",
-        "SENSTYPE",
-        "SENSNAME_CASE",
-    ]
-
     def __init__(
         self,
         dataframe: pd.DataFrame,
         drop_constants: bool = True,
         keep_numeric_only: bool = True,
         drop_parameters_with_nan: bool = False,
+        include_sens_filter: bool = False,
     ) -> None:
         self._dataframe = dataframe if dataframe is not None else pd.DataFrame()
+
+        self._possible_selectors = [
+            "ENSEMBLE",
+            "REAL",
+            "SENSNAME",
+            "SENSCASE",
+            "SENSTYPE",
+            "SENSNAME_CASE",
+        ]
+
+        if include_sens_filter:
+            self._possible_selectors = [
+                col for col in self._possible_selectors if col != "SENSNAME"
+            ]
+            self._dataframe["SENSNAME"].fillna("None")
+
         self._validate_dframe()
         self._sensrun = self._check_if_sensitivity_run()
         self._prepare_data(drop_constants, keep_numeric_only, drop_parameters_with_nan)
         self._parameters = [
-            x for x in self._dataframe if x not in self.POSSIBLE_SELECTORS
+            x for x in self._dataframe if x not in self._possible_selectors
         ]
         self._parameters_per_ensemble = self._split_parameters_by_ensemble()
 
@@ -44,7 +52,7 @@ class ParametersModel:
 
     @property
     def selectors(self) -> list:
-        return [col for col in self.POSSIBLE_SELECTORS if col in self.dataframe]
+        return [col for col in self._possible_selectors if col in self.dataframe]
 
     @property
     def sensitivities(self) -> list:
@@ -64,7 +72,7 @@ class ParametersModel:
 
     @property
     def sens_df(self) -> pd.DataFrame:
-        return self.dataframe[self.POSSIBLE_SELECTORS]
+        return self.dataframe[self._possible_selectors]
 
     @property
     def dataframe(self) -> pd.DataFrame:
@@ -96,7 +104,7 @@ class ParametersModel:
                 param
                 for param in self._dataframe
                 if self._dataframe[param].dropna().nunique() == 1
-                and param not in self.POSSIBLE_SELECTORS
+                and param not in self._possible_selectors
             ]
             self._dataframe = self._dataframe.drop(columns=constant_params)
 

--- a/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
@@ -125,6 +125,7 @@ realizations if you have defined `ensembles`.
                 parametermodel=self._pmodel,
                 vectormodel=self._vmodel,
                 observations=self._observations,
+                selected_resampling_frequency=resampling_frequency,
                 theme=self._theme,
             ),
             self.Ids.PARAM_RESP_VIEW,

--- a/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import pandas as pd
@@ -11,6 +12,8 @@ from webviz_subsurface._providers import (
     Frequency,
 )
 
+from ..._utils.simulation_timeseries import check_and_format_observations
+from ..._utils.webvizstore_functions import get_path
 from ._utils import ParametersModel, ProviderTimeSeriesDataModel
 from ._views._parameter_distributions_view import ParameterDistributionView
 from ._views._parameter_response_view import ParameterResponseView
@@ -64,11 +67,17 @@ realizations if you have defined `ensembles`.
         column_keys: Optional[list] = None,
         drop_constants: bool = True,
         rel_file_pattern: str = "share/results/unsmry/*.arrow",
+        obsfile: Path = None,
     ):
         super().__init__()
 
         self._ensembles = ensembles
         self._theme = webviz_settings.theme
+        self._obsfile = obsfile
+
+        self._observations = {}
+        if self._obsfile:
+            self._observations = check_and_format_observations(get_path(self._obsfile))
 
         if ensembles is None:
             raise ValueError('Incorrect argument, must provide "ensembles"')
@@ -112,7 +121,10 @@ realizations if you have defined `ensembles`.
 
         self.add_view(
             ParameterResponseView(
-                parametermodel=self._pmodel, vectormodel=self._vmodel, theme=self._theme
+                parametermodel=self._pmodel,
+                vectormodel=self._vmodel,
+                observations=self._observations,
+                theme=self._theme,
             ),
             self.Ids.PARAM_RESP_VIEW,
         )

--- a/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
@@ -35,6 +35,7 @@ on reservoir simulation time series data.
     Default is True.
 * **`column_keys`:** List of vectors to extract. If not given, all vectors \
     from the simulations will be extracted. Wild card asterisk `*` can be used.
+* **`obsfile`:** `.yaml` file with observations to be displayed in the time series plot \
 ---
 
 ?> `Arrow` format for simulation time series data can be generated using the `ECL2CSV` forward \

--- a/webviz_subsurface/plugins/_parameter_analysis/_utils/_parameters_model.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_utils/_parameters_model.py
@@ -65,8 +65,14 @@ class ParametersModel:
     @staticmethod
     def _aggregate_ensemble_data(dframe: pd.DataFrame) -> pd.DataFrame:
         """Compute parameter statistics for the different ensembles"""
+        drop_columns = [
+            col
+            for col in ["REAL", "SENSNAME", "SENSTYPE", "SENSNAME_CASE", "SENSCASE"]
+            if col in dframe.columns
+        ]
+
         return (
-            dframe.drop(columns=["REAL"])
+            dframe.drop(columns=drop_columns)
             .groupby(["ENSEMBLE"])
             .agg(
                 [

--- a/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
@@ -67,6 +67,10 @@ class ProviderTimeSeriesDataModel:
         # pylint: disable=attribute-defined-outside-init
         self._dates = dates
 
+    def get_closest_date(self, date: datetime.datetime) -> datetime.datetime:
+        # Returns the closest date to the input date in the dates list.
+        return min(self._dates, key=lambda dte: abs(dte - date))
+
     @staticmethod
     def _create_union_of_vector_names_from_providers(
         providers: List[EnsembleSummaryProvider],

--- a/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
@@ -64,7 +64,7 @@ class ProviderTimeSeriesDataModel:
         return list(sorted(dates_union))
 
     def set_dates(self, dates: List[datetime.datetime]) -> None:
-        #pylint: disable=attribute-defined-outside-init
+        # pylint: disable=attribute-defined-outside-init
         self._dates = dates
 
     @staticmethod
@@ -124,7 +124,7 @@ class ProviderTimeSeriesDataModel:
         ensemble: str,
         realizations: List[int],
         vectors: List[str],
-        resampling_frequency: Frequency,
+        resampling_frequency: Optional[Frequency],
     ) -> pd.DataFrame:
         provider = self._provider_set[ensemble]
         ens_vectors = [vec for vec in vectors if vec in provider.vector_names()]

--- a/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Set
 import pandas as pd
 
 from webviz_subsurface._abbreviations.reservoir_simulation import historical_vector
-from webviz_subsurface._providers import EnsembleSummaryProvider
+from webviz_subsurface._providers import EnsembleSummaryProvider, Frequency
 from webviz_subsurface._utils.simulation_timeseries import (
     set_simulation_line_shape_fallback,
 )
@@ -34,8 +34,6 @@ class ProviderTimeSeriesDataModel:
         if not self._vector_names:
             raise ValueError("No vectors match the selected 'column_keys' criteria")
 
-        self._dates = self.all_dates()
-
         # add vectors to vector selector
         self.vector_selector_data: list = []
         for vector in self.get_non_historical_vector_names():
@@ -56,14 +54,18 @@ class ProviderTimeSeriesDataModel:
             if historical_vector(vector, None, False) not in self._vector_names
         ]
 
-    def all_dates(self) -> List[datetime.datetime]:
+    def get_dates(self, resampling_frequency: Frequency) -> List[datetime.datetime]:
         """List with the union of dates among providers"""
         # TODO: Adjust when providers are updated!
         dates_union: Set[datetime.datetime] = set()
         for provider in list(self._provider_set.values()):
-            _dates = set(provider.dates(None))
+            _dates = set(provider.dates(resampling_frequency=resampling_frequency))
             dates_union.update(_dates)
         return list(sorted(dates_union))
+
+    def set_dates(self, dates: List[datetime.datetime]) -> None:
+        #pylint: disable=attribute-defined-outside-init
+        self._dates = dates
 
     @staticmethod
     def _create_union_of_vector_names_from_providers(
@@ -122,10 +124,15 @@ class ProviderTimeSeriesDataModel:
         ensemble: str,
         realizations: List[int],
         vectors: List[str],
+        resampling_frequency: Frequency,
     ) -> pd.DataFrame:
         provider = self._provider_set[ensemble]
         ens_vectors = [vec for vec in vectors if vec in provider.vector_names()]
-        return provider.get_vectors_df(ens_vectors, None, realizations)
+        return provider.get_vectors_df(
+            vector_names=ens_vectors,
+            resampling_frequency=resampling_frequency,
+            realizations=realizations,
+        )
 
     def get_last_date(self, ensemble: str) -> datetime.datetime:
         return max(self._provider_set[ensemble].dates(None))

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_parameter_filter.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_parameter_filter.py
@@ -25,4 +25,5 @@ class ParamRespParameterFilter(SettingsGroupABC):
             ].copy(),
             reset_on_ensemble_update=True,
             display_header=False,
+            include_sens_filter=True,
         ).layout

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_selections.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_selections.py
@@ -27,11 +27,13 @@ class ParamRespSelections(SettingsGroupABC):
         parametermodel: ParametersModel,
         vectormodel: ProviderTimeSeriesDataModel,
         selected_resampling_frequency: Frequency,
+        disable_resampling_dropdown: bool,
     ) -> None:
         super().__init__("Selections")
         self._parametermodel = parametermodel
         self._vectormodel = vectormodel
         self._selected_resampling_frequency = selected_resampling_frequency
+        self._disable_resampling_dropdown = disable_resampling_dropdown
 
     def layout(self) -> List[Component]:
         dates = self._vectormodel.dates
@@ -113,10 +115,11 @@ class ParamRespSelections(SettingsGroupABC):
                     self.Ids.RESAMPLING_FREQUENCY_DROPDOWN
                 ),
                 clearable=False,
+                disabled=self._disable_resampling_dropdown,
                 options=[
                     {
-                        "label": frequency.value,
-                        "value": frequency.value,
+                        "label": frequency,
+                        "value": frequency,
                     }
                     for frequency in Frequency
                 ],

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_selections.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_selections.py
@@ -7,6 +7,7 @@ from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 
+from ......_providers import Frequency
 from ...._utils import ParametersModel, ProviderTimeSeriesDataModel
 from ...._utils import _datetime_utils as datetime_utils
 
@@ -19,13 +20,18 @@ class ParamRespSelections(SettingsGroupABC):
         DATE_SELECTED = "date-selected"
         DATE_SLIDER = "date-slider"
         PARAMETER_SELECT = "parameter-select"
+        RESAMPLING_FREQUENCY_DROPDOWN = "resampling-frequency-dropdown"
 
     def __init__(
-        self, parametermodel: ParametersModel, vectormodel: ProviderTimeSeriesDataModel
+        self,
+        parametermodel: ParametersModel,
+        vectormodel: ProviderTimeSeriesDataModel,
+        selected_resampling_frequency: Frequency,
     ) -> None:
         super().__init__("Selections")
         self._parametermodel = parametermodel
         self._vectormodel = vectormodel
+        self._selected_resampling_frequency = selected_resampling_frequency
 
     def layout(self) -> List[Component]:
         dates = self._vectormodel.dates
@@ -100,5 +106,20 @@ class ParamRespSelections(SettingsGroupABC):
                 ],
                 placeholder="Select a parameter...",
                 clearable=False,
+            ),
+            wcc.Dropdown(
+                label="Resampling frequency",
+                id=self.register_component_unique_id(
+                    self.Ids.RESAMPLING_FREQUENCY_DROPDOWN
+                ),
+                clearable=False,
+                options=[
+                    {
+                        "label": frequency.value,
+                        "value": frequency.value,
+                    }
+                    for frequency in Frequency
+                ],
+                value=self._selected_resampling_frequency,
             ),
         ]

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_vizualisation.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_vizualisation.py
@@ -46,9 +46,10 @@ class ParamRespVizualisation(SettingsGroupABC):
             wcc.Checklist(
                 id=self.register_component_unique_id(self.Ids.CHECKBOX_OPTIONS),
                 options=[
-                    {"label": "Dateline visible", "value": "DateLine"},
+                    {"label": "Dateline", "value": "DateLine"},
+                    {"label": "Observations", "value": "Observations"},
                 ],
-                value=["DateLine"],
+                value=["DateLine", "Observations"],
             ),
             dcc.Store(
                 id=self.register_component_unique_id(self.Ids.CHECKBOX_OPTIONS_STORE),

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -428,10 +428,7 @@ class ParameterResponseView(ViewABC):
                     else datestr
                 )
                 if date not in self._vectormodel.dates:
-                    # This will happen if the click is on an observation that is on
-                    # a date that is not in the sampled vector dates. It could be fixed
-                    # by somehow finding the nearest date.
-                    raise PreventUpdate
+                    date = self._vectormodel.get_closest_date(date)
                 return self._vectormodel.dates.index(date), state_maxvalue, state_marks
 
             if ParamRespSelections.Ids.RESAMPLING_FREQUENCY_DROPDOWN.value in ctx:
@@ -442,12 +439,7 @@ class ParameterResponseView(ViewABC):
                 )
                 self._vectormodel.set_dates(dates)
                 if date not in dates:
-                    print("Find closest")
-                    return (
-                        self._vectormodel.dates.index(dates[-1]),
-                        len(dates) - 1,
-                        get_slider_marks(dates),
-                    )
+                    date = self._vectormodel.get_closest_date(date)
                 return (
                     self._vectormodel.dates.index(date),
                     len(dates) - 1,

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -541,6 +541,10 @@ class ParameterResponseView(ViewABC):
         @callback_typecheck
         def _update_date_drag_value(dateidx: int) -> str:
             """Update selected date text on date-slider drag"""
+            if dateidx >= len(self._vectormodel.dates):
+                # This is not supposed to happen if callbacks are triggered
+                # in the right order
+                return datetime_utils.to_str(self._vectormodel.dates[-1])
             return datetime_utils.to_str(self._vectormodel.dates[dateidx])
 
         @callback(

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -226,17 +226,27 @@ class ParameterResponseView(ViewABC):
                 else []
             )
 
-            # Get dataframe with vectors and dataframe with parameters and merge
-            # If the resampling dropdown is disable it means the data is presampled,
-            # in which case we pass None as resampling frequency
-            vector_df = self._vectormodel.get_vector_df(
-                ensemble=ensemble,
-                realizations=realizations,
-                vectors=vectors_for_param_corr + [selected_vector],
-                resampling_frequency=resampling_frequency
-                if not self._disable_resampling_dropdown
-                else None,
-            )
+            try:
+                # Get dataframe with vectors and dataframe with parameters and merge
+                # If the resampling dropdown is disable it means the data is presampled,
+                # in which case we pass None as resampling frequency
+                vector_df = self._vectormodel.get_vector_df(
+                    ensemble=ensemble,
+                    realizations=realizations,
+                    vectors=vectors_for_param_corr + [selected_vector],
+                    resampling_frequency=resampling_frequency
+                    if not self._disable_resampling_dropdown
+                    else None,
+                )
+            except ValueError:
+                # It could be that the selected vector does not exist in the
+                # selected ensemble, f.ex if the ensembles have different well names
+                return [
+                    empty_figure(
+                        "Selected vector probably does not exist in selected ensemble"
+                    )
+                ] * 4
+
             if date not in vector_df["DATE"].values:
                 return [empty_figure("Selected date does not exist for ensemble")] * 4
             if selected_vector not in vector_df:

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -8,6 +8,7 @@ from webviz_config.utils import StrEnum, callback_typecheck
 from webviz_config.webviz_plugin_subclasses import ViewABC
 
 from ....._figures import BarChart, ScatterPlot, TimeSeriesFigure
+from ....._providers import Frequency
 from ....._utils.colors import hex_to_rgba_str, rgba_to_hex
 from ....._utils.dataframe_utils import (
     correlate_response_with_dataframe,
@@ -40,6 +41,7 @@ class ParameterResponseView(ViewABC):
         parametermodel: ParametersModel,
         vectormodel: ProviderTimeSeriesDataModel,
         observations: Dict,
+        selected_resampling_frequency: Frequency,
         theme: WebvizConfigTheme,
     ) -> None:
         super().__init__("Parameter Response Analysis")
@@ -52,7 +54,9 @@ class ParameterResponseView(ViewABC):
         self.add_settings_groups(
             {
                 self.Ids.SELECTIONS: ParamRespSelections(
-                    self._parametermodel, self._vectormodel
+                    parametermodel=self._parametermodel,
+                    vectormodel=self._vectormodel,
+                    selected_resampling_frequency=selected_resampling_frequency,
                 ),
                 self.Ids.OPTIONS: ParamRespOptions(),
                 self.Ids.VIZUALISATION: ParamRespVizualisation(self._theme),
@@ -328,7 +332,8 @@ class ParameterResponseView(ViewABC):
                     selected_vector, ensemble
                 ),
                 observations=self._observations[selected_vector]
-                if options["show_observations"]
+                if options
+                and options["show_observations"]
                 and selected_vector in self._observations
                 else {},
                 color_col=param,

--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
@@ -266,7 +266,7 @@ class RftPlotterDataModel:
         ens_params = [
             param
             for param in param_df.columns
-            if param not in self.param_model.POSSIBLE_SELECTORS
+            if param not in self.param_model.selectors
         ]
         ens_rfts = [rft for rft in pivot_df.columns if rft != "REAL"]
 


### PR DESCRIPTION
New functionality in the `ParameterAnalysis` plugin:

- Observations in time series plot. Can be turned on and off in the visualization settings. New input parameter `obsfile`, exactly as in the `SimulationTimeSeries` plugin.
- Possibility to change resampling frequency. The already existing input parameter `time_index` will be used as starting point. There is a new parameter `perform_presampling` (as in `SimulationTimeSeries`) that is default False. If that is set to true, `time_index` is used as the presampling frequency.
- Sensitivity filter in the parameter filter (If `SENSNAME` exists as a parameter in any of the ensembles, it will show up as the top of the parameters list)

---

### Contributor checklist

- [x] :tada: This PR closes #1188 and #1140
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
