### PR TITLE
Improved performance of `EnsembleTableProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#1227](https://github.com/equinor/webviz-subsurface/pull/1227) - New functionality in `SimulationTimeSeriesOneByOne`: option to use the sensitivity filter on all visualisations, not only the timeseries.
+- [#1229](https://github.com/equinor/webviz-subsurface/pull/1229) - New view for QC of data in `RftPlotter`.
 
 ### Fixed
 - [#1232](https://github.com/equinor/webviz-subsurface/pull/1232) - Removed slow function in `RftPlotter` to improve startup time of plugin.
+
+### Changed
+- [#1231](https://github.com/equinor/webviz-subsurface/pull/1231) - Upgrades to the `EnsembleTableProvider` that improves performance: it no longer relies on `fmu-ensemble` for loading csv-files and parameters into dataframes. Additional: added new plugin argument `drop_failed_realizations` to `VolumetricAnalysis` to be able to load in volumetrics files, if they exist, even though the ensemble has crashed.
 
 ## [0.2.20] - 2023-06-26
 

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -356,7 +356,7 @@ def extract_volframe_from_tableprovider(
             table_provider_set = create_csvfile_providerset_from_paths(
                 ensemble_paths, str(Path(volfolder) / volfile), drop_failed_realizations
             )
-            ensembledf = table_provider_set.get_combined_dataframe()
+            ensembledf = table_provider_set.get_aggregated_dataframe()
             volframes.append(ensembledf)
 
         # merge csvfiles from same SOURCE if more than one

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -6,6 +6,10 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 
+from webviz_subsurface._utils.ensemble_table_provider_set_factory import (
+    create_csvfile_providerset_from_paths,
+)
+
 from .ensemble_set_model import EnsembleSetModel
 from .parameter_model import ParametersModel
 
@@ -329,26 +333,30 @@ def filter_df(dframe: pd.DataFrame, filters: dict) -> pd.DataFrame:
     return dframe
 
 
-def extract_volumes(
-    ensemble_set_model: EnsembleSetModel,
-    volfolder: str,
-    volfiles: Dict[str, Any],
+def extract_volframe_from_tableprovider(
+    ensemble_paths: dict, volfolder: str, volfiles: Dict[str, Any]
 ) -> pd.DataFrame:
     """Aggregates volumetric files from an FMU ensemble.
     Files must be stored on standardized csv format.
     """
+
     dfs = []
     for volname, files in volfiles.items():
-        if isinstance(files, list):
-            volframes = [
-                ensemble_set_model.load_csv(Path(volfolder) / volfile)
-                for volfile in files
-            ]
-            df = merge_csv_files(volframes)
-        elif isinstance(files, str):
-            df = ensemble_set_model.load_csv(Path(volfolder) / files)
-        else:
+        if isinstance(files, str):
+            files = [files]
+
+        if not isinstance(files, list):
             raise ValueError("Wrong format of volfile value argument!")
+
+        volframes = []
+        for volfile in files:
+            table_provider_set = create_csvfile_providerset_from_paths(
+                ensemble_paths, str(Path(volfolder) / volfile)
+            )
+            ensembledf = table_provider_set.create_aggreagated_dataframe()
+            volframes.append(ensembledf)
+
+        df = merge_csv_files(volframes) if len(volframes) > 1 else volframes[0]
         df["SOURCE"] = volname
         dfs.append(df)
 

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -10,7 +10,6 @@ from webviz_subsurface._utils.ensemble_table_provider_set_factory import (
     create_csvfile_providerset_from_paths,
 )
 
-from .ensemble_set_model import EnsembleSetModel
 from .parameter_model import ParametersModel
 
 
@@ -334,9 +333,13 @@ def filter_df(dframe: pd.DataFrame, filters: dict) -> pd.DataFrame:
 
 
 def extract_volframe_from_tableprovider(
-    ensemble_paths: dict, volfolder: str, volfiles: Dict[str, Any]
+    ensemble_paths: dict,
+    volfolder: str,
+    volfiles: Dict[str, Any],
+    drop_failed_realizations: bool = True,
 ) -> pd.DataFrame:
-    """Aggregates volumetric files from an FMU ensemble.
+    """
+    Aggregates volumetric files from an FMU ensemble
     Files must be stored on standardized csv format.
     """
 
@@ -351,11 +354,12 @@ def extract_volframe_from_tableprovider(
         volframes = []
         for volfile in files:
             table_provider_set = create_csvfile_providerset_from_paths(
-                ensemble_paths, str(Path(volfolder) / volfile)
+                ensemble_paths, str(Path(volfolder) / volfile), drop_failed_realizations
             )
-            ensembledf = table_provider_set.create_aggreagated_dataframe()
+            ensembledf = table_provider_set.get_combined_dataframe()
             volframes.append(ensembledf)
 
+        # merge csvfiles from same SOURCE if more than one
         df = merge_csv_files(volframes) if len(volframes) > 1 else volframes[0]
         df["SOURCE"] = volname
         dfs.append(df)

--- a/webviz_subsurface/_providers/ensemble_summary_provider/_csv_import.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/_csv_import.py
@@ -4,37 +4,9 @@ from typing import Optional
 
 import pandas as pd
 
-# The fmu.ensemble dependency ecl is only available for Linux,
-# hence, ignore any import exception here to make
-# it still possible to use the PvtPlugin on
-# machines with other OSes.
-#
-# NOTE: Functions in this file cannot be used
-#       on non-Linux OSes.
-try:
-    from fmu.ensemble import ScratchEnsemble
-except ImportError:
-    pass
-
 from webviz_subsurface._utils.perf_timer import PerfTimer
 
 LOGGER = logging.getLogger(__name__)
-
-
-def load_per_real_csv_file_using_fmu(
-    ens_path: str, csv_file_rel_path: str
-) -> pd.DataFrame:
-    LOGGER.debug(f"load_per_real_csv_file_using_fmu() starting - {csv_file_rel_path}")
-    timer = PerfTimer()
-
-    scratch_ensemble = ScratchEnsemble("tempEnsName", ens_path, autodiscovery=True)
-    df = scratch_ensemble.load_csv(csv_file_rel_path)
-
-    LOGGER.debug(
-        f"load_per_real_csv_file_using_fmu() finished in: {timer.elapsed_s():.2f}s"
-    )
-
-    return df
 
 
 def load_ensemble_summary_csv_file(

--- a/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider_factory.py
@@ -10,11 +10,9 @@ from webviz_config.webviz_instance_info import WebvizRunMode
 
 from webviz_subsurface._utils.perf_timer import PerfTimer
 
+from ..ensemble_table_provider._table_import import load_per_real_csv_file
 from ._arrow_unsmry_import import load_per_realization_arrow_unsmry_files
-from ._csv_import import (
-    load_ensemble_summary_csv_file,
-    load_per_real_csv_file_using_fmu,
-)
+from ._csv_import import load_ensemble_summary_csv_file
 from ._provider_impl_arrow_lazy import ProviderImplArrowLazy
 from ._provider_impl_arrow_presampled import ProviderImplArrowPresampled
 from ._resampling import Frequency, resample_single_real_table
@@ -155,7 +153,7 @@ class EnsembleSummaryProviderFactory(WebvizFactory):
 
         timer.lap_s()
 
-        ensemble_df = load_per_real_csv_file_using_fmu(ens_path, csv_file_rel_path)
+        ensemble_df = load_per_real_csv_file(ens_path, csv_file_rel_path)
         et_import_csv_s = timer.lap_s()
 
         ProviderImplArrowPresampled.write_backing_store_from_ensemble_dataframe(

--- a/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_summary_provider/ensemble_summary_provider_factory.py
@@ -120,7 +120,10 @@ class EnsembleSummaryProviderFactory(WebvizFactory):
         return provider
 
     def create_from_per_realization_csv_file(
-        self, ens_path: str, csv_file_rel_path: str
+        self,
+        ens_path: str,
+        csv_file_rel_path: str,
+        drop_failed_realizations: bool = False,
     ) -> EnsembleSummaryProvider:
         """Create EnsembleSummaryProvider from per realization CSV files.
 
@@ -153,7 +156,9 @@ class EnsembleSummaryProviderFactory(WebvizFactory):
 
         timer.lap_s()
 
-        ensemble_df = load_per_real_csv_file(ens_path, csv_file_rel_path)
+        ensemble_df = load_per_real_csv_file(
+            ens_path, csv_file_rel_path, drop_failed_realizations
+        )
         et_import_csv_s = timer.lap_s()
 
         ProviderImplArrowPresampled.write_backing_store_from_ensemble_dataframe(

--- a/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
@@ -1,0 +1,138 @@
+import glob
+import logging
+import os
+import re
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import pandas as pd
+
+from webviz_subsurface._utils.formatting import parse_number_from_string
+from webviz_subsurface._utils.perf_timer import PerfTimer
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class FileEntry:
+    real: int
+    filename: str
+
+
+def _discover_files(
+    globpattern: str, validated_reals: List[int] = None
+) -> List[FileEntry]:
+    globbedpaths = glob.glob(globpattern)
+
+    visited_folders = set()
+
+    file_list: list = []
+    for path in globbedpaths:
+        this_folder = os.path.dirname(path)
+        if this_folder in visited_folders:
+            raise ValueError(f"Multiple matches found in folder: {this_folder}")
+        visited_folders.add(this_folder)
+
+        real = get_realization_number_from_path(path)
+
+        if real is None:
+            raise ValueError(f"Unable to determine realization number for file: {path}")
+
+        if validated_reals is not None and real not in validated_reals:
+            LOGGER.warning(f"Skipping realization {real} no OK file found")
+            continue
+
+        file_list.append(FileEntry(real=real, filename=path))
+
+    # Sort the file entries on realization number
+    file_list = sorted(file_list, key=lambda e: e.real)
+    return file_list
+
+
+def get_realization_number_from_path(path: str) -> int:
+    realidxregexp = re.compile(r"realization-(\d+)")
+
+    for path_comp in reversed(path.split(os.path.sep)):
+        realmatch = re.match(realidxregexp, path_comp)
+        if realmatch:
+            return int(realmatch.group(1))
+
+    raise ValueError(f"Unable to determine realization number for path: {path}")
+
+
+def validate_ralizations(ens_path: str, filterfile: str) -> List[int]:
+    if filterfile is not None:
+        ensemble_paths = glob.glob(os.path.join(ens_path, filterfile))
+    else:
+        ensemble_paths = glob.glob(ens_path)
+    return [get_realization_number_from_path(path) for path in ensemble_paths]
+
+
+def _load_table_from_csv_file(entry: FileEntry) -> pd.DataFrame:
+    LOGGER.debug(f"loading table real={entry.real}: {entry.filename}")
+    df = pd.read_csv(entry.filename)
+    df["REAL"] = int(entry.real)
+    return df
+
+
+def load_per_real_csv_file(
+    ens_path: str, csv_file_rel_path: str, filterfile: str = "OK"
+) -> pd.DataFrame:
+    LOGGER.debug(f"load_per_realization_arrow_unsmry_files() starting - {ens_path}")
+    LOGGER.debug(
+        f"looking for .arrow files using relative pattern: {csv_file_rel_path}"
+    )
+    timer = PerfTimer()
+
+    validated_reals = validate_ralizations(ens_path, filterfile)
+
+    globpattern = os.path.join(ens_path, csv_file_rel_path)
+    files_to_process = _discover_files(globpattern, validated_reals)
+    if len(files_to_process) == 0:
+        LOGGER.warning(f"No csv files were discovered in: {ens_path}")
+        LOGGER.warning(f"Glob pattern used: {globpattern}")
+        return pd.DataFrame()
+
+    with ProcessPoolExecutor() as executor:
+        tables = executor.map(_load_table_from_csv_file, files_to_process)
+
+    LOGGER.debug(f"load_per_real_csv_file() " f"finished in: {timer.elapsed_s():.2f}s")
+    return pd.concat(tables)
+
+
+def _load_table_from_parameters_file(entry: FileEntry) -> dict:
+    LOGGER.debug(f"loading table real={entry.real}: {entry.filename}")
+    data: Dict[str, Any] = {"REAL": int(entry.real)}
+    with open(entry.filename, "r") as f:
+        for line in f:
+            param, value = line.split()
+            data[param] = parse_number_from_string(value)
+    return data
+
+
+def load_per_real_parameters_file(
+    ens_path: str, filterfile: str = "OK"
+) -> pd.DataFrame:
+    parameter_file = "parameters.txt"
+    LOGGER.debug(f"load_per_real_parameters_file() starting - {ens_path}")
+    LOGGER.debug(f"looking for files using relative pattern: {parameter_file}")
+    timer = PerfTimer()
+
+    validated_reals = validate_ralizations(ens_path, filterfile)
+
+    globpattern = os.path.join(ens_path, parameter_file)
+    files_to_process = _discover_files(globpattern, validated_reals)
+    if len(files_to_process) == 0:
+        LOGGER.warning(f"No csv files were discovered in: {ens_path}")
+        LOGGER.warning(f"Glob pattern used: {globpattern}")
+        return pd.DataFrame()
+
+    with ProcessPoolExecutor() as executor:
+        tables = executor.map(_load_table_from_parameters_file, files_to_process)
+
+    LOGGER.debug(
+        f"load_per_real_parameters_file() " f"finished in: {timer.elapsed_s():.2f}s"
+    )
+    return pd.DataFrame(tables)

--- a/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
@@ -109,8 +109,8 @@ def load_per_real_csv_file(
     globpattern = os.path.join(ens_path, csv_file_rel_path)
     files_to_process = _discover_files(globpattern, validated_reals)
     if len(files_to_process) == 0:
-        LOGGER.warning(f"No csv files were discovered in: {ens_path}")
-        LOGGER.warning(f"Glob pattern used: {globpattern}")
+        LOGGER.debug(f"No csv files were discovered in: {ens_path}")
+        LOGGER.debug(f"Glob pattern used: {globpattern}")
         return pd.DataFrame()
 
     with ProcessPoolExecutor() as executor:

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
@@ -120,7 +120,7 @@ class EnsembleTableProviderFactory(WebvizFactory):
         self,
         ens_path: str,
         csv_file_rel_path: str,
-        drop_failed_realizations: bool = True,
+        drop_failed_realizations: bool = False,
     ) -> EnsembleTableProvider:
         """Create EnsembleTableProvider from per realization CSV files.
 

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
@@ -10,24 +10,12 @@ from webviz_config.webviz_factory import WebvizFactory
 from webviz_config.webviz_factory_registry import WEBVIZ_FACTORY_REGISTRY
 from webviz_config.webviz_instance_info import WebvizRunMode
 
-# The fmu.ensemble dependency ecl is only available for Linux,
-# hence, ignore any import exception here to make
-# it still possible to use the PvtPlugin on
-# machines with other OSes.
-#
-# NOTE: Functions in this file cannot be used
-#       on non-Linux OSes.
-try:
-    from fmu.ensemble import ScratchEnsemble
-except ImportError:
-    pass
-
 from webviz_subsurface._utils.perf_timer import PerfTimer
 
 from ..ensemble_summary_provider._arrow_unsmry_import import (
     load_per_realization_arrow_unsmry_files,
 )
-from ..ensemble_summary_provider._csv_import import load_per_real_csv_file_using_fmu
+from ._table_import import load_per_real_csv_file, load_per_real_parameters_file
 from .ensemble_table_provider import EnsembleTableProvider
 from .ensemble_table_provider_impl_arrow import EnsembleTableProviderImplArrow
 
@@ -161,8 +149,8 @@ class EnsembleTableProviderFactory(WebvizFactory):
         LOGGER.info(f"Importing/saving per real CSV data for: {ens_path}")
 
         timer.lap_s()
+        ensemble_df = load_per_real_csv_file(ens_path, csv_file_rel_path)
 
-        ensemble_df = load_per_real_csv_file_using_fmu(ens_path, csv_file_rel_path)
         et_import_csv_s = timer.lap_s()
 
         EnsembleTableProviderImplArrow.write_backing_store_from_ensemble_dataframe(
@@ -280,10 +268,11 @@ class EnsembleTableProviderFactory(WebvizFactory):
         LOGGER.info(f"Importing parameters for: {ens_path}")
 
         timer.lap_s()
+        ensemble_df = load_per_real_parameters_file(ens_path, filterfile="OK")
 
-        scratch_ensemble = ScratchEnsemble("ens_name_tmp", ens_path).filter("OK")
-        ensemble_df = scratch_ensemble.parameters
-        del scratch_ensemble
+        #  scratch_ensemble = ScratchEnsemble("ens_name_tmp", ens_path).filter("OK")
+        # ensemble_df = scratch_ensemble.parameters
+        # del scratch_ensemble
         elapsed_load_parameters_s = timer.lap_s()
 
         try:

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
@@ -155,7 +155,11 @@ class EnsembleTableProviderFactory(WebvizFactory):
         ensemble_df = load_per_real_csv_file(
             ens_path, csv_file_rel_path, drop_failed_realizations
         )
-
+        if ensemble_df.empty:
+            raise ValueError(
+                f"Failed to load csv-files {csv_file_rel_path} for ensemble {ens_path}."
+                " Either the file does not exist or spelling is incorrect."
+            )
         et_import_csv_s = timer.lap_s()
 
         EnsembleTableProviderImplArrow.write_backing_store_from_ensemble_dataframe(

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
@@ -120,7 +120,7 @@ class EnsembleTableProviderFactory(WebvizFactory):
         self,
         ens_path: str,
         csv_file_rel_path: str,
-        drop_failed_realizations: bool = False,
+        drop_failed_realizations: bool = True,
     ) -> EnsembleTableProvider:
         """Create EnsembleTableProvider from per realization CSV files.
 

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
@@ -117,7 +117,10 @@ class EnsembleTableProviderFactory(WebvizFactory):
         return provider
 
     def create_from_per_realization_csv_file(
-        self, ens_path: str, csv_file_rel_path: str
+        self,
+        ens_path: str,
+        csv_file_rel_path: str,
+        drop_failed_realizations: bool = True,
     ) -> EnsembleTableProvider:
         """Create EnsembleTableProvider from per realization CSV files.
 
@@ -149,7 +152,9 @@ class EnsembleTableProviderFactory(WebvizFactory):
         LOGGER.info(f"Importing/saving per real CSV data for: {ens_path}")
 
         timer.lap_s()
-        ensemble_df = load_per_real_csv_file(ens_path, csv_file_rel_path)
+        ensemble_df = load_per_real_csv_file(
+            ens_path, csv_file_rel_path, drop_failed_realizations
+        )
 
         et_import_csv_s = timer.lap_s()
 
@@ -237,7 +242,7 @@ class EnsembleTableProviderFactory(WebvizFactory):
         return provider
 
     def create_from_per_realization_parameter_file(
-        self, ens_path: str
+        self, ens_path: str, drop_failed_realizations: bool = True
     ) -> EnsembleTableProvider:
         """Create EnsembleTableProvider from parameter files.
 
@@ -268,11 +273,8 @@ class EnsembleTableProviderFactory(WebvizFactory):
         LOGGER.info(f"Importing parameters for: {ens_path}")
 
         timer.lap_s()
-        ensemble_df = load_per_real_parameters_file(ens_path, filterfile="OK")
+        ensemble_df = load_per_real_parameters_file(ens_path, drop_failed_realizations)
 
-        #  scratch_ensemble = ScratchEnsemble("ens_name_tmp", ens_path).filter("OK")
-        # ensemble_df = scratch_ensemble.parameters
-        # del scratch_ensemble
         elapsed_load_parameters_s = timer.lap_s()
 
         try:

--- a/webviz_subsurface/_utils/ensemble_table_provider_set.py
+++ b/webviz_subsurface/_utils/ensemble_table_provider_set.py
@@ -1,5 +1,4 @@
-import datetime
-from typing import Dict, ItemsView, List, Optional, Sequence, Set
+from typing import Dict, ItemsView, List, Sequence, Set
 
 import pandas as pd
 
@@ -8,14 +7,7 @@ from webviz_subsurface._providers import EnsembleTableProvider
 
 class EnsembleTableProviderSet:
     """
-    Class to create a set of ensemble summary providers with unique names
-
-    Provides interface for read-only fetching of provider data
-
-    NOTE:
-        - Assuming same implementation of EnsembleTableProvider interface across
-        all providers in set. There is no guarantee of functionality if various
-        provider implementations are mixed in the same set.
+    Class to create a set of ensemble table providers with unique names
     """
 
     def __init__(self, provider_dict: Dict[str, EnsembleTableProvider]) -> None:
@@ -27,8 +19,9 @@ class EnsembleTableProviderSet:
         self._all_realizations = self._create_union_of_realizations_from_providers(
             list(self._provider_dict.values())
         )
+        self._combined_dataframe = pd.DataFrame()
 
-    def create_aggreagated_dataframe(self) -> pd.DataFrame:
+    def get_combined_dataframe(self) -> pd.DataFrame:
         dfs = []
         for ens, provider in self.items():
             df = provider.get_column_data(column_names=provider.column_names())

--- a/webviz_subsurface/_utils/ensemble_table_provider_set.py
+++ b/webviz_subsurface/_utils/ensemble_table_provider_set.py
@@ -19,9 +19,8 @@ class EnsembleTableProviderSet:
         self._all_realizations = self._create_union_of_realizations_from_providers(
             list(self._provider_dict.values())
         )
-        self._combined_dataframe = pd.DataFrame()
 
-    def get_combined_dataframe(self) -> pd.DataFrame:
+    def get_aggregated_dataframe(self) -> pd.DataFrame:
         dfs = []
         for ens, provider in self.items():
             df = provider.get_column_data(column_names=provider.column_names())

--- a/webviz_subsurface/_utils/ensemble_table_provider_set.py
+++ b/webviz_subsurface/_utils/ensemble_table_provider_set.py
@@ -1,0 +1,81 @@
+import datetime
+from typing import Dict, ItemsView, List, Optional, Sequence, Set
+
+import pandas as pd
+
+from webviz_subsurface._providers import EnsembleTableProvider
+
+
+class EnsembleTableProviderSet:
+    """
+    Class to create a set of ensemble summary providers with unique names
+
+    Provides interface for read-only fetching of provider data
+
+    NOTE:
+        - Assuming same implementation of EnsembleTableProvider interface across
+        all providers in set. There is no guarantee of functionality if various
+        provider implementations are mixed in the same set.
+    """
+
+    def __init__(self, provider_dict: Dict[str, EnsembleTableProvider]) -> None:
+        self._provider_dict = provider_dict.copy()
+        self._names = list(self._provider_dict.keys())
+        self._all_column_names = self._create_union_of_column_names_from_providers(
+            list(self._provider_dict.values())
+        )
+        self._all_realizations = self._create_union_of_realizations_from_providers(
+            list(self._provider_dict.values())
+        )
+
+    def create_aggreagated_dataframe(self) -> pd.DataFrame:
+        dfs = []
+        for ens, provider in self.items():
+            df = provider.get_column_data(column_names=provider.column_names())
+            df["ENSEMBLE"] = ens
+            dfs.append(df)
+        return pd.concat(dfs)
+
+    @staticmethod
+    def _create_union_of_column_names_from_providers(
+        providers: List[EnsembleTableProvider],
+    ) -> List[str]:
+        """Create list with the union of vector names among providers"""
+        column_names = []
+        for provider in providers:
+            column_names.extend(provider.column_names())
+        column_names = list(sorted(set(column_names)))
+        return column_names
+
+    @staticmethod
+    def _create_union_of_realizations_from_providers(
+        providers: Sequence[EnsembleTableProvider],
+    ) -> List[int]:
+        """Create list with the union of realizations among providers"""
+        realizations: Set[int] = set()
+        for provider in providers:
+            realizations.update(provider.realizations())
+        output = list(sorted(realizations))
+        return output
+
+    def items(self) -> ItemsView[str, EnsembleTableProvider]:
+        return self._provider_dict.items()
+
+    def provider_names(self) -> List[str]:
+        return self._names
+
+    def provider(self, name: str) -> EnsembleTableProvider:
+        if name not in self._provider_dict.keys():
+            raise ValueError(f'Provider with name "{name}" not present in set!')
+        return self._provider_dict[name]
+
+    def all_providers(self) -> List[EnsembleTableProvider]:
+        return list(self._provider_dict.values())
+
+    def all_realizations(self) -> List[int]:
+        """List with the union of realizations among providers"""
+        return self._all_realizations
+
+    def all_column_names(self) -> List[str]:
+        """List with the union of vector names among providers"""
+        return self._all_column_names

--- a/webviz_subsurface/_utils/ensemble_table_provider_set.py
+++ b/webviz_subsurface/_utils/ensemble_table_provider_set.py
@@ -1,4 +1,4 @@
-from typing import Dict, ItemsView, List, Sequence, Set
+from typing import Dict, ItemsView, List, Optional, Sequence, Set
 
 import pandas as pd
 
@@ -20,10 +20,17 @@ class EnsembleTableProviderSet:
             list(self._provider_dict.values())
         )
 
-    def get_aggregated_dataframe(self) -> pd.DataFrame:
+    def get_aggregated_dataframe(
+        self, column_names: Optional[List[str]] = None
+    ) -> pd.DataFrame:
+        """Get aggregated dataframe from all providers"""
         dfs = []
         for ens, provider in self.items():
-            df = provider.get_column_data(column_names=provider.column_names())
+            df = provider.get_column_data(
+                column_names=column_names
+                if column_names is not None
+                else provider.column_names()
+            )
             df["ENSEMBLE"] = ens
             dfs.append(df)
         return pd.concat(dfs)

--- a/webviz_subsurface/_utils/ensemble_table_provider_set_factory.py
+++ b/webviz_subsurface/_utils/ensemble_table_provider_set_factory.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from typing import Dict
+
+from webviz_subsurface._providers import (
+    EnsembleTableProvider,
+    EnsembleTableProviderFactory,
+)
+
+from .ensemble_table_provider_set import EnsembleTableProviderSet
+
+
+def create_csvfile_providerset_from_paths(
+    name_path_dict: Dict[str, Path],
+    rel_file_pattern: str,
+) -> EnsembleTableProviderSet:
+    """Create set of ensemble summary providers without lazy resampling, but with specified
+    frequency, from dictionary of ensemble name and corresponding arrow file paths
+
+    `Input:`
+    * name_path_dict: Dict[str, Path] - ensemble name as key and arrow file path as value
+    * rel_file_pattern: str - specify a relative (per realization) file pattern to find the
+    wanted .csv files within each realization
+
+    `Return:`
+    Provider set with ensemble summary providers with presampled data according to specified
+    presampling frequency.
+    """
+    # TODO: Make presampling_frequency: Optional[Frequency] when allowing raw data for plugin
+    provider_factory = EnsembleTableProviderFactory.instance()
+    provider_dict: Dict[str, EnsembleTableProvider] = {}
+    for name, path in name_path_dict.items():
+        provider_dict[name] = provider_factory.create_from_per_realization_csv_file(
+            str(path), rel_file_pattern
+        )
+    return EnsembleTableProviderSet(provider_dict)
+
+
+def create_parameter_providerset_from_paths(
+    name_path_dict: Dict[str, Path]
+) -> EnsembleTableProviderSet:
+    """Create set of ensemble table providers
+
+    `Input:`
+    * name_path_dict: Dict[str, Path] - ensemble name as key and arrow file path as value
+    * rel_file_pattern: str - specify a relative (per realization) file pattern to find the
+    wanted .csv files within each realization
+
+    `Return:`
+    Provider set with ensemble summary providers with presampled data according to specified
+    presampling frequency.
+    """
+    # TODO: Make presampling_frequency: Optional[Frequency] when allowing raw data for plugin
+    provider_factory = EnsembleTableProviderFactory.instance()
+    provider_dict: Dict[str, EnsembleTableProvider] = {}
+    for name, path in name_path_dict.items():
+        provider_dict[
+            name
+        ] = provider_factory.create_from_per_realization_parameter_file(str(path))
+    return EnsembleTableProviderSet(provider_dict)

--- a/webviz_subsurface/_utils/ensemble_table_provider_set_factory.py
+++ b/webviz_subsurface/_utils/ensemble_table_provider_set_factory.py
@@ -12,48 +12,41 @@ from .ensemble_table_provider_set import EnsembleTableProviderSet
 def create_csvfile_providerset_from_paths(
     name_path_dict: Dict[str, Path],
     rel_file_pattern: str,
+    drop_failed_realizations: bool = True,
 ) -> EnsembleTableProviderSet:
-    """Create set of ensemble summary providers without lazy resampling, but with specified
-    frequency, from dictionary of ensemble name and corresponding arrow file paths
+    """Create set of ensemble table providers
 
     `Input:`
-    * name_path_dict: Dict[str, Path] - ensemble name as key and arrow file path as value
+    * name_path_dict: Dict[str, Path] - ensemble name as key and ensemble path as value
     * rel_file_pattern: str - specify a relative (per realization) file pattern to find the
     wanted .csv files within each realization
 
-    `Return:`
-    Provider set with ensemble summary providers with presampled data according to specified
-    presampling frequency.
     """
-    # TODO: Make presampling_frequency: Optional[Frequency] when allowing raw data for plugin
     provider_factory = EnsembleTableProviderFactory.instance()
     provider_dict: Dict[str, EnsembleTableProvider] = {}
     for name, path in name_path_dict.items():
         provider_dict[name] = provider_factory.create_from_per_realization_csv_file(
-            str(path), rel_file_pattern
+            str(path), rel_file_pattern, drop_failed_realizations
         )
     return EnsembleTableProviderSet(provider_dict)
 
 
 def create_parameter_providerset_from_paths(
-    name_path_dict: Dict[str, Path]
+    name_path_dict: Dict[str, Path],
+    drop_failed_realizations: bool = True,
 ) -> EnsembleTableProviderSet:
-    """Create set of ensemble table providers
+    """Create set of ensemble parametertable providers
 
     `Input:`
-    * name_path_dict: Dict[str, Path] - ensemble name as key and arrow file path as value
-    * rel_file_pattern: str - specify a relative (per realization) file pattern to find the
-    wanted .csv files within each realization
+    * name_path_dict: Dict[str, Path] - ensemble name as key and ensemble path as value
 
-    `Return:`
-    Provider set with ensemble summary providers with presampled data according to specified
-    presampling frequency.
     """
-    # TODO: Make presampling_frequency: Optional[Frequency] when allowing raw data for plugin
     provider_factory = EnsembleTableProviderFactory.instance()
     provider_dict: Dict[str, EnsembleTableProvider] = {}
     for name, path in name_path_dict.items():
         provider_dict[
             name
-        ] = provider_factory.create_from_per_realization_parameter_file(str(path))
+        ] = provider_factory.create_from_per_realization_parameter_file(
+            str(path), drop_failed_realizations
+        )
     return EnsembleTableProviderSet(provider_dict)

--- a/webviz_subsurface/_utils/formatting.py
+++ b/webviz_subsurface/_utils/formatting.py
@@ -29,33 +29,11 @@ def printable_int_list(integer_list: Optional[List[int]]) -> str:
     return string
 
 
-# function copied from fmu.ensemble to get identical result when
-# extracting ensemble parameters as a DataFrame
 def parse_number_from_string(value: str) -> Union[int, float, str]:
     """Try to parse the string first as an integer, then as float,
     if both fails, return the original string.
-
-    Caveats: Know your Python numbers:
-    https://stackoverflow.com/questions/379906/how-do-i-parse-a-string-to-a-float-or-int-in-python
-
-    Beware, this is a minefield.
-
-    Args:
-        value (str)
-
-    Returns:
-        int, float or string
     """
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        # int(afloat) fails on some, e.g. NaN
-        try:
-            if int(value) == value:
-                return int(value)
-            return value
-        except ValueError:
-            return value  # return float
+
     try:
         return int(value)
     except ValueError:

--- a/webviz_subsurface/_utils/formatting.py
+++ b/webviz_subsurface/_utils/formatting.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 
 
 def printable_int_list(integer_list: Optional[List[int]]) -> str:
@@ -27,3 +27,39 @@ def printable_int_list(integer_list: Optional[List[int]]) -> str:
     if not string.endswith(f", {prev_number}") and string != str(prev_number):
         string += str(prev_number)
     return string
+
+
+# function copied from fmu.ensemble to get identical result when
+# extracting ensemble parameters as a DataFrame
+def parse_number_from_string(value: str) -> Union[int, float, str]:
+    """Try to parse the string first as an integer, then as float,
+    if both fails, return the original string.
+
+    Caveats: Know your Python numbers:
+    https://stackoverflow.com/questions/379906/how-do-i-parse-a-string-to-a-float-or-int-in-python
+
+    Beware, this is a minefield.
+
+    Args:
+        value (str)
+
+    Returns:
+        int, float or string
+    """
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        # int(afloat) fails on some, e.g. NaN
+        try:
+            if int(value) == value:
+                return int(value)
+            return value
+        except ValueError:
+            return value  # return float
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value

--- a/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
@@ -1,15 +1,12 @@
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
-import pandas as pd
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.utils import StrEnum
 
-from webviz_subsurface._providers import (
-    EnsembleSummaryProviderFactory,
-    EnsembleTableProvider,
-    EnsembleTableProviderFactory,
-    Frequency,
+from webviz_subsurface._providers import EnsembleSummaryProviderFactory, Frequency
+from webviz_subsurface._utils.ensemble_table_provider_set_factory import (
+    create_parameter_providerset_from_paths,
 )
 
 from ..._utils.simulation_timeseries import check_and_format_observations
@@ -87,14 +84,12 @@ realizations if you have defined `ensembles`.
         if ensembles is None:
             raise ValueError('Incorrect argument, must provide "ensembles"')
 
-        ensemble_paths: Dict[str, str] = {
+        ensemble_paths = {
             ensemble_name: webviz_settings.shared_settings["scratch_ensembles"][
                 ensemble_name
             ]
             for ensemble_name in ensembles
         }
-
-        table_provider_factory = EnsembleTableProviderFactory.instance()
 
         resampling_frequency = Frequency(time_index)
         provider_factory = EnsembleSummaryProviderFactory.instance()
@@ -121,14 +116,8 @@ realizations if you have defined `ensembles`.
             self._vmodel.get_dates(resampling_frequency=resampling_frequency)
         )
 
-        parameter_df = create_df_from_table_provider(
-            provider_set={
-                ens_name: table_provider_factory.create_from_per_realization_parameter_file(
-                    ens_path
-                )
-                for ens_name, ens_path in ensemble_paths.items()
-            }
-        )
+        parameter_provider_set = create_parameter_providerset_from_paths(ensemble_paths)
+        parameter_df = parameter_provider_set.get_combined_dataframe()
 
         self._pmodel = ParametersModel(
             dataframe=parameter_df,
@@ -151,15 +140,3 @@ realizations if you have defined `ensembles`.
             ParameterDistributionView(self._pmodel),
             self.Ids.PARAM_DIST_VIEW,
         )
-
-
-def create_df_from_table_provider(
-    provider_set: Dict[str, EnsembleTableProvider]
-) -> pd.DataFrame:
-    """Aggregates parameters from all ensemble into a common dataframe."""
-    dfs = []
-    for ens_name, provider in provider_set.items():
-        df = provider.get_column_data(column_names=provider.column_names())
-        df["ENSEMBLE"] = ens_name
-        dfs.append(df)
-    return pd.concat(dfs)

--- a/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_plugin.py
@@ -117,7 +117,7 @@ realizations if you have defined `ensembles`.
         )
 
         parameter_provider_set = create_parameter_providerset_from_paths(ensemble_paths)
-        parameter_df = parameter_provider_set.get_combined_dataframe()
+        parameter_df = parameter_provider_set.get_aggregated_dataframe()
 
         self._pmodel = ParametersModel(
             dataframe=parameter_df,

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -170,7 +170,7 @@ Responses are extracted automatically from the `.arrow` files in the individual 
             parameter_provider_set = create_parameter_providerset_from_paths(
                 self.ens_paths
             )
-            parameterdf = parameter_provider_set.get_combined_dataframe()
+            parameterdf = parameter_provider_set.get_aggregated_dataframe()
 
             if self.response_file:
                 self.responsedf = load_csv(

--- a/webviz_subsurface/plugins/_parameter_response_correlation.py
+++ b/webviz_subsurface/plugins/_parameter_response_correlation.py
@@ -17,10 +17,11 @@ from webviz_subsurface._models import ParametersModel
 from webviz_subsurface._providers import (
     EnsembleSummaryProvider,
     EnsembleSummaryProviderFactory,
-    EnsembleTableProvider,
-    EnsembleTableProviderFactory,
     Frequency,
     get_matching_vector_names,
+)
+from webviz_subsurface._utils.ensemble_table_provider_set_factory import (
+    create_parameter_providerset_from_paths,
 )
 
 
@@ -165,16 +166,11 @@ Responses are extracted automatically from the `.arrow` files in the individual 
                 ens: webviz_settings.shared_settings["scratch_ensembles"][ens]
                 for ens in ensembles
             }
-            table_provider_factory = EnsembleTableProviderFactory.instance()
 
-            parameterdf = create_df_from_table_provider(
-                provider_set={
-                    ens_name: table_provider_factory.create_from_per_realization_parameter_file(
-                        ens_path
-                    )
-                    for ens_name, ens_path in self.ens_paths.items()
-                }
+            parameter_provider_set = create_parameter_providerset_from_paths(
+                self.ens_paths
             )
+            parameterdf = parameter_provider_set.get_combined_dataframe()
 
             if self.response_file:
                 self.responsedf = load_csv(
@@ -774,18 +770,6 @@ def theme_layout(theme, specific_layout) -> Dict:
 @webvizstore
 def read_csv(csv_file) -> pd.DataFrame:
     return pd.read_csv(csv_file, index_col=False)
-
-
-def create_df_from_table_provider(
-    provider_set: Dict[str, EnsembleTableProvider]
-) -> pd.DataFrame:
-    """Aggregates parameters from all ensemble into a common dataframe."""
-    dfs = []
-    for ens_name, provider in provider_set.items():
-        df = provider.get_column_data(column_names=provider.column_names())
-        df["ENSEMBLE"] = ens_name
-        dfs.append(df)
-    return pd.concat(dfs)
 
 
 def create_df_from_summary_provider(

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_plugin.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_plugin.py
@@ -89,7 +89,7 @@ run with that sensitivity.
             )
 
         parameter_provider_set = create_parameter_providerset_from_paths(ensemble_paths)
-        parameter_df = parameter_provider_set.get_combined_dataframe()
+        parameter_df = parameter_provider_set.get_aggregated_dataframe()
         parametermodel = ParametersModel(dataframe=parameter_df, drop_constants=True)
 
         self.add_view(

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_plugin.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_plugin.py
@@ -1,19 +1,17 @@
 from pathlib import Path
 from typing import Dict
 
-import pandas as pd
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.utils import StrEnum
 
 from webviz_subsurface._models.parameter_model import ParametersModel
-from webviz_subsurface._providers import (
-    EnsembleTableProvider,
-    EnsembleTableProviderFactory,
-    Frequency,
-)
+from webviz_subsurface._providers import Frequency
 from webviz_subsurface._utils.ensemble_summary_provider_set_factory import (
     create_lazy_ensemble_summary_provider_set_from_paths,
     create_presampled_ensemble_summary_provider_set_from_paths,
+)
+from webviz_subsurface._utils.ensemble_table_provider_set_factory import (
+    create_parameter_providerset_from_paths,
 )
 
 from ._utils import SimulationTimeSeriesOneByOneDataModel
@@ -59,7 +57,6 @@ run with that sensitivity.
         super().__init__()
 
         # vectormodel: ProviderTimeSeriesDataModel
-        table_provider = EnsembleTableProviderFactory.instance()
         resampling_frequency = Frequency(sampling)
 
         if ensembles is not None:
@@ -91,13 +88,8 @@ run with that sensitivity.
                 " are not instantiated for plugin"
             )
 
-        parameterproviderset = {
-            ens_name: table_provider.create_from_per_realization_parameter_file(
-                str(ens_path)
-            )
-            for ens_name, ens_path in ensemble_paths.items()
-        }
-        parameter_df = create_df_from_table_provider(parameterproviderset)
+        parameter_provider_set = create_parameter_providerset_from_paths(ensemble_paths)
+        parameter_df = parameter_provider_set.get_combined_dataframe()
         parametermodel = ParametersModel(dataframe=parameter_df, drop_constants=True)
 
         self.add_view(
@@ -141,14 +133,3 @@ run with that sensitivity.
     #         {"id": self.uuid("vector"), "content": "Select time series"},
     #         {"id": self.uuid("ensemble"), "content": "Select ensemble"},
     #     ]
-
-
-def create_df_from_table_provider(
-    providerset: Dict[str, EnsembleTableProvider]
-) -> pd.DataFrame:
-    dfs = []
-    for ens, provider in providerset.items():
-        df = provider.get_column_data(column_names=provider.column_names())
-        df["ENSEMBLE"] = ens
-        dfs.append(df)
-    return pd.concat(dfs)

--- a/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
@@ -189,7 +189,7 @@ reek_test_data/aggregated_data/parameters.csv)
             parameter_provider_set = create_parameter_providerset_from_paths(
                 ensemble_paths, drop_failed_realizations
             )
-            parameters = parameter_provider_set.get_combined_dataframe()
+            parameters = parameter_provider_set.get_aggregated_dataframe()
         else:
             raise ValueError(
                 'Incorrent arguments. Either provide a "csvfile_vol" or "ensembles" and "volfiles"'


### PR DESCRIPTION
PR with improvements to the `EnsembleTableProvider` which leads to improved start up time of an `Webviz` instance.

Main issue with the current `EnsembleTableProvider` was that it was initializing a `ScratchEnsemble` for every unique csv-file/parameters in each unique ensemble, instead of using a cached `ScratchEnsemble`. This was time consuming and not very memory friendly.

This PR includes:

- Removal of the `fmu-ensemble` dependency in the `EnsembleTableProvider`. 
  - `fmu-ensemble` was used only for loading csvfiles into dataframes, and loading parameters into dataframe. This functionality is now included in this PR instead, and is based alot on exising functionality from the `EnsembleSummaryProvider`
  - The functionality from `fmu-ensemble` to filter on successful realization has been included (based on finding an "OK" file in the runpath).

- Replacement of the `EnsembleSetModel` in following plugins
  - VolumetricAnalysis
  - RftPlotter

- Addition of an `EnsembleTableProviderSet` and factory for easy creation of an instance from enemble_paths
  - added functionality of creating an aggregated dataframe from the set, and removed duplicated code from several plugins.
 
- New argument `drop_failed_realizations` to `VolumetricAnalysis`
  - the default behavior previous was to skip csv-files from failed realizations, but often the users wanted to look at volumes from RMS, even though e.g. ECLIPSE had failed. 
---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
