### PR TITLE
Sensitivity filter in `RftPlotter` parameter response view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Changed
+
+- [#1211](https://github.com/equinor/webviz-subsurface/pull/1211) - `RftPlotter`: Parameter response view always displayed, also for sensitivity ensembles. Instead it is no possible to filter on SENSNAME.
+
 ## [0.2.18] - 2023-04-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [#1211](https://github.com/equinor/webviz-subsurface/pull/1211) - `RftPlotter`: Parameter response view always displayed, also for sensitivity ensembles. Instead it is no possible to filter on SENSNAME.
+- [#1211](https://github.com/equinor/webviz-subsurface/pull/1211) - `RftPlotter`: Parameter response view always displayed, also for sensitivity ensembles. Instead it is now possible to filter on SENSNAME.
 
 ### Added
 - [#1207](https://github.com/equinor/webviz-subsurface/pull/1207) - New functionality in `ParameterAnalysis`: observations, resampling frequency and sensitivity filter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1211](https://github.com/equinor/webviz-subsurface/pull/1211) - `RftPlotter`: Parameter response view always displayed, also for sensitivity ensembles. Instead it is no possible to filter on SENSNAME.
 
+### Added
+- [#1207](https://github.com/equinor/webviz-subsurface/pull/1207) - New functionality in `ParameterAnalysis`: observations, resampling frequency and sensitivity filter.
+
 ## [0.2.18] - 2023-04-12
 
 ### Changed
@@ -21,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#1199](https://github.com/equinor/webviz-subsurface/pull/1199) - Added more statistical options to the WellOverview tab in `WellAnalysis`, and the possibility to see injection rates.
-- [#1207](https://github.com/equinor/webviz-subsurface/pull/1207) - New functionality in `ParameterAnalysis`: observations, resampling frequency and sensitivity filter.
 
 ## [0.2.17] - 2023-01-18
 

--- a/webviz_subsurface/plugins/_rft_plotter/_plugin.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_plugin.py
@@ -122,10 +122,9 @@ forward_models.html?highlight=gendata_rft#MERGE_RFT_ERTOBS).
         self.add_view(MapView(self._datamodel), self.Ids.MAP_VIEW)
         self.add_view(MisfitPerRealView(self._datamodel), self.Ids.MISFIT_PER_REAL_VIEW)
         self.add_view(SimVsObsView(self._datamodel), self.Ids.SIM_VS_OBS_VIEW)
-        if not self._datamodel.param_model.sensrun:
-            self.add_view(
-                ParameterResponseView(self._datamodel), self.Ids.PARAMETER_RESPONSE_VIEW
-            )
+        self.add_view(
+            ParameterResponseView(self._datamodel), self.Ids.PARAMETER_RESPONSE_VIEW
+        )
 
     def add_webvizstore(self) -> List[Tuple[Callable, List[Dict]]]:
         return self._datamodel.webviz_store

--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_formation_figure.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_formation_figure.py
@@ -157,7 +157,7 @@ class FormationFigure:
                     "name": row["ZONE"],
                     "y0": row[top_col],
                     "y1": row[base_col],
-                    "line": dict(color="#646567", width=1.0),
+                    "line": {"color": "#646567", "width": 1.0},
                     "fillcolor": formation_colors[
                         list(df["ZONE"].unique()).index(row["ZONE"])
                     ]

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_utils/_map_figure.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_utils/_map_figure.py
@@ -11,7 +11,7 @@ class MapFigure:
         self._ertdf = (
             ertdf.loc[(ertdf["ENSEMBLE"] == ensemble) & (ertdf["ZONE"].isin(zones))]
             .groupby(["WELL", "DATE", "ENSEMBLE"])
-            .aggregate("mean")
+            .mean(numeric_only=False)
             .reset_index()
         )
 

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
@@ -12,17 +12,18 @@ class ParameterFilterSettings(SettingsGroupABC):
     class Ids(StrEnum):
         PARAM_FILTER = "param-filter"
 
-    def __init__(self, parameter_df: pd.DataFrame, mc_ensembles: List[str]) -> None:
+    def __init__(self, parameter_df: pd.DataFrame, ensembles: List[str]) -> None:
         super().__init__("Parameter Filter")
         self._parameter_df = parameter_df
-        self._mc_ensembles = mc_ensembles
+        self._ensembles = ensembles
 
     def layout(self) -> List[Component]:
         return ParameterFilter(
             uuid=self.register_component_unique_id(self.Ids.PARAM_FILTER),
             dframe=self._parameter_df[
-                self._parameter_df["ENSEMBLE"].isin(self._mc_ensembles)
+                self._parameter_df["ENSEMBLE"].isin(self._ensembles)
             ].copy(),
             reset_on_ensemble_update=True,
             display_header=False,
+            include_sens_filter=True,
         ).layout

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_selections.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_selections.py
@@ -69,7 +69,7 @@ class Selections(SettingsGroupABC):
                 label="Parameter",
                 id=self.register_component_unique_id(self.Ids.PARAM),
                 options=[{"label": param, "value": param} for param in self._params],
-                clearable=False,
+                clearable=True,
                 value=None,
             ),
         ]

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_view.py
@@ -33,7 +33,7 @@ class ParameterResponseView(ViewABC):
         self.add_settings_group(
             ParameterFilterSettings(
                 parameter_df=self._datamodel.param_model.dataframe,
-                mc_ensembles=self._datamodel.param_model.mc_ensembles,
+                ensembles=self._datamodel.param_model.ensembles,
             ),
             self.Ids.PARAMETER_FILTER,
         )
@@ -220,6 +220,10 @@ class ParameterResponseView(ViewABC):
                 # This happens if there are multiple ensembles and one of the ensembles
                 # doesn't have non-constant parameters.
                 return ["The selected ensemble has no non-constant parameters."] * 3
+            if df.shape[0] <= 1:
+                # This happens if f.ex it is filtered on a sensitivity with only one
+                # realization.
+                return ["Too few realizations to calculate correlations"] * 3
 
             if corrtype == CorrType.SIM_VS_PARAM or param is None:
                 corrseries = correlate(df[ens_params + [current_key]], current_key)


### PR DESCRIPTION
All ensembles are now displayed in the parameter response view. Not only the ones that are labelled monte carlo. Instead there is now a sensitivity filter in the parameter filter. If `SENSNAME` exists as a parameter in any of the ensembles, it will show up as the top of the parameters list.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
