### PR TITLE
QC Data view in `RftPlotter`

### DIFF
--- a/webviz_subsurface/plugins/_rft_plotter/_plugin.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_plugin.py
@@ -8,8 +8,8 @@ from ._utils._rft_plotter_data_model import RftPlotterDataModel
 from ._views._map_view import MapView
 from ._views._misfit_per_real_view import MisfitPerRealView
 from ._views._parameter_response_view import ParameterResponseView
-from ._views._sim_vs_obs_view import SimVsObsView
 from ._views._qc_view import QCView
+from ._views._sim_vs_obs_view import SimVsObsView
 
 
 class RftPlotter(WebvizPluginABC):

--- a/webviz_subsurface/plugins/_rft_plotter/_plugin.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_plugin.py
@@ -9,6 +9,7 @@ from ._views._map_view import MapView
 from ._views._misfit_per_real_view import MisfitPerRealView
 from ._views._parameter_response_view import ParameterResponseView
 from ._views._sim_vs_obs_view import SimVsObsView
+from ._views._qc_view import QCView
 
 
 class RftPlotter(WebvizPluginABC):
@@ -96,6 +97,7 @@ forward_models.html?highlight=gendata_rft#MERGE_RFT_ERTOBS).
         MISFIT_PER_REAL_VIEW = "misfit-per-real-view"
         SIM_VS_OBS_VIEW = "sim-vs-obs-view"
         PARAMETER_RESPONSE_VIEW = "parameter-response-view"
+        QC_VIEW = "qc-view"
 
     def __init__(
         self,
@@ -125,6 +127,7 @@ forward_models.html?highlight=gendata_rft#MERGE_RFT_ERTOBS).
         self.add_view(
             ParameterResponseView(self._datamodel), self.Ids.PARAMETER_RESPONSE_VIEW
         )
+        self.add_view(QCView(self._datamodel), self.Ids.QC_VIEW)
 
     def add_webvizstore(self) -> List[Tuple[Callable, List[Dict]]]:
         return self._datamodel.webviz_store

--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
@@ -121,6 +121,13 @@ class RftPlotterDataModel:
             lambda x: list(self.ertdatadf["DATE"].unique()).index(x)
         )
         self.date_marks = self.set_date_marks()
+        self.ertdatadf_inactive = filter_frame(
+            self.ertdatadf,
+            {
+                "ACTIVE": 0,
+            },
+        )
+
         self.ertdatadf = filter_frame(
             self.ertdatadf,
             {

--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
@@ -92,21 +92,19 @@ class RftPlotterDataModel:
                     "(share/results/tables/rft_ert.csv) not found!"
                 ) from exc
 
+        self.ertdatadf.columns = self.ertdatadf.columns.str.upper()
         self.ertdatadf = self.ertdatadf.rename(
             columns={
-                "time": "DATE",
-                "is_active": "ACTIVE",
-                "isactive": "ACTIVE",
-                "well": "WELL",
-                "zone": "ZONE",
-                "pressure": "SIMULATED",
-                "true_vertical_depth": "TVD",
-                "measured_depth": "MD",
-                "observed": "OBSERVED",
-                "obs": "OBSERVED",
-                "error": "OBSERVED_ERR",
-                "utm_x": "EAST",
-                "utm_y": "NORTH",
+                "TIME": "DATE",
+                "IS_ACTIVE": "ACTIVE",
+                "ISACTIVE": "ACTIVE",
+                "PRESSURE": "SIMULATED",
+                "TRUE_VERTICAL_DEPTH": "TVD",
+                "MEASURED_DEPTH": "MD",
+                "OBS": "OBSERVED",
+                "ERROR": "OBSERVED_ERR",
+                "UTM_X": "EAST",
+                "UTM_Y": "NORTH",
             }
         )
         self.ertdatadf["DIFF"] = (

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/__init__.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/__init__.py
@@ -1,0 +1,1 @@
+from ._view import QCView

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_settings.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_settings.py
@@ -10,6 +10,7 @@ class QCSettings(SettingsGroupABC):
     class Ids(StrEnum):
         ENSEMBLE = "ensemble"
         COLUMNS = "columns"
+        ONLY_INACTIVE = "only-inactive"
 
     def __init__(self, ensembles: List[str], columns: List[str]) -> None:
         super().__init__("Settings")
@@ -49,5 +50,15 @@ class QCSettings(SettingsGroupABC):
                 options=[{"label": name, "value": name} for name in self._columns],
                 value=self._default_columns,
                 multi=True,
+            ),
+            wcc.Checklist(
+                id=self.register_component_unique_id(self.Ids.ONLY_INACTIVE),
+                options=[
+                    {
+                        "label": "View only inactive",
+                        "value": "only_inactive",
+                    }
+                ],
+                value=[],
             ),
         ]

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_settings.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_settings.py
@@ -1,0 +1,28 @@
+from typing import List
+
+import webviz_core_components as wcc
+from dash.development.base_component import Component
+from webviz_config.utils import StrEnum
+from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
+
+
+class QCSettings(SettingsGroupABC):
+    class Ids(StrEnum):
+        ENSEMBLE = "ensemble"
+
+    def __init__(self, ensembles: List[str]) -> None:
+        super().__init__("Settings")
+        self._ensembles = ensembles
+
+    def layout(self) -> List[Component]:
+        ensemble = self._ensembles[0] if self._ensembles else None
+        return [
+            wcc.Dropdown(
+                label="Ensemble",
+                id=self.register_component_unique_id(self.Ids.ENSEMBLE),
+                options=[{"label": ens, "value": ens} for ens in self._ensembles],
+                value=ensemble,
+                multi=False,
+                clearable=False,
+            ),
+        ]

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_settings.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_settings.py
@@ -9,10 +9,27 @@ from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 class QCSettings(SettingsGroupABC):
     class Ids(StrEnum):
         ENSEMBLE = "ensemble"
