### PR TITLE
CO2Leakage: Improve containment plots

### DIFF
--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -43,6 +43,8 @@ from webviz_subsurface.plugins._co2_leakage.views.mainview.settings import ViewS
 from . import _error
 from ._utilities.color_tables import co2leakage_color_tables
 
+TILE_PATH = "share/results/tables"
+
 
 class CO2Leakage(WebvizPluginABC):
     """
@@ -55,10 +57,12 @@ class CO2Leakage(WebvizPluginABC):
     * **`well_pick_file`:** Path to a file containing well picks
     * **`co2_containment_relpath`:** Path to a table of co2 containment data (amount of
         CO2 outside/inside a boundary), for co2 mass. Relative to each realization.
-    * **`co2_containment_volume_actual_relpath`:** Path to a table of co2 containment data (amount of
-        CO2 outside/inside a boundary), for co2 volume of type "actual". Relative to each realization.
-    * **`co2_containment_volume_actual_simple_relpath`:** Path to a table of co2 containment data (amount of
-        CO2 outside/inside a boundary), for co2 volume of type "actual_simple". Relative to each realization.
+    * **`co2_containment_volume_actual_relpath`:** Path to a table of co2 containment data (amount
+        of CO2 outside/inside a boundary), for co2 volume of type "actual". Relative to each
+        realization.
+    * **`co2_containment_volume_actual_simple_relpath`:** Path to a table of co2 containment data
+        (amount of CO2 outside/inside a boundary), for co2 volume of type "actual_simple".
+        Relative to each realization.
     * **`unsmry_relpath`:** Relative path to a csv version of a unified summary file
     * **`fault_polygon_attribute`:** Polygons with this attribute are used as fault
         polygons
@@ -78,6 +82,7 @@ class CO2Leakage(WebvizPluginABC):
         MAIN_SETTINGS = "main-settings"
 
     # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-locals
     def __init__(
         self,
         app: Dash,
@@ -86,10 +91,12 @@ class CO2Leakage(WebvizPluginABC):
         file_containment_boundary: Optional[str] = None,
         file_hazardous_boundary: Optional[str] = None,
         well_pick_file: Optional[str] = None,
-        co2_containment_relpath: str = "share/results/tables/co2_volumes.csv",
-        co2_containment_volume_actual_relpath: str = "share/results/tables/plume_volume_actual.csv",
-        co2_containment_volume_actual_simple_relpath: str = "share/results/tables/plume_volume_actual_simple.csv",
-        unsmry_relpath: str = "share/results/tables/unsmry--raw.csv",
+        co2_containment_relpath: str = TILE_PATH + "/co2_volumes.csv",
+        co2_containment_volume_actual_relpath: str = TILE_PATH
+        + "/plume_volume_actual.csv",
+        co2_containment_volume_actual_simple_relpath: str = TILE_PATH
+        + "/plume_volume_actual_simple.csv",
+        unsmry_relpath: str = TILE_PATH + "/unsmry--raw.csv",
         fault_polygon_attribute: str = "dl_extracted_faultlines",
         initial_surface: Optional[str] = None,
         map_attribute_names: Optional[Dict[str, str]] = None,
@@ -226,11 +233,11 @@ class CO2Leakage(WebvizPluginABC):
         ) -> Tuple[go.Figure, go.Figure, Dict, Dict]:
             styles = [{"display": "none"}] * 3
             figs = [no_update] * 3
-            if (
-                source == GraphSource.CONTAINMENT_MASS
-                or source == GraphSource.CONTAINMENT_VOLUME_ACTUAL
-                or source == GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE
-            ):
+            if source in [
+                GraphSource.CONTAINMENT_MASS,
+                GraphSource.CONTAINMENT_VOLUME_ACTUAL,
+                GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE,
+            ]:
                 y_limits = [None, None]
                 if len(y_min_auto) == 0:
                     y_limits[0] = y_min_val
@@ -314,16 +321,13 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
         )
         def make_unit_list(attribute: str):
-            if (
-                attribute == GraphSource.CONTAINMENT_MASS
-                or attribute == GraphSource.UNSMRY
-            ):
+            if attribute in [GraphSource.CONTAINMENT_MASS, GraphSource.UNSMRY]:
                 options = list(Co2MassScale)
                 value = Co2MassScale.MTONS
-            elif (
-                attribute == GraphSource.CONTAINMENT_VOLUME_ACTUAL
-                or attribute == GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE
-            ):
+            elif attribute in [
+                GraphSource.CONTAINMENT_VOLUME_ACTUAL,
+                GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE,
+            ]:
                 options = list(Co2VolumeScale)
                 value = Co2VolumeScale.BILLION_CUBIC_METERS
             return options, value

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -238,11 +238,15 @@ class CO2Leakage(WebvizPluginABC):
                 GraphSource.CONTAINMENT_VOLUME_ACTUAL,
                 GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE,
             ]:
-                y_limits = [None, None]
+                y_limits = []
                 if len(y_min_auto) == 0:
-                    y_limits[0] = y_min_val
+                    y_limits.append(y_min_val)
+                else:
+                    y_limits.append(None)
                 if len(y_max_auto) == 0:
-                    y_limits[1] = y_max_val
+                    y_limits.append(y_max_val)
+                else:
+                    y_limits.append(None)
                 styles = [{}] * 3
 
                 if (
@@ -320,17 +324,19 @@ class CO2Leakage(WebvizPluginABC):
             Output(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
             Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
         )
-        def make_unit_list(attribute: str):
-            if attribute in [GraphSource.CONTAINMENT_MASS, GraphSource.UNSMRY]:
-                options = list(Co2MassScale)
-                value = Co2MassScale.MTONS
-            elif attribute in [
+        def make_unit_list(
+            attribute: str,
+        ) -> Union[
+            Tuple[List[Co2MassScale], Co2MassScale],
+            Tuple[List[Co2VolumeScale], Co2VolumeScale],
+        ]:
+            if attribute in [
                 GraphSource.CONTAINMENT_VOLUME_ACTUAL,
                 GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE,
             ]:
-                options = list(Co2VolumeScale)
-                value = Co2VolumeScale.BILLION_CUBIC_METERS
-            return options, value
+                return list(Co2VolumeScale), Co2VolumeScale.BILLION_CUBIC_METERS
+
+            return list(Co2MassScale), Co2MassScale.MTONS
 
         # Cannot avoid many arguments and/or locals since all layers of the DeckGL map
         # needs to be updated simultaneously

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import plotly.graph_objects as go
-from dash import Dash, Input, Output, State, callback, html
+from dash import Dash, Input, Output, State, callback, html, no_update
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
-from webviz_config.utils import StrEnum
+from webviz_config.utils import StrEnum, callback_typecheck
 
 from webviz_subsurface._providers import FaultPolygonsServer, SurfaceImageServer
 from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import (
@@ -13,22 +13,25 @@ from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import (
     create_map_layers,
     create_map_viewports,
     derive_surface_address,
+    generate_containment_figures,
+    generate_unsmry_figures,
     get_plume_polygon,
     property_origin,
     readable_name,
 )
-from webviz_subsurface.plugins._co2_leakage._utilities.co2volume import (
-    generate_co2_time_containment_figure,
-    generate_co2_volume_figure,
-)
 from webviz_subsurface.plugins._co2_leakage._utilities.fault_polygons import (
     FaultPolygonsHandler,
 )
-from webviz_subsurface.plugins._co2_leakage._utilities.generic import MapAttribute
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    Co2MassScale,
+    Co2VolumeScale,
+    GraphSource,
+    MapAttribute,
+)
 from webviz_subsurface.plugins._co2_leakage._utilities.initialization import (
-    init_co2_containment_table_providers,
     init_map_attribute_names,
     init_surface_providers,
+    init_table_provider,
     init_well_pick_provider,
 )
 from webviz_subsurface.plugins._co2_leakage.views.mainview.mainview import (
@@ -47,10 +50,16 @@ class CO2Leakage(WebvizPluginABC):
     ensemble
 
     * **`ensembles`:** Which ensembles in `shared_settings` to visualize.
-    * **`boundary_file`:** Path to a polygon representing the containment area
+    * **`file_containment_boundary`:** Path to a polygon representing the containment area
+    * **`file_hazardous_boundary`:** Path to a polygon representing the hazardous area
     * **`well_pick_file`:** Path to a file containing well picks
     * **`co2_containment_relpath`:** Path to a table of co2 containment data (amount of
-        CO2 outside/inside a boundary). Relative to each realization.
+        CO2 outside/inside a boundary), for co2 mass. Relative to each realization.
+    * **`co2_containment_volume_actual_relpath`:** Path to a table of co2 containment data (amount of
+        CO2 outside/inside a boundary), for co2 volume of type "actual". Relative to each realization.
+    * **`co2_containment_volume_actual_simple_relpath`:** Path to a table of co2 containment data (amount of
+        CO2 outside/inside a boundary), for co2 volume of type "actual_simple". Relative to each realization.
+    * **`unsmry_relpath`:** Relative path to a csv version of a unified summary file
     * **`fault_polygon_attribute`:** Polygons with this attribute are used as fault
         polygons
     * **`map_attribute_names`:** Dictionary for overriding the default mapping between
@@ -74,9 +83,13 @@ class CO2Leakage(WebvizPluginABC):
         app: Dash,
         webviz_settings: WebvizSettings,
         ensembles: List[str],
-        boundary_file: Optional[str] = None,
+        file_containment_boundary: Optional[str] = None,
+        file_hazardous_boundary: Optional[str] = None,
         well_pick_file: Optional[str] = None,
         co2_containment_relpath: str = "share/results/tables/co2_volumes.csv",
+        co2_containment_volume_actual_relpath: str = "share/results/tables/plume_volume_actual.csv",
+        co2_containment_volume_actual_simple_relpath: str = "share/results/tables/plume_volume_actual_simple.csv",
+        unsmry_relpath: str = "share/results/tables/unsmry--raw.csv",
         fault_polygon_attribute: str = "dl_extracted_faultlines",
         initial_surface: Optional[str] = None,
         map_attribute_names: Optional[Dict[str, str]] = None,
@@ -86,7 +99,8 @@ class CO2Leakage(WebvizPluginABC):
         super().__init__()
         self._error_message = ""
 
-        self._boundary_file = boundary_file
+        self._file_containment_boundary = file_containment_boundary
+        self._file_hazardous_boundary = file_hazardous_boundary
         try:
             self._ensemble_paths = {
                 ensemble_name: webviz_settings.shared_settings["scratch_ensembles"][
@@ -113,9 +127,21 @@ class CO2Leakage(WebvizPluginABC):
                 for ens in ensembles
             }
             # CO2 containment
-            self._co2_table_providers = init_co2_containment_table_providers(
+            self._co2_table_providers = init_table_provider(
                 self._ensemble_paths,
                 co2_containment_relpath,
+            )
+            self._co2_volume_actual_table_providers = init_table_provider(
+                self._ensemble_paths,
+                co2_containment_volume_actual_relpath,
+            )
+            self._co2_volume_actual_simple_table_providers = init_table_provider(
+                self._ensemble_paths,
+                co2_containment_volume_actual_simple_relpath,
+            )
+            self._unsmry_providers = init_table_provider(
+                self._ensemble_paths,
+                unsmry_relpath,
             )
             # Well picks
             self._well_pick_provider = init_well_pick_provider(
@@ -170,16 +196,88 @@ class CO2Leakage(WebvizPluginABC):
         @callback(
             Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "figure"),
             Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "figure"),
+            Output(
+                self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "figure"
+            ),
+            Output(self._view_component(MapViewElement.Ids.BAR_PLOT), "style"),
+            Output(self._view_component(MapViewElement.Ids.TIME_PLOT), "style"),
+            Output(
+                self._view_component(MapViewElement.Ids.TIME_PLOT_ONE_REAL), "style"
+            ),
             Input(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
+            Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
+            Input(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
+            Input(self._settings_component(ViewSettings.Ids.REALIZATION), "value"),
+            Input(self._settings_component(ViewSettings.Ids.Y_MIN_AUTO_GRAPH), "value"),
+            Input(self._settings_component(ViewSettings.Ids.Y_MIN_GRAPH), "value"),
+            Input(self._settings_component(ViewSettings.Ids.Y_MAX_AUTO_GRAPH), "value"),
+            Input(self._settings_component(ViewSettings.Ids.Y_MAX_GRAPH), "value"),
         )
-        def update_graphs(ensemble: str) -> Tuple[go.Figure, go.Figure]:
-            fig_args = (
-                self._co2_table_providers[ensemble],
-                self._co2_table_providers[ensemble].realizations(),
-            )
-            fig0 = generate_co2_volume_figure(*fig_args)
-            fig1 = generate_co2_time_containment_figure(*fig_args)
-            return fig0, fig1
+        @callback_typecheck
+        def update_graphs(
+            ensemble: str,
+            source: GraphSource,
+            co2_scale: Union[Co2MassScale, Co2VolumeScale],
+            realizations: List[int],
+            y_min_auto: List[str],
+            y_min_val: Optional[float],
+            y_max_auto: List[str],
+            y_max_val: Optional[float],
+        ) -> Tuple[go.Figure, go.Figure, Dict, Dict]:
+            styles = [{"display": "none"}] * 3
+            figs = [no_update] * 3
+            if (
+                source == GraphSource.CONTAINMENT_MASS
+                or source == GraphSource.CONTAINMENT_VOLUME_ACTUAL
+                or source == GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE
+            ):
+                y_limits = [None, None]
+                if len(y_min_auto) == 0:
+                    y_limits[0] = y_min_val
+                if len(y_max_auto) == 0:
+                    y_limits[1] = y_max_val
+                styles = [{}] * 3
+
+                if (
+                    source == GraphSource.CONTAINMENT_MASS
+                    and ensemble in self._co2_table_providers
+                ):
+                    figs[: len(figs)] = generate_containment_figures(
+                        self._co2_table_providers[ensemble],
+                        co2_scale,
+                        realizations[0],
+                        y_limits,
+                    )
+                elif (
+                    source == GraphSource.CONTAINMENT_VOLUME_ACTUAL
+                    and ensemble in self._co2_volume_actual_table_providers
+                ):
+                    figs[: len(figs)] = generate_containment_figures(
+                        self._co2_volume_actual_table_providers[ensemble],
+                        co2_scale,
+                        realizations[0],
+                        y_limits,
+                    )
+                elif (
+                    source == GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE
+                    and ensemble in self._co2_volume_actual_simple_table_providers
+                ):
+                    figs[: len(figs)] = generate_containment_figures(
+                        self._co2_volume_actual_simple_table_providers[ensemble],
+                        co2_scale,
+                        realizations[0],
+                        y_limits,
+                    )
+            elif source == GraphSource.UNSMRY and ensemble in self._unsmry_providers:
+                u_figs = generate_unsmry_figures(
+                    self._unsmry_providers[ensemble],
+                    co2_scale,
+                    self._co2_table_providers[ensemble],
+                )
+                figs[: len(u_figs)] = u_figs
+                styles[: len(u_figs)] = [{}] * len(u_figs)
+
+            return *figs, *styles  # type: ignore
 
         @callback(
             Output(self._view_component(MapViewElement.Ids.DATE_SLIDER), "marks"),
@@ -209,6 +307,26 @@ class CO2Leakage(WebvizPluginABC):
             if MapAttribute(attribute) == MapAttribute.MIGRATION_TIME:
                 return {"display": "none"}
             return {}
+
+        @callback(
+            Output(self._settings_component(ViewSettings.Ids.CO2_SCALE), "options"),
+            Output(self._settings_component(ViewSettings.Ids.CO2_SCALE), "value"),
+            Input(self._settings_component(ViewSettings.Ids.GRAPH_SOURCE), "value"),
+        )
+        def make_unit_list(attribute: str):
+            if (
+                attribute == GraphSource.CONTAINMENT_MASS
+                or attribute == GraphSource.UNSMRY
+            ):
+                options = list(Co2MassScale)
+                value = Co2MassScale.MTONS
+            elif (
+                attribute == GraphSource.CONTAINMENT_VOLUME_ACTUAL
+                or attribute == GraphSource.CONTAINMENT_VOLUME_ACTUAL_SIMPLE
+            ):
+                options = list(Co2VolumeScale)
+                value = Co2VolumeScale.BILLION_CUBIC_METERS
+            return options, value
 
         # Cannot avoid many arguments and/or locals since all layers of the DeckGL map
         # needs to be updated simultaneously
@@ -302,7 +420,8 @@ class CO2Leakage(WebvizPluginABC):
                         realization,
                     )
                 ),
-                license_boundary_file=self._boundary_file,
+                file_containment_boundary=self._file_containment_boundary,
+                file_hazardous_boundary=self._file_hazardous_boundary,
                 well_pick_provider=self._well_pick_provider,
                 plume_extent_data=plume_polygon,
             )

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import geojson
 import numpy as np
-import webviz_subsurface_components as wsc
 import plotly.graph_objects as go
+import webviz_subsurface_components as wsc
 
 from webviz_subsurface._providers import (
     EnsembleSurfaceProvider,

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -320,16 +320,19 @@ def generate_containment_figures(
     realization: int,
     y_limits: List[float],
 ) -> Tuple[go.Figure, go.Figure, go.Figure]:
-    fig_args = (
-        table_provider,
-        table_provider.realizations(),
-        co2_scale,
-    )
     try:
-        fig0 = generate_co2_volume_figure(*fig_args)
-        fig1 = generate_co2_time_containment_figure(*fig_args)
+        fig0 = generate_co2_volume_figure(
+            table_provider,
+            table_provider.realizations(),
+            co2_scale,
+        )
+        fig1 = generate_co2_time_containment_figure(
+            table_provider,
+            table_provider.realizations(),
+            co2_scale,
+        )
         fig2 = generate_co2_time_containment_one_realization_figure(
-            *fig_args, realization, y_limits
+            table_provider, co2_scale, realization, y_limits
         )
     except KeyError as exc:
         warnings.warn(f"Could not generate CO2 figures: {exc}")

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -1,12 +1,15 @@
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import geojson
 import numpy as np
 import webviz_subsurface_components as wsc
+import plotly.graph_objects as go
 
 from webviz_subsurface._providers import (
     EnsembleSurfaceProvider,
+    EnsembleTableProvider,
     SimulatedSurfaceAddress,
     StatisticalSurfaceAddress,
     SurfaceAddress,
@@ -18,7 +21,19 @@ from webviz_subsurface._providers.ensemble_surface_provider.ensemble_surface_pro
 )
 from webviz_subsurface._utils.webvizstore_functions import read_csv
 from webviz_subsurface.plugins._co2_leakage._utilities import plume_extent
-from webviz_subsurface.plugins._co2_leakage._utilities.generic import MapAttribute
+from webviz_subsurface.plugins._co2_leakage._utilities.co2volume import (
+    generate_co2_time_containment_figure,
+    generate_co2_time_containment_one_realization_figure,
+    generate_co2_volume_figure,
+)
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    Co2MassScale,
+    Co2VolumeScale,
+    MapAttribute,
+)
+from webviz_subsurface.plugins._co2_leakage._utilities.summary_graphs import (
+    generate_summary_figure,
+)
 from webviz_subsurface.plugins._co2_leakage._utilities.surface_publishing import (
     TruncatedSurfaceAddress,
     publish_and_get_surface_metadata,
@@ -219,7 +234,8 @@ def create_map_layers(
     formation: str,
     surface_data: Optional[SurfaceData],
     fault_polygon_url: Optional[str],
-    license_boundary_file: Optional[str],
+    file_containment_boundary: Optional[str],
+    file_hazardous_boundary: Optional[str],
     well_pick_provider: Optional[WellPickProvider],
     plume_extent_data: Optional[geojson.FeatureCollection],
 ) -> List[Dict]:
@@ -249,13 +265,26 @@ def create_map_layers(
                 "data": fault_polygon_url,
             }
         )
-    if license_boundary_file is not None:
+    if file_containment_boundary is not None:
         layers.append(
             {
-                "@@type": "FaultPolygonsLayer",
-                "name": "Containment Boundary",
+                "@@type": "GeoJsonLayer",
+                "name": "Containment Polygon",
                 "id": "license-boundary-layer",
-                "data": _parse_polygon_file(license_boundary_file),
+                "data": _parse_polygon_file(file_containment_boundary),
+                "stroked": False,
+                "getFillColor": [0, 172, 0, 120],
+            }
+        )
+    if file_hazardous_boundary is not None:
+        layers.append(
+            {
+                "@@type": "GeoJsonLayer",
+                "name": "Hazardous Polygon",
+                "id": "hazardous-boundary-layer",
+                "data": _parse_polygon_file(file_hazardous_boundary),
+                "stroked": False,
+                "getFillColor": [200, 0, 0, 120],
             }
         )
     if well_pick_provider is not None:
@@ -285,8 +314,63 @@ def create_map_layers(
     return layers
 
 
+def generate_containment_figures(
+    table_provider: EnsembleTableProvider,
+    co2_scale: Union[Co2MassScale, Co2VolumeScale],
+    realization: int,
+    y_limits: List[float],
+) -> Tuple[go.Figure, go.Figure, go.Figure]:
+    fig_args = (
+        table_provider,
+        table_provider.realizations(),
+        co2_scale,
+    )
+    try:
+        fig0 = generate_co2_volume_figure(*fig_args)
+        fig1 = generate_co2_time_containment_figure(*fig_args)
+        fig2 = generate_co2_time_containment_one_realization_figure(
+            *fig_args, realization, y_limits
+        )
+    except KeyError as exc:
+        warnings.warn(f"Could not generate CO2 figures: {exc}")
+        raise exc
+    return fig0, fig1, fig2
+
+
+def generate_unsmry_figures(
+    table_provider_unsmry: EnsembleTableProvider,
+    co2_mass_scale: Co2MassScale,
+    table_provider_containment: EnsembleTableProvider,
+) -> Tuple[go.Figure]:
+    return (
+        generate_summary_figure(
+            table_provider_unsmry,
+            table_provider_unsmry.realizations(),
+            co2_mass_scale,
+            table_provider_containment,
+            table_provider_containment.realizations(),
+        ),
+    )
+
+
 def _parse_polygon_file(filename: str) -> Dict[str, Any]:
-    xyz = read_csv(filename)[["x", "y"]].values
+    df = read_csv(filename)
+    if "x" in df.columns:
+        xyz = df[["x", "y"]].values
+    elif "X_UTME" in df.columns:
+        if "POLY_ID" in df.columns:
+            xyz = [gf[["X_UTME", "Y_UTMN"]].values for _, gf in df.groupby("POLY_ID")]
+        else:
+            xyz = df[["X_UTME", "Y_UTMN"]].values
+    else:
+        # Attempt to use the first two columns as the x and y coordinates
+        xyz = df.values[:, :2]
+    if isinstance(xyz, list):
+        poly_type = "MultiPolygon"
+        coords = [[arr.tolist()] for arr in xyz]
+    else:
+        poly_type = "Polygon"
+        coords = [xyz.tolist()]
     as_geojson = {
         "type": "FeatureCollection",
         "features": [
@@ -294,8 +378,8 @@ def _parse_polygon_file(filename: str) -> Dict[str, Any]:
                 "type": "Feature",
                 "properties": {},
                 "geometry": {
-                    "type": "LineString",
-                    "coordinates": xyz.tolist(),
+                    "type": poly_type,
+                    "coordinates": coords,
                 },
             }
         ],

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -318,7 +318,7 @@ def generate_containment_figures(
     table_provider: EnsembleTableProvider,
     co2_scale: Union[Co2MassScale, Co2VolumeScale],
     realization: int,
-    y_limits: List[float],
+    y_limits: List[Optional[float]],
 ) -> Tuple[go.Figure, go.Figure, go.Figure]:
     try:
         fig0 = generate_co2_volume_figure(
@@ -342,7 +342,7 @@ def generate_containment_figures(
 
 def generate_unsmry_figures(
     table_provider_unsmry: EnsembleTableProvider,
-    co2_mass_scale: Co2MassScale,
+    co2_mass_scale: Union[Co2MassScale, Co2VolumeScale],
     table_provider_containment: EnsembleTableProvider,
 ) -> Tuple[go.Figure]:
     return (

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas
@@ -100,7 +100,9 @@ def _read_terminal_co2_volumes(
 
 
 def _read_co2_volumes(
-    table_provider: EnsembleTableProvider, realizations: List[int], scale: Co2MassScale
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    scale: Union[Co2MassScale, Co2VolumeScale],
 ) -> pandas.DataFrame:
     scale_factor = _find_scale_factor(table_provider, scale)
     return pandas.concat(
@@ -111,7 +113,7 @@ def _read_co2_volumes(
     )
 
 
-def _change_type_names(df: pandas.DataFrame):
+def _change_type_names(df: pandas.DataFrame) -> None:
     df["type"] = df["type"].replace("total", "Total")
     df["type"] = df["type"].replace("total_contained", "Contained")
     df["type"] = df["type"].replace("total_outside", "Outside")
@@ -170,7 +172,7 @@ def generate_co2_time_containment_one_realization_figure(
     table_provider: EnsembleTableProvider,
     scale: Union[Co2MassScale, Co2VolumeScale],
     time_series_realization: int,
-    y_limits: List[float],
+    y_limits: List[Optional[float]],
 ) -> go.Figure:
     df = _read_co2_volumes(table_provider, [time_series_realization], scale)
     df.sort_values(by="date", inplace=True)

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/co2volume.py
@@ -1,6 +1,6 @@
 import itertools
 from enum import Enum
-from typing import List
+from typing import Any, Dict, List, Union
 
 import numpy as np
 import pandas
@@ -8,6 +8,10 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 from webviz_subsurface._providers import EnsembleTableProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    Co2MassScale,
+    Co2VolumeScale,
+)
 
 
 class _Columns(Enum):
@@ -17,120 +21,289 @@ class _Columns(Enum):
     VOLUME_OUTSIDE = "volume_outside"
 
 
+_COLOR_TOTAL = "#222222"
+_COLOR_CONTAINED = "#00aa00"
+_COLOR_OUTSIDE = "#006ddd"
+_COLOR_HAZARDOUS = "#dd4300"
+
+
 def _read_dataframe(
-    table_provider: EnsembleTableProvider, realization: int
+    table_provider: EnsembleTableProvider,
+    realization: int,
+    scale_factor: float,
 ) -> pandas.DataFrame:
-    return table_provider.get_column_data(
-        ["date", "co2_inside", "co2_outside"], [realization]
-    )
+    df = table_provider.get_column_data(table_provider.column_names(), [realization])
+    if scale_factor == 1.0:
+        return df
+    else:
+        for col in df.columns:
+            if col != "date":
+                df[col] /= scale_factor
+        return df
+
+
+def _find_scale_factor(
+    table_provider: EnsembleTableProvider,
+    scale: Union[Co2MassScale, Co2VolumeScale],
+) -> float:
+    if scale == Co2MassScale.KG or scale == Co2VolumeScale.CUBIC_METERS:
+        return 1.0
+    elif scale == Co2MassScale.MTONS or scale == Co2VolumeScale.BILLION_CUBIC_METERS:
+        return 1e9
+    elif scale == Co2MassScale.NORMALIZE or scale == Co2VolumeScale.NORMALIZE:
+        df = table_provider.get_column_data(table_provider.column_names())
+        return df["total"].max()
+    else:
+        return 1.0
 
 
 def _read_terminal_co2_volumes(
-    table_provider: EnsembleTableProvider, realizations: List[int]
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    scale: Union[Co2MassScale, Co2VolumeScale],
 ) -> pandas.DataFrame:
-    records = []
+    records: Dict[str, List[Any]] = {
+        "real": [],
+        "amount": [],
+        "containment": [],
+        "phase": [],
+        "sort_key": [],
+        "sort_key_secondary": [],
+    }
+    scale_factor = _find_scale_factor(table_provider, scale)
     for real in realizations:
-        df = _read_dataframe(table_provider, real)
+        df = _read_dataframe(table_provider, real, scale_factor)
         last = df.iloc[np.argmax(df["date"])]
         label = str(real)
-        records += [
-            (label, last["co2_inside"], "inside", 0.0),
-            (label, last["co2_outside"], "outside", last["co2_outside"]),
+        records["real"] += [label] * 6
+        records["amount"] += [
+            last["aqueous_contained"],
+            last["gas_contained"],
+            last["aqueous_outside"],
+            last["gas_outside"],
+            last["aqueous_hazardous"],
+            last["gas_hazardous"],
         ]
-    df = pandas.DataFrame.from_records(
-        records,
-        columns=[
-            _Columns.REALIZATION.value,
-            _Columns.VOLUME.value,
-            _Columns.CONTAINMENT.value,
-            _Columns.VOLUME_OUTSIDE.value,
-        ],
+        records["containment"] += [
+            "contained",
+            "contained",
+            "outside",
+            "outside",
+            "hazardous",
+            "hazardous",
+        ]
+        records["phase"] += ["aqueous", "gas", "aqueous", "gas", "aqueous", "gas"]
+        records["sort_key"] += [last["gas_hazardous"]] * 6
+        records["sort_key_secondary"] += [last["gas_outside"]] * 6
+    df = pandas.DataFrame.from_dict(records)
+    df.sort_values(
+        ["sort_key", "sort_key_secondary"], inplace=True, ascending=[True, True]
     )
-    df.sort_values(_Columns.VOLUME_OUTSIDE.value, inplace=True, ascending=True)
     return df
 
 
 def _read_co2_volumes(
-    table_provider: EnsembleTableProvider, realizations: List[int]
+    table_provider: EnsembleTableProvider, realizations: List[int], scale: Co2MassScale
 ) -> pandas.DataFrame:
+    scale_factor = _find_scale_factor(table_provider, scale)
     return pandas.concat(
         [
-            _read_dataframe(table_provider, real).assign(realization=real)
+            _read_dataframe(table_provider, real, scale_factor).assign(realization=real)
             for real in realizations
         ]
     )
 
 
+def _change_type_names(df: pandas.DataFrame):
+    df["type"] = df["type"].replace("total", "Total")
+    df["type"] = df["type"].replace("total_contained", "Contained")
+    df["type"] = df["type"].replace("total_outside", "Outside")
+    df["type"] = df["type"].replace("total_hazardous", "Hazardous")
+    df["type"] = df["type"].replace("total_gas", "Gas")
+    df["type"] = df["type"].replace("total_aqueous", "Aqueous")
+    df["type"] = df["type"].replace("gas_contained", "Contained mobile gas")
+    df["type"] = df["type"].replace("gas_outside", "Outside mobile gas")
+    df["type"] = df["type"].replace("gas_hazardous", "Hazardous mobile gas")
+    df["type"] = df["type"].replace("aqueous_contained", "Contained aqueous")
+    df["type"] = df["type"].replace("aqueous_outside", "Outside aqueous")
+    df["type"] = df["type"].replace("aqueous_hazardous", "Hazardous aqueous")
+
+
+def _adjust_figure(fig: go.Figure) -> None:
+    fig.layout.title.x = 0.5
+    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
+    fig.layout.margin.b = 6
+    fig.layout.margin.t = 40
+    fig.layout.margin.l = 10
+    fig.layout.margin.r = 10
+
+
 def generate_co2_volume_figure(
     table_provider: EnsembleTableProvider,
     realizations: List[int],
+    scale: Union[Co2MassScale, Co2VolumeScale],
 ) -> go.Figure:
-    df = _read_terminal_co2_volumes(table_provider, realizations)
+    df = _read_terminal_co2_volumes(table_provider, realizations, scale)
     fig = px.bar(
         df,
-        y=_Columns.REALIZATION.value,
-        x=_Columns.VOLUME.value,
-        color=_Columns.CONTAINMENT.value,
-        title="End-state CO2 containment",
+        y="real",
+        x="amount",
+        color="containment",
+        pattern_shape="phase",
+        title="End-state CO<sub>2</sub> containment (all realizations)",
         orientation="h",
-        category_orders={_Columns.CONTAINMENT.value: ["outside", "inside"]},
-        color_discrete_sequence=["#dd4300", "#006ddd"],
+        category_orders={
+            "containment": ["hazardous", "outside", "contained"],
+            "phase": ["gas", "aqueous"],
+        },
+        color_discrete_sequence=[_COLOR_HAZARDOUS, _COLOR_OUTSIDE, _COLOR_CONTAINED],
     )
     fig.layout.legend.title.text = ""
     fig.layout.legend.orientation = "h"
     fig.layout.legend.y = -0.3
+    fig.layout.legend.font = dict(size=8)
     fig.layout.yaxis.title = "Realization"
     fig.layout.xaxis.exponentformat = "power"
-    fig.layout.xaxis.title = "Mass [kg]"
-    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
-    fig.layout.margin.b = 10
-    fig.layout.margin.t = 60
-    fig.layout.margin.l = 10
-    fig.layout.margin.r = 10
+    fig.layout.xaxis.title = scale.value
+    _adjust_figure(fig)
+    return fig
+
+
+def generate_co2_time_containment_one_realization_figure(
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    scale: Union[Co2MassScale, Co2VolumeScale],
+    time_series_realization: int,
+    y_limits: List[float],
+) -> go.Figure:
+    df = _read_co2_volumes(table_provider, [time_series_realization], scale)
+    df.sort_values(by="date", inplace=True)
+    df = df.drop(
+        columns=[
+            "realization",
+            "REAL",
+            "total",
+            "total_contained",
+            "total_outside",
+            "total_hazardous",
+            "total_gas",
+            "total_aqueous",
+        ]
+    )
+    df = pandas.melt(df, id_vars=["date"])
+    df = df.rename(columns={"value": "mass", "variable": "type"})
+    df.sort_values(by="date", inplace=True)
+    _change_type_names(df)
+    if y_limits[0] == None and y_limits[1] != None:
+        y_limits[0] = 0.0
+    elif y_limits[1] == None and y_limits[0] != None:
+        y_limits[1] = max(df.groupby("date")["mass"].sum()) * 1.05
+    fig = px.area(
+        df,
+        x="date",
+        y="mass",
+        color="type",
+        category_orders={
+            "type": [
+                "Hazardous mobile gas",
+                "Hazardous aqueous",
+                "Outside mobile gas",
+                "Outside aqueous",
+                "Contained mobile gas",
+                "Contained aqueous",
+            ]
+        },
+        color_discrete_sequence=[
+            _COLOR_HAZARDOUS,
+            _COLOR_HAZARDOUS,
+            _COLOR_OUTSIDE,
+            _COLOR_OUTSIDE,
+            _COLOR_CONTAINED,
+            _COLOR_CONTAINED,
+        ],
+        pattern_shape="type",
+        pattern_shape_sequence=[
+            "",
+            "/",
+            "",
+            "/",
+            "",
+            "/",
+        ],  # ['', '/', '\\', 'x', '-', '|', '+', '.'],
+        range_y=y_limits,
+    )
+    fig.layout.yaxis.range = y_limits
+    fig.layout.legend.orientation = "h"
+    fig.layout.legend.title.text = ""
+    fig.layout.legend.y = -0.3
+    fig.layout.legend.font = dict(size=8)
+    fig.layout.title = "CO<sub>2</sub> containment for realization: " + str(
+        time_series_realization
+    )
+    fig.layout.xaxis.title = "Time"
+    fig.layout.yaxis.title = scale.value
+    _adjust_figure(fig)
     return fig
 
 
 def generate_co2_time_containment_figure(
     table_provider: EnsembleTableProvider,
     realizations: List[int],
+    scale: Union[Co2MassScale, Co2VolumeScale],
 ) -> go.Figure:
-    df = _read_co2_volumes(table_provider, realizations)
+    df = _read_co2_volumes(table_provider, realizations, scale)
     df.sort_values(by="date", inplace=True)
-    df["date"] = df["date"].astype(str)
-    dates = df["date"].str[:4] + "-" + df["date"].str[4:6] + "-" + df["date"].str[6:]
-    df["dt"] = dates
-    df["co2_total"] = df["co2_inside"] + df["co2_outside"]
     fig = go.Figure()
     colors = px.colors.qualitative.Plotly
+    cols_to_plot = {
+        "Total": ("total", "solid", _COLOR_TOTAL),
+        "Contained": ("total_contained", "solid", _COLOR_CONTAINED),
+        "Outside": ("total_outside", "solid", _COLOR_OUTSIDE),
+        "Hazardous": ("total_hazardous", "solid", _COLOR_HAZARDOUS),
+        "Gas": ("total_gas", "dot", _COLOR_TOTAL),
+        "Aqueous": ("total_aqueous", "dash", _COLOR_TOTAL),
+        "Contained mobile gas": ("gas_contained", "dot", _COLOR_CONTAINED),
+        "Outside mobile gas": ("gas_outside", "dot", _COLOR_OUTSIDE),
+        "Hazardous mobile gas": ("gas_hazardous", "dot", _COLOR_HAZARDOUS),
+        "Contained aqueous": ("aqueous_contained", "dash", _COLOR_CONTAINED),
+        "Outside aqueous": ("aqueous_outside", "dash", _COLOR_OUTSIDE),
+        "Hazardous aqueous": ("aqueous_hazardous", "dash", _COLOR_HAZARDOUS),
+    }
+    active_cols_at_startup = ["Total", "Outside", "Hazardous"]
     # Generate dummy scatters for legend entries
-    outside_args = dict(line_dash="dot", legendgroup="Outside", name="Outside")
-    total_args = dict(legendgroup="Total", name="Total")
-    dummy_args = dict(mode="lines", marker_color="black", hoverinfo="none")
-    fig.add_scatter(y=[0.0], **dummy_args, **outside_args)
-    fig.add_scatter(y=[0.0], **dummy_args, **total_args)
+    dummy_args = dict(mode="lines", hoverinfo="none")  # , marker_color="black"
+    for col, value in cols_to_plot.items():
+        args = dict(
+            line_dash=value[1], marker_color=value[2], legendgroup=col, name=col
+        )
+        if col not in active_cols_at_startup:
+            args["visible"] = "legendonly"
+        fig.add_scatter(y=[0.0], **dummy_args, **args)
     for rlz, color in zip(realizations, itertools.cycle(colors)):
         sub_df = df[df["realization"] == rlz]
         common_args = dict(
-            x=sub_df["dt"],
+            x=sub_df["date"],
             hovertemplate="%{x}: %{y}<br>Realization: %{meta[0]}",
-            meta=[rlz],
-            marker_color=color,
+            meta=[rlz],  # marker_color=color,
             showlegend=False,
         )
-        fig.add_scatter(y=sub_df["co2_outside"], **outside_args, **common_args)
-        fig.add_scatter(y=sub_df["co2_total"], **total_args, **common_args)
+        for col, value in cols_to_plot.items():
+            args = dict(
+                line_dash=value[1], marker_color=value[2], legendgroup=col, name=col
+            )
+            if col not in active_cols_at_startup:
+                args["visible"] = "legendonly"
+            fig.add_scatter(y=sub_df[value[0]], **args, **common_args)
     fig.layout.legend.orientation = "h"
     fig.layout.legend.title.text = ""
-    fig.layout.legend.yanchor = "bottom"
-    fig.layout.legend.y = 1.02
-    fig.layout.legend.xanchor = "right"
-    fig.layout.legend.x = 1
-    fig.layout.xaxis.title = "Time (date)"
-    fig.layout.yaxis.title = "Mass [kg]"
-    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
-    fig.layout.margin.b = 10
-    fig.layout.margin.t = 60
-    fig.layout.margin.l = 10
-    fig.layout.margin.r = 10
-    fig.layout.yaxis.range = (0, 1.05 * df["co2_total"].max())
+    fig.layout.legend.y = -0.3
+    fig.layout.legend.font = dict(size=8)
+    fig.layout.legend.tracegroupgap = 0
+    fig.layout.title = "CO<sub>2</sub> containment (all realizations)"
+    fig.layout.xaxis.title = "Time"
+    fig.layout.yaxis.title = scale.value
+    fig.layout.yaxis.exponentformat = "none"
+    fig.layout.yaxis.range = (0, 1.05 * df["total"].max())  # Change this ?
+    _adjust_figure(fig)
+    # fig.update_layout(legend=dict(font=dict(size=8)), legend_tracegroupgap=0)
     return fig

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/color_tables.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/color_tables.py
@@ -79,7 +79,8 @@ def _reversed_color_tables(tables: ColorTables) -> ColorTables:
         _new_t = copy.deepcopy(_t)
         _new_t["name"] = _t["name"] + " (Reverse)"
         _new_t["colors"] = [
-            [c0[0]] + c1[1:] for c0, c1 in zip(_t["colors"], _t["colors"][::-1])
+            tuple([c0[0]] + list(c1[1:]))
+            for c0, c1 in zip(_t["colors"], _t["colors"][::-1])
         ]
         rev.append(_new_t)
     return rev

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from webviz_config.utils import StrEnum
+
 
 class MapAttribute(Enum):
     MIGRATION_TIME = "Migration Time"
@@ -7,3 +9,22 @@ class MapAttribute(Enum):
     MAX_AMFG = "Maximum AMFG"
     SGAS_PLUME = "Plume (SGAS)"
     AMFG_PLUME = "Plume (AMFG)"
+
+
+class Co2MassScale(StrEnum):
+    NORMALIZE = "Fraction"
+    MTONS = "M tons"
+    KG = "Kg"
+
+
+class Co2VolumeScale(StrEnum):
+    NORMALIZE = "Fraction"
+    BILLION_CUBIC_METERS = "Cubic kms"
+    CUBIC_METERS = "Cubic meters"
+
+
+class GraphSource(StrEnum):
+    UNSMRY = "UNSMRY"
+    CONTAINMENT_MASS = "Containment Data (mass)"
+    CONTAINMENT_VOLUME_ACTUAL = "Containment Data (volume, actual)"
+    CONTAINMENT_VOLUME_ACTUAL_SIMPLE = "Containment Data (volume, actual_simple)"

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
@@ -1,0 +1,232 @@
+import dataclasses
+from typing import Iterable, List
+
+import pandas as pd
+import numpy as np
+import plotly.colors
+import plotly.graph_objects as go
+
+from webviz_subsurface._providers import EnsembleTableProvider
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2MassScale
+
+
+def generate_summary_figure(
+    table_provider_unsmry: EnsembleTableProvider,
+    realizations_unsmry: List[int],
+    scale: Co2MassScale,
+    table_provider_containment: EnsembleTableProvider,
+    realizations_containment: List[int],
+) -> go.Figure:
+    columns_unsmry = _column_subset_unsmry(table_provider_unsmry)
+    columns_containment = _column_subset_containment(table_provider_containment)
+    df_unsmry = _read_dataframe(
+        table_provider_unsmry, realizations_unsmry, columns_unsmry, scale
+    )
+    df_containment = _read_dataframe_containment(
+        table_provider_containment, realizations_containment, columns_containment, scale
+    )
+    fig = go.Figure()
+    showlegend = True
+
+    r = min(df_unsmry.REAL)
+    unsmry_last_total = df_unsmry[df_unsmry.REAL == r]["total"].iloc[-1]
+    unsmry_last_mobile = df_unsmry[df_unsmry.REAL == r][columns_unsmry.mobile].iloc[-1]
+    unsmry_last_dissolved = df_unsmry[df_unsmry.REAL == r][
+        columns_unsmry.dissolved
+    ].iloc[-1]
+    containment_last_total = df_containment[df_containment.REAL == r]["total"].iloc[-1]
+    containment_last_mobile = df_containment[df_containment.REAL == r][
+        columns_containment.mobile
+    ].iloc[-1]
+    containment_last_dissolved = df_containment[df_containment.REAL == r][
+        columns_containment.dissolved
+    ].iloc[-1]
+    last_total_err_percentage = (
+        100.0 * abs(containment_last_total - unsmry_last_total) / unsmry_last_total
+    )
+    last_mobile_err_percentage = (
+        100.0 * abs(containment_last_mobile - unsmry_last_mobile) / unsmry_last_mobile
+    )
+    last_dissolved_err_percentage = (
+        100.0
+        * abs(containment_last_dissolved - unsmry_last_dissolved)
+        / unsmry_last_dissolved
+    )
+    last_total_err_percentage = np.round(last_total_err_percentage, 2)
+    last_mobile_err_percentage = np.round(last_mobile_err_percentage, 2)
+    last_dissolved_err_percentage = np.round(last_dissolved_err_percentage, 2)
+
+    for _, sub_df in df_unsmry.groupby("realization"):
+        colors = plotly.colors.qualitative.Plotly
+        fig.add_scatter(
+            x=sub_df[columns_unsmry.time],
+            y=sub_df["total"],
+            name="UNSMRY",
+            legendgroup="group_1",
+            legendgrouptitle_text="Total ({} %)".format(last_total_err_percentage),
+            showlegend=showlegend,
+            marker_color=colors[3],
+        )
+        fig.add_scatter(
+            x=sub_df[columns_unsmry.time],
+            y=sub_df[columns_unsmry.mobile],
+            name=f"UNSMRY ({columns_unsmry.mobile})",
+            legendgroup="group_2",
+            legendgrouptitle_text="Mobile ({} %)".format(last_mobile_err_percentage),
+            showlegend=showlegend,
+            marker_color=colors[2],
+        )
+        fig.add_scatter(
+            x=sub_df[columns_unsmry.time],
+            y=sub_df[columns_unsmry.dissolved],
+            name=f"UNSMRY ({columns_unsmry.dissolved})",
+            legendgroup="group_3",
+            legendgrouptitle_text="Dissolved ({} %)".format(
+                last_dissolved_err_percentage
+            ),
+            showlegend=showlegend,
+            marker_color=colors[0],
+        )
+        fig.add_scatter(
+            x=sub_df[columns_unsmry.time],
+            y=sub_df[columns_unsmry.trapped],
+            name=f"UNSMRY ({columns_unsmry.trapped})",
+            legendgroup="group_4",
+            legendgrouptitle_text="Trapped",
+            showlegend=showlegend,
+            marker_color=colors[1],
+        )
+        showlegend = False
+    showlegend = True
+    for _, sub_df in df_containment.groupby("realization"):
+        colors = plotly.colors.qualitative.Plotly
+        fig.add_scatter(
+            x=sub_df[columns_containment.time],
+            y=sub_df["total"],
+            name="Containment script",
+            legendgroup="group_1",
+            showlegend=showlegend,
+            marker_color=colors[3],
+            line_dash="dash",
+        )
+        fig.add_scatter(
+            x=sub_df[columns_containment.time],
+            y=sub_df[columns_containment.mobile],
+            name=f"Containment script ({columns_containment.mobile})",
+            legendgroup="group_2",
+            showlegend=showlegend,
+            marker_color=colors[2],
+            line_dash="dash",
+        )
+        fig.add_scatter(
+            x=sub_df[columns_containment.time],
+            y=sub_df[columns_containment.dissolved],
+            name=f"Containment script ({columns_containment.dissolved})",
+            legendgroup="group_3",
+            showlegend=showlegend,
+            marker_color=colors[0],
+            line_dash="dash",
+        )
+        showlegend = False
+    fig.layout.xaxis.title = "Time"
+    fig.layout.yaxis.title = f"Amount CO2 [{scale.value}]"
+    fig.layout.paper_bgcolor = "rgba(0,0,0,0)"
+    fig.layout.margin.b = 10
+    fig.layout.margin.t = 60
+    fig.layout.margin.l = 10
+    fig.layout.margin.r = 10
+    return fig
+
+
+@dataclasses.dataclass
+class _ColumnNames:
+    time: str
+    dissolved: str
+    trapped: str
+    mobile: str
+
+    def values(self) -> Iterable[str]:
+        return dataclasses.asdict(self).values()
+
+
+@dataclasses.dataclass
+class _ColumnNamesContainment:
+    time: str
+    dissolved: str
+    mobile: str
+
+    def values(self) -> Iterable[str]:
+        return dataclasses.asdict(self).values()
+
+
+def _read_dataframe(
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    columns: _ColumnNames,
+    co2_scale: Co2MassScale,
+) -> pd.DataFrame:
+    full = pd.concat(
+        [
+            table_provider.get_column_data(list(columns.values()), [real]).assign(
+                realization=real
+            )
+            for real in realizations
+        ]
+    )
+    full["total"] = (
+        full[columns.dissolved] + full[columns.trapped] + full[columns.mobile]
+    )
+    for col in [columns.dissolved, columns.trapped, columns.mobile, "total"]:
+        if co2_scale == Co2MassScale.MTONS:
+            full[col] = full[col] / 1e9
+        elif co2_scale == Co2MassScale.NORMALIZE:
+            full[col] = full[col] / full["total"].max()
+    return full
+
+
+def _read_dataframe_containment(
+    table_provider: EnsembleTableProvider,
+    realizations: List[int],
+    columns: _ColumnNamesContainment,
+    co2_scale: Co2MassScale,
+) -> pd.DataFrame:
+    full = pd.concat(
+        [
+            table_provider.get_column_data(list(columns.values()), [real]).assign(
+                realization=real
+            )
+            for real in realizations
+        ]
+    )
+    full["total"] = full[columns.dissolved] + full[columns.mobile]
+    for col in [columns.dissolved, columns.mobile, "total"]:
+        if co2_scale == Co2MassScale.MTONS:
+            full[col] = full[col] / 1e9
+        elif co2_scale == Co2MassScale.NORMALIZE:
+            full[col] = full[col] / full["total"].max()
+    return full
+
+
+def _column_subset_unsmry(table_provider: EnsembleTableProvider) -> _ColumnNames:
+    existing = set(table_provider.column_names())
+    assert "DATE" in existing
+    # Try PFLOTRAN names
+    col_names = _ColumnNames("DATE", "FGMDS", "FGMTR", "FGMGP")
+    if set(col_names.values()).issubset(existing):
+        return col_names
+    # Try Eclipse names
+    col_names = _ColumnNames("DATE", "FWCD", "FGCDI", "FGCDM")
+    if set(col_names.values()).issubset(existing):
+        return col_names
+    raise KeyError(f"Could not find suitable data columns among: {', '.join(existing)}")
+
+
+def _column_subset_containment(
+    table_provider: EnsembleTableProvider,
+) -> _ColumnNamesContainment:
+    existing = set(table_provider.column_names())
+    assert "date" in existing
+    col_names = _ColumnNamesContainment("date", "total_aqueous", "total_gas")
+    if set(col_names.values()).issubset(existing):
+        return col_names
+    raise KeyError(f"Could not find suitable data columns among: {', '.join(existing)}")

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Iterable, List
+from typing import Iterable, List, Union
 
 import numpy as np
 import pandas as pd
@@ -7,14 +7,17 @@ import plotly.colors
 import plotly.graph_objects as go
 
 from webviz_subsurface._providers import EnsembleTableProvider
-from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2MassScale
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    Co2MassScale,
+    Co2VolumeScale,
+)
 
 
 # pylint: disable=too-many-locals
 def generate_summary_figure(
     table_provider_unsmry: EnsembleTableProvider,
     realizations_unsmry: List[int],
-    scale: Co2MassScale,
+    scale: Union[Co2MassScale, Co2VolumeScale],
     table_provider_containment: EnsembleTableProvider,
     realizations_containment: List[int],
 ) -> go.Figure:
@@ -166,7 +169,7 @@ def _read_dataframe(
     table_provider: EnsembleTableProvider,
     realizations: List[int],
     columns: _ColumnNames,
-    co2_scale: Co2MassScale,
+    co2_scale: Union[Co2MassScale, Co2VolumeScale],
 ) -> pd.DataFrame:
     full = pd.concat(
         [
@@ -191,7 +194,7 @@ def _read_dataframe_containment(
     table_provider: EnsembleTableProvider,
     realizations: List[int],
     columns: _ColumnNamesContainment,
-    co2_scale: Co2MassScale,
+    co2_scale: Union[Co2MassScale, Co2VolumeScale],
 ) -> pd.DataFrame:
     full = pd.concat(
         [

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
@@ -10,6 +10,7 @@ from webviz_subsurface._providers import EnsembleTableProvider
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import Co2MassScale
 
 
+# pylint: disable=too-many-locals
 def generate_summary_figure(
     table_provider_unsmry: EnsembleTableProvider,
     realizations_unsmry: List[int],
@@ -28,17 +29,21 @@ def generate_summary_figure(
     fig = go.Figure()
     showlegend = True
 
-    r = min(df_unsmry.REAL)
-    unsmry_last_total = df_unsmry[df_unsmry.REAL == r]["total"].iloc[-1]
-    unsmry_last_mobile = df_unsmry[df_unsmry.REAL == r][columns_unsmry.mobile].iloc[-1]
-    unsmry_last_dissolved = df_unsmry[df_unsmry.REAL == r][
+    r_min = min(df_unsmry.REAL)
+    unsmry_last_total = df_unsmry[df_unsmry.REAL == r_min]["total"].iloc[-1]
+    unsmry_last_mobile = df_unsmry[df_unsmry.REAL == r_min][columns_unsmry.mobile].iloc[
+        -1
+    ]
+    unsmry_last_dissolved = df_unsmry[df_unsmry.REAL == r_min][
         columns_unsmry.dissolved
     ].iloc[-1]
-    containment_last_total = df_containment[df_containment.REAL == r]["total"].iloc[-1]
-    containment_last_mobile = df_containment[df_containment.REAL == r][
+    containment_last_total = df_containment[df_containment.REAL == r_min]["total"].iloc[
+        -1
+    ]
+    containment_last_mobile = df_containment[df_containment.REAL == r_min][
         columns_containment.mobile
     ].iloc[-1]
-    containment_last_dissolved = df_containment[df_containment.REAL == r][
+    containment_last_dissolved = df_containment[df_containment.REAL == r_min][
         columns_containment.dissolved
     ].iloc[-1]
     last_total_err_percentage = (
@@ -63,7 +68,7 @@ def generate_summary_figure(
             y=sub_df["total"],
             name="UNSMRY",
             legendgroup="group_1",
-            legendgrouptitle_text="Total ({} %)".format(last_total_err_percentage),
+            legendgrouptitle_text=f"Total ({last_total_err_percentage} %)",
             showlegend=showlegend,
             marker_color=colors[3],
         )
@@ -72,7 +77,7 @@ def generate_summary_figure(
             y=sub_df[columns_unsmry.mobile],
             name=f"UNSMRY ({columns_unsmry.mobile})",
             legendgroup="group_2",
-            legendgrouptitle_text="Mobile ({} %)".format(last_mobile_err_percentage),
+            legendgrouptitle_text=f"Mobile ({last_mobile_err_percentage} %)",
             showlegend=showlegend,
             marker_color=colors[2],
         )
@@ -81,9 +86,7 @@ def generate_summary_figure(
             y=sub_df[columns_unsmry.dissolved],
             name=f"UNSMRY ({columns_unsmry.dissolved})",
             legendgroup="group_3",
-            legendgrouptitle_text="Dissolved ({} %)".format(
-                last_dissolved_err_percentage
-            ),
+            legendgrouptitle_text=f"Dissolved ({last_dissolved_err_percentage} %)",
             showlegend=showlegend,
             marker_color=colors[0],
         )

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/summary_graphs.py
@@ -1,8 +1,8 @@
 import dataclasses
 from typing import Iterable, List
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import plotly.colors
 import plotly.graph_objects as go
 

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/mainview.py
@@ -26,6 +26,7 @@ class MapViewElement(ViewElementABC):
         DATE_WRAPPER = "date-wrapper"
         BAR_PLOT = "bar-plot"
         TIME_PLOT = "time-plot"
+        TIME_PLOT_ONE_REAL = "time-plot-one-realization"
 
     def __init__(self, color_scales: List[Dict[str, Any]]) -> None:
         super().__init__()
@@ -82,10 +83,11 @@ class MapViewElement(ViewElementABC):
                         "flexDirection": "row",
                         "justifyContent": "space-evenly",
                     },
-                    children=SummaryGraphLayout(
+                    children=_summary_graph_layout(
                         self.register_component_unique_id(self.Ids.BAR_PLOT),
                         self.register_component_unique_id(self.Ids.TIME_PLOT),
-                    ).children,
+                        self.register_component_unique_id(self.Ids.TIME_PLOT_ONE_REAL),
+                    ),
                 ),
             ],
             style={
@@ -96,24 +98,31 @@ class MapViewElement(ViewElementABC):
         )
 
 
-class SummaryGraphLayout(html.Div):
-    def __init__(self, bar_plot_id: str, time_plot_id: str, **kwargs: Dict) -> None:
-        super().__init__(
-            children=[
-                wcc.Graph(
-                    id=bar_plot_id,
-                    figure=go.Figure(),
-                    config={
-                        "displayModeBar": False,
-                    },
-                ),
-                wcc.Graph(
-                    id=time_plot_id,
-                    figure=go.Figure(),
-                    config={
-                        "displayModeBar": False,
-                    },
-                ),
-            ],
-            **kwargs,
-        )
+def _summary_graph_layout(
+    bar_plot_id: str,
+    time_plot_id: str,
+    time_plot_one_realization_id: str,
+) -> List:
+    return [
+        wcc.Graph(
+            id=bar_plot_id,
+            figure=go.Figure(),
+            config={
+                "displayModeBar": False,
+            },
+        ),
+        wcc.Graph(
+            id=time_plot_id,
+            figure=go.Figure(),
+            config={
+                "displayModeBar": False,
+            },
+        ),
+        wcc.Graph(
+            id=time_plot_one_realization_id,
+            figure=go.Figure(),
+            config={
+                "displayModeBar": False,
+            },
+        ),
+    ]

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -12,7 +12,11 @@ from webviz_subsurface._providers.ensemble_surface_provider.ensemble_surface_pro
     SurfaceStatistic,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import property_origin
-from webviz_subsurface.plugins._co2_leakage._utilities.generic import MapAttribute
+from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
+    Co2MassScale,
+    GraphSource,
+    MapAttribute,
+)
 
 
 class ViewSettings(SettingsGroupABC):
@@ -28,6 +32,13 @@ class ViewSettings(SettingsGroupABC):
         CM_MAX = "cm-max"
         CM_MIN_AUTO = "cm-min-auto"
         CM_MAX_AUTO = "cm-max-auto"
+
+        GRAPH_SOURCE = "graph-source"
+        CO2_SCALE = "co2-scale"
+        Y_MIN_GRAPH = "y-min-graph"
+        Y_MAX_GRAPH = "y-max-graph"
+        Y_MIN_AUTO_GRAPH = "y-min-auto-graph"
+        Y_MAX_AUTO_GRAPH = "y-max-auto-graph"
 
         PLUME_THRESHOLD = "plume-threshold"
         PLUME_SMOOTHING = "plume-smoothing"
@@ -64,6 +75,14 @@ class ViewSettings(SettingsGroupABC):
                 self.register_component_unique_id(self.Ids.CM_MAX),
                 self.register_component_unique_id(self.Ids.CM_MIN_AUTO),
                 self.register_component_unique_id(self.Ids.CM_MAX_AUTO),
+            ),
+            GraphSelectorsLayout(
+                self.register_component_unique_id(self.Ids.GRAPH_SOURCE),
+                self.register_component_unique_id(self.Ids.CO2_SCALE),
+                self.register_component_unique_id(self.Ids.Y_MIN_GRAPH),
+                self.register_component_unique_id(self.Ids.Y_MAX_GRAPH),
+                self.register_component_unique_id(self.Ids.Y_MIN_AUTO_GRAPH),
+                self.register_component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH),
             ),
             ExperimentalFeaturesLayout(
                 self.register_component_unique_id(self.Ids.PLUME_THRESHOLD),
@@ -136,6 +155,25 @@ class ViewSettings(SettingsGroupABC):
             Output(self.component_unique_id(self.Ids.CM_MAX).to_string(), "disabled"),
             Input(self.component_unique_id(self.Ids.CM_MIN_AUTO).to_string(), "value"),
             Input(self.component_unique_id(self.Ids.CM_MAX_AUTO).to_string(), "value"),
+        )
+        def set_color_range_data(
+            min_auto: List[str], max_auto: List[str]
+        ) -> Tuple[bool, bool]:
+            return len(min_auto) == 1, len(max_auto) == 1
+
+        @callback(
+            Output(
+                self.component_unique_id(self.Ids.Y_MIN_GRAPH).to_string(), "disabled"
+            ),
+            Output(
+                self.component_unique_id(self.Ids.Y_MAX_GRAPH).to_string(), "disabled"
+            ),
+            Input(
+                self.component_unique_id(self.Ids.Y_MIN_AUTO_GRAPH).to_string(), "value"
+            ),
+            Input(
+                self.component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH).to_string(), "value"
+            ),
         )
         def set_color_range_data(
             min_auto: List[str], max_auto: List[str]
@@ -235,6 +273,67 @@ class MapSelectorLayout(wcc.Selectors):
                         ),
                     ],
                 )
+            ],
+        )
+
+
+class GraphSelectorsLayout(wcc.Selectors):
+    _CM_RANGE = {
+        "display": "flex",
+        "flexDirection": "row",
+    }
+
+    def __init__(
+        self,
+        graph_source_id: str,
+        co2_scale_id: str,
+        y_min_id: str,
+        y_max_id: str,
+        y_min_auto_id: str,
+        y_max_auto_id: str,
+    ):
+        super().__init__(
+            label="Graph Settings",
+            open_details=False,
+            children=[
+                "Source",
+                wcc.Dropdown(
+                    id=graph_source_id,
+                    options=list(GraphSource),
+                    value=GraphSource.CONTAINMENT_MASS,
+                    clearable=False,
+                ),
+                "Unit",
+                wcc.Dropdown(
+                    id=co2_scale_id,
+                    options=list(Co2MassScale),
+                    value=Co2MassScale.MTONS,
+                    clearable=False,
+                ),
+                "Minimum",
+                html.Div(
+                    [
+                        dcc.Input(id=y_min_id, type="number"),
+                        dcc.Checklist(
+                            ["Auto"],
+                            ["Auto"],
+                            id=y_min_auto_id,
+                        ),
+                    ],
+                    style=self._CM_RANGE,
+                ),
+                "Maximum",
+                html.Div(
+                    [
+                        dcc.Input(id=y_max_id, type="number"),
+                        dcc.Checklist(
+                            ["Auto"],
+                            ["Auto"],
+                            id=y_max_auto_id,
+                        ),
+                    ],
+                    style=self._CM_RANGE,
+                ),
             ],
         )
 

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -175,7 +175,7 @@ class ViewSettings(SettingsGroupABC):
                 self.component_unique_id(self.Ids.Y_MAX_AUTO_GRAPH).to_string(), "value"
             ),
         )
-        def set_color_range_data(
+        def set_y_min_max(
             min_auto: List[str], max_auto: List[str]
         ) -> Tuple[bool, bool]:
             return len(min_auto) == 1, len(max_auto) == 1
@@ -388,7 +388,7 @@ class EnsembleSelectorLayout(wcc.Selectors):
                 "Ensemble",
                 wcc.Dropdown(
                     id=ensemble_id,
-                    options=[dict(value=en, label=en) for en in ensembles],
+                    options=[{"value": en, "label": en} for en in ensembles],
                     value=ensembles[0],
                     clearable=False,
                 ),


### PR DESCRIPTION
The script generating CO2 containment data was updated and this commit ensures that the new format is read and presented properly. This includes:
- Hide the plots if the data fails to load or is missing
- CO2 amounts can be scaled to Mtons/fraction
- Updated default 'map_attributes_names' to be consistent with recent changes in xtgeoapp_grd3dmaps
- Parsing and visualization of boundary polygon has been improved
- New "UNSMRY" plot aimed to show unified summary data from Pflotran or Eclipse
- Support for visualizing multi polygon boundary files

Other improvements:
- Added option of hazardous polygon. This creates a new category "hazardous" in the containment plots (colored red). Changed color of "outside" from red to blue and color of "inside" from blue to green.
- Removed mobile gas plot
- Added a plot showing the contained co2 for a particular realization
- Add containment plots to UNSMRY-graph, plus numerical values for differences
- Add two volume types to options in Graph Settings: Source. This will use volume data (instead of mass), if available.
- Change how fraction/normalization is used as unit, divide by the maximum value across all realizations, instead of scaling each realization independently.
- Various minor visual changes, plot titles etc

Note: This PR includes all changes made in the unmerged PR #1187 , as well as changes made after this.

![2023_06_21_picture_for_PR](https://github.com/equinor/webviz-subsurface/assets/99661468/35c1c13e-119b-4b9c-b7f5-40a5343148ce)

