### PR TITLE
Remove slow performant function in RftPlotter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#1227](https://github.com/equinor/webviz-subsurface/pull/1227) - New functionality in `SimulationTimeSeriesOneByOne`: option to use the sensitivity filter on all visualisations, not only the timeseries.
 
+### Fixed
+- [#1232](https://github.com/equinor/webviz-subsurface/pull/1232) - Removed slow function in `RftPlotter` to improve startup time of plugin.
+
 ## [0.2.20] - 2023-06-26
 
 ### Added

--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
@@ -159,11 +159,16 @@ class RftPlotterDataModel:
     def set_date_marks(self) -> Dict[int, Dict[str, Any]]:
         marks = {}
 
-        # Set number of datemarks for the slider
-        num_samples = min(4, len(self.dates))
+        # Set number of datemarks for the slider based on number of unique dates
+        unique_dates = len(self.dates)
+        possible_to_split_in_three = (unique_dates - 3) % 2 == 0
+        if unique_dates < 10 and possible_to_split_in_three:
+            num_samples = 3
+        else:
+            num_samples = min(4, unique_dates)
 
         # Generate evenly spaced indices
-        indices = np.linspace(0, len(self.dates) - 1, num_samples).astype(int)
+        indices = np.linspace(0, unique_dates - 1, num_samples).astype(int)
 
         # Sample dates using the calculated indices
         sampled_dates = [self.dates[i] for i in indices]

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_settings/_map_settings.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_settings/_map_settings.py
@@ -20,16 +20,14 @@ class MapSettings(SettingsGroupABC):
         self,
         ensembles: List[str],
         zones: List[str],
-        date_marks: Dict[str, Dict[str, Any]],
-        date_range_min: int,
-        date_range_max: int,
+        date_marks: Dict[int, Dict[str, Any]],
+        unique_dates_count: int,
     ) -> None:
         super().__init__("Map settings")
         self._ensembles = ensembles
         self._zone_names = zones
         self._date_marks = date_marks