+        COLUMNS = "columns"
 
-    def __init__(self, ensembles: List[str]) -> None:
+    def __init__(self, ensembles: List[str], columns: List[str]) -> None:
         super().__init__("Settings")
         self._ensembles = ensembles
+        self._columns = columns
+        self._default_columns = [
+            "REAL",
+            "EAST",
+            "NORTH",
+            "MD",
+            "ZONE",
+            "WELL",
+            "DATE",
+            "VALID_ZONE",
+            "ACTIVE",
+            "INACTIVE_INFO",
+        ]
+        self._default_columns = [
+            col for col in self._default_columns if col in self._columns
+        ]
 
     def layout(self) -> List[Component]:
         ensemble = self._ensembles[0] if self._ensembles else None
@@ -24,5 +41,13 @@ class QCSettings(SettingsGroupABC):
                 value=ensemble,
                 multi=False,
                 clearable=False,
+            ),
+            wcc.SelectWithLabel(
+                label="Columns",
+                size=min(10, len(self._columns)),
+                id=self.register_component_unique_id(self.Ids.COLUMNS),
+                options=[{"label": name, "value": name} for name in self._columns],
+                value=self._default_columns,
+                multi=True,
             ),
         ]

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -1,4 +1,3 @@
-import webviz_core_components as wcc
 from dash import dash_table, html
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
@@ -21,7 +20,12 @@ class TableViewElement(ViewElementABC):
                         sort_mode="multi",
                         filter_action="native",
                         style_as_list_view=True,
-                        style_table={"height": "84vh", "overflowY": "auto"},
+                        style_table={
+                            "height": "84vh",
+                            "overflowY": "auto",
+                            "width": "120vh",
+                            "overflowX": "auto",
+                        },
                     ),
                 ),
             ]

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -23,8 +23,12 @@ class TableViewElement(ViewElementABC):
                         style_table={
                             "height": "84vh",
                             "overflowY": "auto",
-                            "width": "120vh",
-                            "overflowX": "auto",
+                        },
+                        style_cell={
+                            "whiteSpace": "normal",
+                            "height": "auto",
+                            "textAlign": "left",
+                            "width": "auto",
                         },
                     ),
                 ),

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -1,0 +1,28 @@
+import webviz_core_components as wcc
+from dash import dash_table, html
+from webviz_config.utils import StrEnum
+from webviz_config.webviz_plugin_subclasses import ViewElementABC
+
+
+class TableViewElement(ViewElementABC):
+    class Ids(StrEnum):
+        TABLE = "table"
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def inner_layout(self) -> html.Div:
+        return html.Div(
+            children=[
+                html.Div(
+                    children=dash_table.DataTable(
+                        id=self.register_component_unique_id(self.Ids.TABLE),
+                        sort_action="native",
+                        sort_mode="multi",
+                        filter_action="native",
+                        style_as_list_view=True,
+                        style_table={"height": "84vh", "overflowY": "auto"},
+                    ),
+                ),
+            ]
+        )

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_view.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_view.py
@@ -1,13 +1,13 @@
-from typing import List, Dict, Tuple
+from typing import Dict, List, Tuple
 
 import pandas as pd
 from dash import Input, Output, callback
 from webviz_config.utils import StrEnum, callback_typecheck
 from webviz_config.webviz_plugin_subclasses import ViewABC
 
