### PR TITLE
Bugfixes in the `EnsembleTableProvider` and `SimulationTimeseriesOneByOne`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#1232](https://github.com/equinor/webviz-subsurface/pull/1232) - Removed slow function in `RftPlotter` to improve startup time of plugin.
+- [#1234](https://github.com/equinor/webviz-subsurface/pull/1234) - Fixed a bug that occured in `SimulationTimeSeriesOneByOne` when changing between ensembles with different sensitivity names.
+
 
 ### Changed
 - [#1231](https://github.com/equinor/webviz-subsurface/pull/1231) - Upgrades to the `EnsembleTableProvider` that improves performance: it no longer relies on `fmu-ensemble` for loading csv-files and parameters into dataframes. Additional: added new plugin argument `drop_failed_realizations` to `VolumetricAnalysis` to be able to load in volumetrics files, if they exist, even though the ensemble has crashed.

--- a/webviz_subsurface/_models/parameter_model.py
+++ b/webviz_subsurface/_models/parameter_model.py
@@ -29,7 +29,6 @@ class ParametersModel:
             self._possible_selectors = [
                 col for col in self._possible_selectors if col != "SENSNAME"
             ]
-            self._dataframe["SENSNAME"].fillna("None")
 
         self._validate_dframe()
         self._sensrun = self._check_if_sensitivity_run()
@@ -57,7 +56,7 @@ class ParametersModel:
 
     @property
     def sensitivities(self) -> list:
-        return list(self._dataframe["SENSNAME"].unique()) if self.sensrun else []
+        return list(self._dataframe["SENSNAME"].unique())
 
     @property
     def sensrun(self) -> bool:
@@ -147,7 +146,7 @@ class ParametersModel:
         self._sensitivity_ensembles = []
 
         if "SENSNAME" not in self._dataframe:
-            return False
+            self._dataframe["SENSNAME"] = np.nan
 
         # if mix of gen_kw and sensitivity ensembles add
         # dummy sensitivvity columns to gen_kw ensembles

--- a/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
@@ -126,6 +126,10 @@ def _load_table_from_parameters_file(entry: FileEntry) -> dict:
     with open(entry.filename, "r") as paramfile:
         for line in paramfile:
             param, *valuelist = line.split()
+            # Remove leading and trailing qoutation marks.
+            # This can happen if a parameter value includes a space
+            if len(valuelist) > 1:
+                valuelist = [val.strip('"') for val in valuelist]
             value = " ".join(valuelist)
             data[param] = parse_number_from_string(value)
     return data

--- a/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/_table_import.py
@@ -125,7 +125,8 @@ def _load_table_from_parameters_file(entry: FileEntry) -> dict:
     data: Dict[str, Any] = {"REAL": int(entry.real)}
     with open(entry.filename, "r") as paramfile:
         for line in paramfile:
-            param, value = line.split()
+            param, *valuelist = line.split()
+            value = " ".join(valuelist)
             data[param] = parse_number_from_string(value)
     return data
 
@@ -143,7 +144,7 @@ def load_per_real_parameters_file(
     globpattern = os.path.join(ens_path, parameter_file)
     files_to_process = _discover_files(globpattern, validated_reals)
     if len(files_to_process) == 0:
-        LOGGER.warning(f"No csv files were discovered in: {ens_path}")
+        LOGGER.warning(f"No 'parameter.txt' files were discovered in: {ens_path}")
         LOGGER.warning(f"Glob pattern used: {globpattern}")
         return pd.DataFrame()
 

--- a/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
+++ b/webviz_subsurface/_providers/ensemble_table_provider/ensemble_table_provider_factory.py
@@ -279,6 +279,11 @@ class EnsembleTableProviderFactory(WebvizFactory):
         timer.lap_s()
         ensemble_df = load_per_real_parameters_file(ens_path, drop_failed_realizations)
 
+        if ensemble_df.empty:
+            raise ValueError(
+                f"Failed to load 'parameter.txt' files for ensemble {ens_path}."
+            )
+
         elapsed_load_parameters_s = timer.lap_s()
 
         try:

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view.py
@@ -132,6 +132,7 @@ class OneByOneView(ViewABC):
                     SensitivityFilter.Ids.SENSITIVITY_FILTER,
                 ),
                 "value",
+                allow_duplicate=True,
             ),
             Input(
                 self.view_element(self.Ids.TORNADO_PLOT)
@@ -168,6 +169,14 @@ class OneByOneView(ViewABC):
                     SensitivityFilter.Ids.SENSITIVITY_FILTER,
                 ),
                 "options",
+            ),
+            Output(
+                self.settings_group_unique_id(
+                    self.Ids.SENSITIVITY_FILTER,
+                    SensitivityFilter.Ids.SENSITIVITY_FILTER,
+                ),
+                "value",
+                allow_duplicate=True,
             ),
             Output(
                 {
@@ -220,9 +229,10 @@ class OneByOneView(ViewABC):
                 },
                 "value",
             ),
+            prevent_initial_call="initial_duplicate",
         )
         @callback_typecheck
-        def _update_sensitivity_filter_and_reference(
+        def _update_sensitivity_filter_reference_and_vector_selector(
             ensemble: str, vector: list, reference: str
         ) -> tuple:
             """Update graph with line coloring, vertical line and title"""
@@ -241,6 +251,7 @@ class OneByOneView(ViewABC):
             )
             return (
                 [{"label": elm, "value": elm} for elm in sensitivities],
+                sensitivities,
                 [{"label": elm, "value": elm} for elm in sensitivities],
                 self._data_model.get_tornado_reference(sensitivities, reference),
                 vector_selector_data,

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view.py
@@ -122,6 +122,8 @@ class OneByOneView(ViewABC):
         )
         def _update_realization_store(sensitivites: list, ensemble: str) -> List[int]:
             """Update graph with line coloring, vertical line and title"""
+            if not sensitivites:
+                raise PreventUpdate
             df = self._data_model.get_sensitivity_dataframe_for_ensemble(ensemble)
             return self._data_model.get_realizations_for_sensitivies(df, sensitivites)
 


### PR DESCRIPTION
PR with some bugfixes:

- Bugfix in the `EnsembleTableProvider` to allow spaces in parameter values, when loading parameters.txt. (e.g in a sensitivity name). 
  - This change is done on a unreleased feature, hence no changelog entry.

- Bugfixes in the `SimulationTimeseriesOneByOne` 
  - Change selected sensitivity filter values when ensemble is changed. Closes #1228
    - Here the new feature in Dash to allow for duplicate outputs in callbacks has been utilized to avoid combining two callbacks into one.
  - Prevent update if no sensitivities have been selected in the sensitivity filter
  - Avoid Error if no sensitivity ensembles are input to the plugin
    - handled by allowing existing functionality in the `ParametersModel `to insert values for `SENSNAME/SENSCASE`
