### PR TITLE
Bugfiz in `ParameterAnalysis`

### DIFF
--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -233,7 +233,7 @@ class ParameterResponseView(ViewABC):
                 vector_df = self._vectormodel.get_vector_df(
                     ensemble=ensemble,
                     realizations=realizations,
-                    vectors=vectors_for_param_corr + [selected_vector],
+                    vectors=list(set(vectors_for_param_corr + [selected_vector])),
                     resampling_frequency=resampling_frequency
                     if not self._disable_resampling_dropdown
                     else None,
@@ -306,7 +306,9 @@ class ParameterResponseView(ViewABC):
                         corr_p_fig = empty_figure("Not able to calculate correlations")
                     else:
                         corrseries = correlate_response_with_dataframe(
-                            merged_df, param, vectors_for_param_corr + [selected_vector]
+                            merged_df,
+                            param,
+                            list(set(vectors_for_param_corr + [selected_vector])),
                         )
                         if corrseries.isnull().values.any():
                             corr_p_fig = empty_figure(


### PR DESCRIPTION
When the selected vector was also included in the list of vectors for parameter correlation then it was duplicated in the list passed to the summary provider. This gave an error. F.ex if the selected vector is `FOPT` and the correlation vector is `F*`. The solution is to remove duplicates from the list.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
