### PR TITLE
CO2Leakage: Add options-button for plotting polygons and fault lines, plus some minor visual changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [#1231](https://github.com/equinor/webviz-subsurface/pull/1231) - Upgrades to the `EnsembleTableProvider` that improves performance: it no longer relies on `fmu-ensemble` for loading csv-files and parameters into dataframes. Additional: added new plugin argument `drop_failed_realizations` to `VolumetricAnalysis` to be able to load in volumetrics files, if they exist, even though the ensemble has crashed.
+- [#1239](https://github.com/equinor/webviz-subsurface/pull/1239) - Added button for options and global filters to `CO2Leakage`, plus some minor visual changes.
+- [#1226](https://github.com/equinor/webviz-subsurface/pull/1226) - Various visual and performance upgrades to `CO2Leakage`: New UNSMRY plot, added option for hazardous polygon, changed some containment plots, added volume as alternative data source, and more.
 
 ## [0.2.20] - 2023-06-26
 

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -167,6 +167,9 @@ class CO2Leakage(WebvizPluginABC):
                 initial_surface,
                 self._map_attribute_names,
                 [c["name"] for c in self._color_tables],  # type: ignore
+                self._well_pick_provider.well_names()
+                if self._well_pick_provider
+                else [],
             ),
             self.Ids.MAIN_SETTINGS,
         )
@@ -358,6 +361,7 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.PLUME_THRESHOLD), "value"),
             Input(self._settings_component(ViewSettings.Ids.PLUME_SMOOTHING), "value"),
             Input(ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS, "value"),
+            Input(ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER, "value"),
             State(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
         )
         def update_map_attribute(
@@ -374,6 +378,7 @@ class CO2Leakage(WebvizPluginABC):
             plume_threshold: Optional[float],
             plume_smoothing: Optional[float],
             options_dialog_options: List[int],
+            selected_wells: List[str],
             ensemble: str,
         ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
             attribute = MapAttribute(attribute)
@@ -437,6 +442,7 @@ class CO2Leakage(WebvizPluginABC):
                 well_pick_provider=self._well_pick_provider,
                 plume_extent_data=plume_polygon,
                 options_dialog_options=options_dialog_options,
+                selected_wells=selected_wells,
             )
             annotations = create_map_annotations(
                 formation=formation,

--- a/webviz_subsurface/plugins/_co2_leakage/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_plugin.py
@@ -357,6 +357,7 @@ class CO2Leakage(WebvizPluginABC):
             Input(self._settings_component(ViewSettings.Ids.CM_MAX), "value"),
             Input(self._settings_component(ViewSettings.Ids.PLUME_THRESHOLD), "value"),
             Input(self._settings_component(ViewSettings.Ids.PLUME_SMOOTHING), "value"),
+            Input(ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS, "value"),
             State(self._settings_component(ViewSettings.Ids.ENSEMBLE), "value"),
         )
         def update_map_attribute(
@@ -372,6 +373,7 @@ class CO2Leakage(WebvizPluginABC):
             cm_max_val: Optional[float],
             plume_threshold: Optional[float],
             plume_smoothing: Optional[float],
+            options_dialog_options: List[int],
             ensemble: str,
         ) -> Tuple[List[Dict[Any, Any]], List[Any], Dict[Any, Any]]:
             attribute = MapAttribute(attribute)
@@ -434,6 +436,7 @@ class CO2Leakage(WebvizPluginABC):
                 file_hazardous_boundary=self._file_hazardous_boundary,
                 well_pick_provider=self._well_pick_provider,
                 plume_extent_data=plume_polygon,
+                options_dialog_options=options_dialog_options,
             )
             annotations = create_map_annotations(
                 formation=formation,
@@ -442,3 +445,12 @@ class CO2Leakage(WebvizPluginABC):
             )
             viewports = create_map_viewports()
             return (layers, annotations, viewports)
