### PR TITLE
Fix bug for `perform_presampling: true` in `SimulationTimeSeries`

### DIFF
--- a/webviz_subsurface/plugins/_simulation_time_series/_plugin.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_plugin.py
@@ -122,7 +122,7 @@ class SimulationTimeSeries(WebvizPluginABC):
                 "is not supported by plugin yet!"
             )
         self._sampling = Frequency(sampling)
-        self._presampled_frequency = None
+        self._has_presampled_providers = False
 
         # TODO: Update functionality when allowing raw data and csv file input
         # NOTE: If csv is implemented-> handle/disable statistics, PER_INTVL_, PER_DAY_, delta
@@ -135,10 +135,11 @@ class SimulationTimeSeries(WebvizPluginABC):
                 for ensemble_name in ensembles
             }
             if perform_presampling:
-                self._presampled_frequency = self._sampling
+                presampled_frequency = self._sampling
+                self._has_presampled_providers = True
                 self._input_provider_set = (
                     create_presampled_ensemble_summary_provider_set_from_paths(
-                        ensemble_paths, rel_file_pattern, self._presampled_frequency
+                        ensemble_paths, rel_file_pattern, presampled_frequency
                     )
                 )
             else:
@@ -324,7 +325,7 @@ class SimulationTimeSeries(WebvizPluginABC):
             SubplotView(
                 custom_vector_definitions=self._custom_vector_definitions,
                 custom_vector_definitions_base=self._custom_vector_definitions_base,
-                disable_resampling_dropdown=self._presampled_frequency is not None,
+                has_presampled_providers=self._has_presampled_providers,
                 initial_selected_vectors=self._initial_vectors,
                 initial_vector_selector_data=self._initial_vector_selector_data,
                 initial_visualization=self._initial_visualization_selection,

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_resampling_frequency.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_resampling_frequency.py
@@ -21,25 +21,31 @@ class ResamplingFrequencySettings(SettingsGroupABC):
 
     def __init__(
         self,
-        disable_resampling_dropdown: bool,
+        disable_dropdowns: bool,
         selected_resampling_frequency: Frequency,
         ensembles_dates: List[datetime.datetime],
         input_provider_set: EnsembleSummaryProviderSet,
     ) -> None:
         super().__init__("Resampling frequency")
-        self._disable_resampling_dropdown = disable_resampling_dropdown
+        self._disable_dropdowns = disable_dropdowns
         self._selected_resampling_frequency = selected_resampling_frequency
         self._ensembles_dates = ensembles_dates
         self._input_provider_set = input_provider_set
 
     def layout(self) -> List[Component]:
         return [
+            wcc.Label(
+                "NB: Disabled for pre-sampled data",
+                style={"font-style": "italic", "font-weight": "bold"}
+                if self._disable_dropdowns
+                else {"display": "none"},
+            ),
             wcc.Dropdown(
                 id=self.register_component_unique_id(
                     ResamplingFrequencySettings.Ids.RESAMPLING_FREQUENCY_DROPDOWN
                 ),
                 clearable=False,
-                disabled=self._disable_resampling_dropdown,
+                disabled=self._disable_dropdowns,
                 options=[
                     {
                         "label": frequency.value,
@@ -59,11 +65,11 @@ class ResamplingFrequencySettings(SettingsGroupABC):
                 },
             ),
             wcc.Dropdown(
-                clearable=True,
-                disabled=self._disable_resampling_dropdown,
                 id=self.register_component_unique_id(
                     ResamplingFrequencySettings.Ids.RELATIVE_DATE_DROPDOWN
                 ),
+                clearable=True,
+                disabled=self._disable_dropdowns,
                 options=[
                     {
                         "label": datetime_utils.to_str(_date),
@@ -71,11 +77,5 @@ class ResamplingFrequencySettings(SettingsGroupABC):
                     }
                     for _date in sorted(self._ensembles_dates)
                 ],
-            ),
-            wcc.Label(
-                "NB: Disabled for pre-sampled data",
-                style={"font-style": "italic"}
-                if self._disable_resampling_dropdown
-                else {"display": "none"},
             ),
         ]


### PR DESCRIPTION
When plugin was configured with `perform_presampling: true`, the active presamling frequency was passed to the presampled ensemble summary providers when looking for dates. This is incorrect and prevented by not retrieving dates for presampled providers. 

The dates was retrieved for usage in "Data relative to date" selection. As this calculation is dependent of equal vector length handled by extrapolation/interpolation functionality in providers, it is disabled for presampled providers.