-from ._table_view_element import TableViewElement
 from ..._utils import RftPlotterDataModel
 from ._settings import QCSettings
+from ._table_view_element import TableViewElement
 
 DATA_TYPES = {
     "REAL": "numeric",

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_view.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_view.py
@@ -57,7 +57,7 @@ class QCView(ViewABC):
         QC_TABLE = "qc-table"
 
     def __init__(self, datamodel: RftPlotterDataModel) -> None:
-        super().__init__("QC")
+        super().__init__("QC Data")
         self._datamodel = datamodel
 
         self.add_settings_group(
@@ -97,10 +97,16 @@ class QCView(ViewABC):
                 .to_string(),
                 "value",
             ),
+            Input(
+                self.settings_group(self.Ids.QC_SETTINGS)
+                .component_unique_id(QCSettings.Ids.ONLY_INACTIVE)
+                .to_string(),
+                "value",
+            ),
         )
         @callback_typecheck
         def _update_table(
-            ensemble: str, selected_columns: List[str]
+            ensemble: str, selected_columns: List[str], only_inactive: List[str]
         ) -> Tuple[List[Dict], List[Dict]]:
             columns = [
                 {
@@ -111,9 +117,12 @@ class QCView(ViewABC):
                 }
                 for col in selected_columns
             ]
-            df = pd.concat(
-                [self._datamodel.ertdatadf, self._datamodel.ertdatadf_inactive]
-            )
+            if only_inactive:
+                df = self._datamodel.ertdatadf_inactive
+            else:
+                df = pd.concat(
+                    [self._datamodel.ertdatadf, self._datamodel.ertdatadf_inactive]
+                )
             df = df[df["ENSEMBLE"] == ensemble]
             return (
                 df.sort_values(by="REAL", ascending=True).to_dict("records"),

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_view.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_view.py
@@ -1,0 +1,86 @@
+from typing import Any, Dict, List, Union
+
+import pandas as pd
+import webviz_core_components as wcc
+from dash import Input, Output, State, callback
+from dash.exceptions import PreventUpdate
+from webviz_config.utils import StrEnum, callback_typecheck
+from webviz_config.webviz_plugin_subclasses import ViewABC
+
+from ._table_view_element import TableViewElement
+from ..._utils import RftPlotterDataModel
+from ._settings import QCSettings
+
+
+class QCView(ViewABC):
+    class Ids(StrEnum):
+        QC_SETTINGS = "qc-settings"
+        QC_TABLE = "qc-table"
+
+    def __init__(self, datamodel: RftPlotterDataModel) -> None:
+        super().__init__("QC")
+        self._datamodel = datamodel
+
+        self.add_settings_group(
+            QCSettings(
+                ensembles=self._datamodel.ensembles,
+            ),
+            self.Ids.QC_SETTINGS,
+        )
+
+        map_column = self.add_column()
+        map_column.add_view_element(TableViewElement(), self.Ids.QC_TABLE)
+
+    def set_callbacks(self) -> None:
+        @callback(
+            Output(
+                self.view_element(self.Ids.QC_TABLE)
+                .component_unique_id(TableViewElement.Ids.TABLE)
+                .to_string(),
+                "data",
+            ),
+            Output(
+                self.view_element(self.Ids.QC_TABLE)
+                .component_unique_id(TableViewElement.Ids.TABLE)
+                .to_string(),
+                "columns",
+            ),
+            Input(
+                self.settings_group(self.Ids.QC_SETTINGS)
+                .component_unique_id(QCSettings.Ids.ENSEMBLE)
+                .to_string(),
+                "value",
+            ),
+        )
+        @callback_typecheck
+        def _update_table(
+            ensemble: str,
+        ) -> tuple:
+            columns = [
+                {
+                    "name": col,
+                    "id": col,
+                    #"type": "numeric",
+                    "format": {"specifier": ".1f"},
+                }
+                for col in [
+                    "REAL",
+                    "EAST",
+                    "NORTH",
+                    "TVD",
+                    "ZONE",
+                    "WELL",
+                    "DATE",
+                    "valid_zone",
+                    "ACTIVE",
+                    "inactive_info",
+                ]
+            ]
+            df = pd.concat(
+                [self._datamodel.ertdatadf, self._datamodel.ertdatadf_inactive]
+            )
+            df = df[df["ENSEMBLE"] == ensemble]
+            return (
+                df.sort_values(by="REAL", ascending=True).to_dict("records"),
+                columns,
+            )


### PR DESCRIPTION
New view in `RftPlotter` that displays the data in a data table. Valuable for QC of de-activated data points.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