+
+        @callback(
+            Output(ViewSettings.Ids.OPTIONS_DIALOG, "open"),
+            Input(ViewSettings.Ids.OPTIONS_DIALOG_BUTTON, "n_clicks"),
+        )
+        def open_close_options_dialog(_n_clicks: Optional[int]) -> bool:
+            if _n_clicks is not None:
+                return _n_clicks > 0
+            raise PreventUpdate

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/callbacks.py
@@ -29,6 +29,7 @@ from webviz_subsurface.plugins._co2_leakage._utilities.co2volume import (
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     Co2VolumeScale,
+    LayoutLabels,
     MapAttribute,
 )
 from webviz_subsurface.plugins._co2_leakage._utilities.summary_graphs import (
@@ -222,6 +223,7 @@ def create_map_viewports() -> Dict:
                     "colormap-layer",
                     "fault-polygons-layer",
                     "license-boundary-layer",
+                    "hazardous-boundary-layer",
                     "well-picks-layer",
                     "plume-polygon-layer",
                 ],
@@ -238,6 +240,7 @@ def create_map_layers(
     file_hazardous_boundary: Optional[str],
     well_pick_provider: Optional[WellPickProvider],
     plume_extent_data: Optional[geojson.FeatureCollection],
+    options_dialog_options: List[int],
 ) -> List[Dict]:
     layers = []
     if surface_data is not None:
@@ -256,7 +259,10 @@ def create_map_layers(
             }
         )
 