-        self._date_range_min = date_range_min
-        self._date_range_max = date_range_max
+        self._unique_dates_count = unique_dates_count
 
     def layout(self) -> List[Component]:
         return [
@@ -79,12 +77,9 @@ class MapSettings(SettingsGroupABC):
             wcc.RangeSlider(
                 label="Filter date range",
                 id=self.register_component_unique_id(self.Ids.DATE_RANGE),
-                min=self._date_range_min,
-                max=self._date_range_max,
-                value=[
-                    self._date_range_min,
-                    self._date_range_max,
-                ],
+                min=0,
+                max=self._unique_dates_count - 1,
+                value=[0, self._unique_dates_count - 1],
                 marks=self._date_marks,
             ),
             wcc.Label(

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_utils/_map_figure.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_utils/_map_figure.py
@@ -8,9 +8,14 @@ from ...._types import ColorAndSizeByType
 
 class MapFigure:
     def __init__(
-        self, ertdf: pd.DataFrame, ensemble: str, zones: List[str], dates: List[str]
+        self,
+        ertdf: pd.DataFrame,
+        ensemble: str,
+        zones: List[str],
+        min_date: str,
+        max_date: str,
     ) -> None:
-        self._min_date, self._max_date = dates
+        self._min_date, self._max_date = min_date, max_date
         self._ertdf = ertdf.loc[
             (ertdf["ENSEMBLE"] == ensemble)
             & (ertdf["ZONE"].isin(zones))

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_utils/_map_figure.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_utils/_map_figure.py
@@ -7,26 +7,30 @@ from ...._types import ColorAndSizeByType
 
 
 class MapFigure:
-    def __init__(self, ertdf: pd.DataFrame, ensemble: str, zones: List[str]) -> None:
+    def __init__(
+        self, ertdf: pd.DataFrame, ensemble: str, zones: List[str], dates: List[str]
+    ) -> None:
+        self._min_date, self._max_date = dates
+        self._ertdf = ertdf.loc[
+            (ertdf["ENSEMBLE"] == ensemble)
+            & (ertdf["ZONE"].isin(zones))
+            & (ertdf["DATE"] >= self._min_date)
+            & (ertdf["DATE"] <= self._max_date)
+        ]
         self._ertdf = (
-            ertdf.loc[(ertdf["ENSEMBLE"] == ensemble) & (ertdf["ZONE"].isin(zones))]
+            self._ertdf.drop(columns="ZONE")
             .groupby(["WELL", "DATE", "ENSEMBLE"])
             .mean(numeric_only=False)
             .reset_index()
         )
-
         self._traces: List[Dict[str, Any]] = []
 
     def add_misfit_plot(
         self,
         sizeby: ColorAndSizeByType,
         colorby: ColorAndSizeByType,
-        dates: List[float],
     ) -> None:
-        df = self._ertdf.loc[
-            (self._ertdf["DATE_IDX"] >= dates[0])
-            & (self._ertdf["DATE_IDX"] <= dates[1])
-        ]
+        df = self._ertdf
         self._traces.append(
             {
                 "x": df["EAST"],
@@ -36,11 +40,16 @@ class MapFigure:
                 "mode": "markers",
                 "hovertext": [
                     f"Well: {well}"
+                    f"<br>Date: {date}"
                     f"<br>Mean simulated pressure: {pressure:.2f}"
                     f"<br>Mean misfit: {misfit:.2f}"
                     f"<br>Stddev pressure: {stddev:.2f}"
-                    for well, stddev, misfit, pressure in zip(
-                        df["WELL"], df["STDDEV"], df["DIFF"], df["SIMULATED"]
+                    for well, date, stddev, misfit, pressure in zip(
+                        df["WELL"],
+                        df["DATE"],
+                        df["STDDEV"],
+                        df["DIFF"],
+                        df["SIMULATED"],
                     )
                 ],
                 "hoverinfo": "text",
@@ -106,6 +115,7 @@ class MapFigure:
             "margin": {"t": 50, "l": 50},
             "xaxis": {"constrain": "domain", "showgrid": False},
             "yaxis": {"scaleanchor": "x", "showgrid": False},
+            "title": f"Date filter: {self._min_date} - {self._max_date}",
         }
 
     @property

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_view.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_view.py
@@ -127,8 +127,11 @@ class MapView(ViewABC):
             dateidx: List[int],
             zones: List[str],
         ) -> Union[str, List[wcc.Graph]]:
-            dates = [self._datamodel.dates[idx] for idx in dateidx]
-            figure = MapFigure(self._datamodel.ertdatadf, ensemble, zones, dates)
+            min_date = self._datamodel.dates[dateidx[0]]
+            max_date = self._datamodel.dates[dateidx[1]]
+            figure = MapFigure(
+                self._datamodel.ertdatadf, ensemble, zones, min_date, max_date
+            )
             if self._datamodel.faultlinesdf is not None:
                 figure.add_fault_lines(self._datamodel.faultlinesdf)
             figure.add_misfit_plot(sizeby, colorby)

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_view.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_map_view/_view.py
@@ -30,8 +30,7 @@ class MapView(ViewABC):
                 ensembles=self._datamodel.ensembles,
                 zones=self._datamodel.zone_names,
                 date_marks=self._datamodel.date_marks,
-                date_range_min=self._datamodel.ertdatadf["DATE_IDX"].min(),
-                date_range_max=self._datamodel.ertdatadf["DATE_IDX"].max(),
+                unique_dates_count=len(self._datamodel.dates),
             ),
             self.Ids.MAP_SETTINGS,
         )
@@ -125,13 +124,14 @@ class MapView(ViewABC):
             ensemble: str,
             sizeby: ColorAndSizeByType,
             colorby: ColorAndSizeByType,
-            dates: List[float],
+            dateidx: List[int],
             zones: List[str],
         ) -> Union[str, List[wcc.Graph]]:
-            figure = MapFigure(self._datamodel.ertdatadf, ensemble, zones)
+            dates = [self._datamodel.dates[idx] for idx in dateidx]
+            figure = MapFigure(self._datamodel.ertdatadf, ensemble, zones, dates)
             if self._datamodel.faultlinesdf is not None:
                 figure.add_fault_lines(self._datamodel.faultlinesdf)
-            figure.add_misfit_plot(sizeby, colorby, dates)
+            figure.add_misfit_plot(sizeby, colorby)
 
             return [
                 wcc.Graph(


### PR DESCRIPTION
PR to get rid of a very slow pandas apply function in the `RftPlotter`. In one medium sized project this function took 37 sec 😲 
The code is now improved and does no longer require this function.

The function in question:
```       
        self.ertdatadf["DATE_IDX"] = self.ertdatadf["DATE"].apply(
            lambda x: list(self.ertdatadf["DATE"].unique()).index(x)
        )
```

Small additional feature
- the selected date filter has been added as title in the map.
- the date has been added as hover info per RFT point in the map.
- Removed FutureWarning from pandas by dropping the `ZONE` column before doing a `groupby.mean()`