### PR TITLE
Fix CI and enable mypy again

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -52,10 +52,6 @@ jobs:
           pip install "bleach<5"  # https://github.com/equinor/webviz-config/issues/586
           pip install "werkzeug<2.1"  # ...while waiting for https://github.com/plotly/dash/issues/1992
           pip install "selenium<4.3"  # breaking change in selenium==4.3
-          pip install "scipy<1.9.3"   # breaking change in scipy==1.9.3
-          pip install "pytest<7.2.0"
-          pip install "pytest-xdist<3.0"
-          pip install "xtgeo<2.20.2"
           pip install .
 
           # Testing against our latest release (including pre-releases)
@@ -78,7 +74,7 @@ jobs:
           pylint webviz_subsurface tests setup.py
           bandit -r -c ./bandit.yml webviz_subsurface tests setup.py
           isort --check-only webviz_subsurface tests setup.py
-          # mypy --package webviz_subsurface
+          mypy --package webviz_subsurface
 
       - name: 🤖 Run tests
         env:

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,3 +41,6 @@ ignore_errors=True
 
 [mypy-webviz_subsurface.plugins._surface_with_seismic_cross_section.*]
 ignore_errors=True
+
+[mypy-webviz_subsurface.plugins._inplace_volumes.*]
+ignore_errors=True

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ TESTS_REQUIRE = [
     "pylint<=2.13.9",  # Locked due to https://github.com/equinor/webviz-subsurface/issues/1052
     "pytest-mock",
     "pytest-xdist",
+    "pytest-forked",
     "selenium>=3.141",
     "types-pkg-resources",
     "types-pyyaml",

--- a/tests/unit_tests/model_tests/test_well_set_model.py
+++ b/tests/unit_tests/model_tests/test_well_set_model.py
@@ -66,5 +66,5 @@ def test_get_fence(testdata_folder: Path) -> None:
     assert int(fence[:, 3].min()) == -40
     assert int(fence[:, 3].max()) == 2713
     # Test tvd
-    assert int(fence[:, 2].min()) == 1
+    assert int(fence[:, 2].min()) == 0
     assert int(fence[:, 2].max()) == 1643

--- a/webviz_subsurface/_providers/ensemble_grid_provider/grid_viz_service.py
+++ b/webviz_subsurface/_providers/ensemble_grid_provider/grid_viz_service.py
@@ -121,7 +121,9 @@ class GridWorker:
         self, cell_filter: Optional[CellFilter], original_cell_indices: np.ndarray
     ) -> None:
         # Make copy of the cell filter
-        self._cached_cell_filter = dataclasses.replace(cell_filter)
+        self._cached_cell_filter = (
+            dataclasses.replace(cell_filter) if cell_filter is not None else None
+        )
         self._cached_original_cell_indices = original_cell_indices
 
 

--- a/webviz_subsurface/_providers/ensemble_surface_provider/surface_array_server.py
+++ b/webviz_subsurface/_providers/ensemble_surface_provider/surface_array_server.py
@@ -123,7 +123,7 @@ class SurfaceArrayServer:
             )
 
         meta_cache_key = "META:" + base_cache_key
-        meta: Optional[SurfaceArrayMeta] = self._array_cache.get(meta_cache_key)
+        meta = self._array_cache.get(meta_cache_key)
         if not meta:
             return None
 

--- a/webviz_subsurface/_providers/ensemble_surface_provider/surface_image_server.py
+++ b/webviz_subsurface/_providers/ensemble_surface_provider/surface_image_server.py
@@ -4,7 +4,7 @@ import json
 import logging
 import math
 from dataclasses import asdict, dataclass
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -118,7 +118,7 @@ class SurfaceImageServer:
             )
 
         meta_cache_key = "META:" + base_cache_key
-        meta: Optional[SurfaceImageMeta] = self._image_cache.get(meta_cache_key)
+        meta = self._image_cache.get(meta_cache_key)
         if not meta:
             return None
 
@@ -160,7 +160,7 @@ class SurfaceImageServer:
             img_cache_key = "IMG:" + full_surf_address_str
             LOGGER.debug(f"Looking for image in cache (key={img_cache_key}")
 
-            cached_img_bytes = self._image_cache.get(img_cache_key)
+            cached_img_bytes: Any = self._image_cache.get(img_cache_key)
             if not cached_img_bytes:
                 LOGGER.error(
                     f"Error getting image for address: {full_surf_address_str}"

--- a/webviz_subsurface/plugins/_map_viewer_fmu/map_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/map_viewer_fmu.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from dash import Dash, html
 from webviz_config import WebvizPluginABC, WebvizSettings
@@ -114,6 +114,7 @@ color-tables.json for color_tables format.
             )
             for ens in ensembles
         }
+        self._surface_server: Union[SurfaceImageServer, SurfaceArrayServer]
         if self.render_surfaces_as_images:
             self._surface_server = SurfaceImageServer.instance(app)
         else:


### PR DESCRIPTION
PR that fixes the failing CI tests, and enables mypy in the CI again.

Tests were failing due to pyscal removing the dependencies on scipy<1.93 https://github.com/equinor/pyscal/pull/401. This led Scipy to be updated, using an improved interpolation algorithm which led to the assertion error. 
It was also needed to unpin the xtgeo version to include a bugfix https://github.com/equinor/xtgeo/pull/822