-    if fault_polygon_url is not None:
+    if (
+        fault_polygon_url is not None
+        and LayoutLabels.SHOW_FAULTPOLYGONS in options_dialog_options
+    ):
         layers.append(
             {
                 "@@type": "FaultPolygonsLayer",
@@ -265,7 +271,10 @@ def create_map_layers(
                 "data": fault_polygon_url,
             }
         )
-    if file_containment_boundary is not None:
+    if (
+        file_containment_boundary is not None
+        and LayoutLabels.SHOW_CONTAINMENT_POLYGON in options_dialog_options
+    ):
         layers.append(
             {
                 "@@type": "GeoJsonLayer",
@@ -274,9 +283,13 @@ def create_map_layers(
                 "data": _parse_polygon_file(file_containment_boundary),
                 "stroked": False,
                 "getFillColor": [0, 172, 0, 120],
+                "visible": True,
             }
         )
-    if file_hazardous_boundary is not None:
+    if (
+        file_hazardous_boundary is not None
+        and LayoutLabels.SHOW_HAZARDOUS_POLYGON in options_dialog_options
+    ):
         layers.append(
             {
                 "@@type": "GeoJsonLayer",
@@ -285,6 +298,7 @@ def create_map_layers(
                 "data": _parse_polygon_file(file_hazardous_boundary),
                 "stroked": False,
                 "getFillColor": [200, 0, 0, 120],
+                "visible": True,
             }
         )
     if well_pick_provider is not None:

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -36,6 +36,8 @@ class LayoutLabels(str, Enum):
     SHOW_FAULTPOLYGONS = "Show fault polygons"
     SHOW_CONTAINMENT_POLYGON = "Show containment polygon"
     SHOW_HAZARDOUS_POLYGON = "Show hazardous polygon"
+    SHOW_WELLS = "Show wells"
+    WELL_FILTER = "Well filter"
     COMMON_SELECTIONS = "Options and global filters"
 
 

--- a/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
+++ b/webviz_subsurface/plugins/_co2_leakage/_utilities/generic.py
@@ -28,3 +28,25 @@ class GraphSource(StrEnum):
     CONTAINMENT_MASS = "Containment Data (mass)"
     CONTAINMENT_VOLUME_ACTUAL = "Containment Data (volume, actual)"
     CONTAINMENT_VOLUME_ACTUAL_SIMPLE = "Containment Data (volume, actual_simple)"
+
+
+class LayoutLabels(str, Enum):
+    """Text labels used in layout components"""
+
+    SHOW_FAULTPOLYGONS = "Show fault polygons"
+    SHOW_CONTAINMENT_POLYGON = "Show containment polygon"
+    SHOW_HAZARDOUS_POLYGON = "Show hazardous polygon"
+    COMMON_SELECTIONS = "Options and global filters"
+
+
+# pylint: disable=too-few-public-methods
+class LayoutStyle:
+    """CSS styling"""
+
+    OPTIONS_BUTTON = {
+        "marginBottom": "10px",
+        "width": "100%",
+        "height": "30px",
+        "line-height": "30px",
+        "background-color": "lightgrey",
+    }

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -138,7 +138,11 @@ class ViewSettings(SettingsGroupABC):
                 elif current_value in surfaces:
                     picked_formation = dash.no_update
                 else:
-                    picked_formation = formations[0]["value"]
+                    picked_formation = (
+                        "all"
+                        if any((x["value"] == "all" for x in formations))
+                        else formations[0]["value"]
+                    )
             return formations, picked_formation
 
         @callback(
@@ -261,6 +265,11 @@ class MapSelectorLayout(wcc.Selectors):
         cm_min_auto_id: str,
         cm_max_auto_id: str,
     ):
+        default_colormap = (
+            "turbo (Seq)"
+            if "turbo (Seq)" in color_scale_names
+            else color_scale_names[0]
+        )
         super().__init__(
             label="Map Settings",
             open_details=True,
@@ -292,7 +301,7 @@ class MapSelectorLayout(wcc.Selectors):
                         dcc.Dropdown(
                             id=colormap_id,
                             options=color_scale_names,
-                            value=color_scale_names[0],
+                            value=default_colormap,
                             clearable=False,
                         ),
                         "Minimum",

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -26,6 +26,7 @@ class ViewSettings(SettingsGroupABC):
         OPTIONS_DIALOG_BUTTON = "options-dialog-button"
         OPTIONS_DIALOG = "options-dialog"
         OPTIONS_DIALOG_OPTIONS = "options-dialog-options"
+        OPTIONS_DIALOG_WELL_FILTER = "options-dialog-well-filter"
 
         FORMATION = "formation"
         ENSEMBLE = "ensemble"
@@ -56,6 +57,7 @@ class ViewSettings(SettingsGroupABC):
         initial_surface: Optional[str],
         map_attribute_names: Dict[MapAttribute, str],
         color_scale_names: List[str],
+        well_names: List[str],
     ):
         super().__init__("Settings")
         self._ensemble_paths = ensemble_paths
@@ -63,10 +65,11 @@ class ViewSettings(SettingsGroupABC):
         self._map_attribute_names = map_attribute_names
         self._color_scale_names = color_scale_names
         self._initial_surface = initial_surface
+        self._well_names = well_names
 
     def layout(self) -> List[Component]:
         return [
-            DialogLayout(),
+            DialogLayout(self._well_names),
             OpenDialogButton(),
             EnsembleSelectorLayout(
                 self.register_component_unique_id(self.Ids.ENSEMBLE),
@@ -208,6 +211,7 @@ class DialogLayout(wcc.Dialog):
 
     def __init__(
         self,
+        well_names: List[str],
     ) -> None:
         checklist_options = []
         checklist_values = []
@@ -217,6 +221,8 @@ class DialogLayout(wcc.Dialog):
         checklist_values.append(LayoutLabels.SHOW_CONTAINMENT_POLYGON)
         checklist_options.append(LayoutLabels.SHOW_HAZARDOUS_POLYGON)
         checklist_values.append(LayoutLabels.SHOW_HAZARDOUS_POLYGON)
+        checklist_options.append(LayoutLabels.SHOW_WELLS)
+        checklist_values.append(LayoutLabels.SHOW_WELLS)
 
         super().__init__(
             title=LayoutLabels.COMMON_SELECTIONS,
@@ -229,7 +235,34 @@ class DialogLayout(wcc.Dialog):
                     options=[{"label": opt, "value": opt} for opt in checklist_options],
                     value=checklist_values,
                 ),
+                wcc.FlexBox(
+                    children=[
+                        html.Div(
+                            style={
+                                "flex": 3,
+                                "minWidth": "20px",
+                                "display": "block" if well_names else "none",
+                            },
+                            children=WellFilter(well_names),
+                        ),
+                    ],
+                    style={"width": "20vw"},
+                ),
             ],
+        )
+
+
+class WellFilter(html.Div):
+    def __init__(self, well_names: List[str]) -> None:
+        super().__init__(
+            style={"display": "block" if well_names else "none"},
+            children=wcc.SelectWithLabel(
+                label=LayoutLabels.WELL_FILTER,
+                id=ViewSettings.Ids.OPTIONS_DIALOG_WELL_FILTER,
+                options=[{"label": i, "value": i} for i in well_names],
+                value=well_names,
+                size=min(20, len(well_names)),
+            ),
         )
 
 

--- a/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_leakage/views/mainview/settings.py
@@ -15,12 +15,18 @@ from webviz_subsurface.plugins._co2_leakage._utilities.callbacks import property
 from webviz_subsurface.plugins._co2_leakage._utilities.generic import (
     Co2MassScale,
     GraphSource,
+    LayoutLabels,
+    LayoutStyle,
     MapAttribute,
 )
 
 
 class ViewSettings(SettingsGroupABC):
     class Ids(StrEnum):
+        OPTIONS_DIALOG_BUTTON = "options-dialog-button"
+        OPTIONS_DIALOG = "options-dialog"
+        OPTIONS_DIALOG_OPTIONS = "options-dialog-options"
+
         FORMATION = "formation"
         ENSEMBLE = "ensemble"
         REALIZATION = "realization"
@@ -60,6 +66,8 @@ class ViewSettings(SettingsGroupABC):
 
     def layout(self) -> List[Component]:
         return [
+            DialogLayout(),
+            OpenDialogButton(),
             EnsembleSelectorLayout(
                 self.register_component_unique_id(self.Ids.ENSEMBLE),
                 self.register_component_unique_id(self.Ids.REALIZATION),
@@ -179,6 +187,46 @@ class ViewSettings(SettingsGroupABC):
             min_auto: List[str], max_auto: List[str]
         ) -> Tuple[bool, bool]:
             return len(min_auto) == 1, len(max_auto) == 1
+
+
+class OpenDialogButton(html.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            LayoutLabels.COMMON_SELECTIONS,
+            id=ViewSettings.Ids.OPTIONS_DIALOG_BUTTON,
+            style=LayoutStyle.OPTIONS_BUTTON,
+            n_clicks=0,
+        )
+
+
+class DialogLayout(wcc.Dialog):
+    """Layout for the options dialog"""
+
+    def __init__(
+        self,
+    ) -> None:
+        checklist_options = []
+        checklist_values = []
+        checklist_options.append(LayoutLabels.SHOW_FAULTPOLYGONS)
+        checklist_values.append(LayoutLabels.SHOW_FAULTPOLYGONS)
+        checklist_options.append(LayoutLabels.SHOW_CONTAINMENT_POLYGON)
+        checklist_values.append(LayoutLabels.SHOW_CONTAINMENT_POLYGON)
+        checklist_options.append(LayoutLabels.SHOW_HAZARDOUS_POLYGON)
+        checklist_values.append(LayoutLabels.SHOW_HAZARDOUS_POLYGON)
+
+        super().__init__(
+            title=LayoutLabels.COMMON_SELECTIONS,
+            id=ViewSettings.Ids.OPTIONS_DIALOG,
+            draggable=True,
+            open=False,
+            children=[
+                wcc.Checklist(
+                    id=ViewSettings.Ids.OPTIONS_DIALOG_OPTIONS,
+                    options=[{"label": opt, "value": opt} for opt in checklist_options],
+                    value=checklist_values,
+                ),
+            ],
+        )
 
 
 class FilterSelectorLayout(wcc.Selectors):


### PR DESCRIPTION
Added button "OPTIONS AND GLOBAL FILTERS", similar to MapViewer.

Also changed default color scale to turbo and changed default formation to "All" instead of the first one alphabetically.

![2023_10_12_picture_for_PR](https://github.com/equinor/webviz-subsurface/assets/99661468/1e3409dc-ae4e-4af0-a38a-7d13c544a49a)

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
