### PR TITLE
Add filter linking in `SimulationTimeseriesOneByOne`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Added
+- [#1227](https://github.com/equinor/webviz-subsurface/pull/1227) - New functionality in `SimulationTimeSeriesOneByOne`: option to use the sensitivity filter on all visualisations, not only the timeseries.
+
+## [0.2.20] - 2023-06-26
+
+### Added
 - [#1217](https://github.com/equinor/webviz-subsurface/pull/1217) - New plugin `SimulationTimeSeriesOneByOne`, meant to replace the old `ReservoirSimulationTimeSeriesOneByOne`. Uses the `.arrow` summary provider and is implemented with WLF (Webviz Layout Framework).
 
 ### Fixed

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_utils/_simulation_time_series_onebyone_datamodel.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_utils/_simulation_time_series_onebyone_datamodel.py
@@ -148,6 +148,12 @@ class SimulationTimeSeriesOneByOneDataModel:
             return "rms_seed"
         return sensitivities[0]
 
+    @staticmethod
+    def get_realizations_for_sensitivies(
+        sens_df: pd.DataFrame, sensitivities: List[str]
+    ) -> List[int]:
+        return list(sens_df[sens_df["SENSNAME"].isin(sensitivities)]["REAL"].unique())
+
     def create_tornado_figure(
         self,
         tornado_data: TornadoData,

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_settings/_sensitivity_filter.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_settings/_sensitivity_filter.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import webviz_core_components as wcc
+from dash import html
 from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
@@ -9,6 +10,7 @@ from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 class SensitivityFilter(SettingsGroupABC):
     class Ids(StrEnum):
         SENSITIVITY_FILTER = "sensitivity-filter"
+        SENSITIVITY_FILTER_LINK = "sensitivity-filter-link"
 
     def __init__(self, sensitivities: List[str]) -> None:
         super().__init__("Sensitivity Filter")
@@ -16,10 +18,27 @@ class SensitivityFilter(SettingsGroupABC):
 
     def layout(self) -> List[Component]:
         return [
+            html.Div(
+                style={"margin-bottom": "10px"},
+                children=[
+                    wcc.Checklist(
+                        id=self.register_component_unique_id(
+                            self.Ids.SENSITIVITY_FILTER_LINK
+                        ),
+                        options=[
+                            {
+                                "label": "Apply filter only on timeseries",
+                                "value": "no link",
+                            }
+                        ],
+                        value=[],
+                    ),
+                ],
+            ),
             wcc.SelectWithLabel(
                 id=self.register_component_unique_id(self.Ids.SENSITIVITY_FILTER),
                 options=[{"label": i, "value": i} for i in self._sensitivities],
                 value=self._sensitivities,
                 size=min(20, len(self._sensitivities)),
-            )
+            ),
         ]


### PR DESCRIPTION
PR that adds the option to use the sensitivity filter on all elements or only the timeseries graph in the `SimulationTimeseriesOneByOne` plugin.
- deafault behaviour is set to use the filter across all visualisations

Solves #1224

![image](https://github.com/equinor/webviz-subsurface/assets/61694854/a5fde524-b2de-4a0d-92e6-e8e633824a92)


