### PR TITLE
Added facies fractions to `VolumetricAnalysis` and smaller bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED] - YYYY-MM-DD
+
+### Added
+- [#1244](https://github.com/equinor/webviz-subsurface/pull/1244) - New functionality in `VolumetricAnalysis` to compute facies fractions if `FACIES` is present in the volumetric table. Also added possibility to have labels on bar plots with user defined value format. 
+
+
+## [0.2.22] - 2023-08-31
 
 ### Added
 - [#1227](https://github.com/equinor/webviz-subsurface/pull/1227) - New functionality in `SimulationTimeSeriesOneByOne`: option to use the sensitivity filter on all visualisations, not only the timeseries.

--- a/webviz_subsurface/_figures/px_figure.py
+++ b/webviz_subsurface/_figures/px_figure.py
@@ -6,6 +6,8 @@ import plotly.express as px
 import plotly.graph_objects as go
 from pandas.api.types import is_numeric_dtype
 
+VALID_BOXMODES = ["group", "overlay"]
+
 
 def create_figure(plot_type: str, **kwargs: Any) -> go.Figure:
     """Create subplots for selected parameters"""
@@ -32,6 +34,9 @@ def set_default_args(**plotargs: Any) -> dict:
     plotargs["histnorm"] = plotargs.get("histnorm", "percent")
     plotargs["barmode"] = plotargs.get("barmode", "group")
     plotargs["opacity"] = plotargs.get("opacity", 0.7)
+
+    if "boxmode" in plotargs and plotargs["boxmode"] not in VALID_BOXMODES:
+        plotargs["boxmode"] = VALID_BOXMODES[0]
 
     if plotargs.get("facet_col") is not None:
         facet_cols = plotargs["data_frame"][plotargs["facet_col"]].nunique()

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -109,6 +109,9 @@ def comparison_callback(
     ):
         groupby.append("FLUID_ZONE")
 
+    if selections["Response"] == "FACIES_FRACTION" and "FACIES" not in groupby:
+        groupby.append("FACIES")
+
     if display_option == "multi-response table":
         # select max one hc_response for a cleaner table
         responses = [selections["Response"]] + [
@@ -287,7 +290,6 @@ def create_comparison_df(
         df[col, "diff (%)"] = ((df[col][value2] / df[col][value1]) - 1) * 100
         df.loc[df[col]["diff"] == 0, (col, "diff (%)")] = 0
     df = df[responses].replace([np.inf, -np.inf], np.nan).reset_index()
-
     # remove rows where the selected response is nan
     # can happen for properties where the volume columns are 0
     df = df.loc[~((df[resp][value1].isna()) & (df[resp][value2].isna()))]

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/tornado_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/tornado_controllers.py
@@ -22,7 +22,7 @@ from ..utils.utils import update_relevant_components
 from ..views.tornado_view import tornado_error_layout, tornado_plots_layout
 
 
-# pylint: disable=too-many-locals, too-many-statements
+# pylint: disable=too-many-locals, too-many-statements, too-many-branches
 def tornado_controllers(
     get_uuid: Callable, volumemodel: InplaceVolumesModel, theme: WebvizConfigTheme
 ) -> None:
@@ -48,6 +48,23 @@ def tornado_controllers(
             groups.append(selections["Subplots"])
 
         filters = selections["filters"].copy()
+
+        if selections["Response"] == "FACIES_FRACTION" and "FACIES" not in groups:
+            if len(filters.get("FACIES", [])) == 1:
+                groups.append("FACIES")
+            else:
+                return update_relevant_components(
+                    id_list=id_list,
+                    update_info=[
+                        {
+                            "new_value": tornado_error_layout(
+                                "To see tornado for FACIES_FRACTION. Either select "
+                                "'FACIES' as subplot value or filter to only one facies"
+                            ),
+                            "conditions": {"page": page_selected},
+                        }
+                    ],
+                )
 
         figures = []
         tables = []
@@ -340,10 +357,4 @@ def create_tornado_table(
 
     columns = create_table_columns(columns=[subplots]) if subplots is not None else []
     columns.extend(tornado_table.columns)
-    columns.extend(
-        create_table_columns(
-            columns=["Reference"],
-            use_si_format=["Reference"] if use_si_format else [],
-        )
-    )
     return table_data, columns

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
@@ -5,6 +5,15 @@ import plotly.graph_objects as go
 import webviz_core_components as wcc
 from dash import dash_table
 
+from webviz_subsurface._models import InplaceVolumesModel
+from webviz_subsurface._utils.colors import StandardColors
+
+FLUID_COLORS = {
+    "oil": StandardColors.OIL_GREEN,
+    "gas": StandardColors.GAS_RED,
+    "water": StandardColors.WATER_BLUE,
+}
+
 
 def create_table_columns(
     columns: list,
@@ -85,11 +94,6 @@ def create_data_table(
 
 
 def fluid_table_style() -> list:
-    fluid_colors = {
-        "oil": "#007079",
-        "gas": "#FF1243",
-        "water": "#ADD8E6",
-    }
     return [
         {
             "if": {
@@ -99,7 +103,7 @@ def fluid_table_style() -> list:
             "color": color,
             "fontWeight": "bold",
         }
-        for fluid, color in fluid_colors.items()
+        for fluid, color in FLUID_COLORS.items()
     ]
 
 
@@ -153,3 +157,19 @@ def update_tornado_figures_xaxis(figures: List[go.Figure]) -> None:
     x_absmax = max([max(abs(trace.x)) for fig in figures for trace in fig.data])
     for fig in figures:
         fig.update_layout(xaxis_range=[-x_absmax, x_absmax])
+
+
+def get_text_format_bar_plot(
+    responses: list, selections: dict, volumemodel: InplaceVolumesModel
+) -> Union[bool, str]:
+    """Get number format for bar plot labels"""
+    if not selections["textformat"]:
+        return False
+
+    if selections["textformat"] == "default":
+        if any(x in responses for x in volumemodel.volume_columns):
+            return f".{selections['decimals']}s"
+        if any(x in responses for x in volumemodel.property_columns):
+            return f".{selections['decimals']}f"
+
+    return f".{selections['decimals']}{selections['textformat']}"

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 import webviz_core_components as wcc
-from dash import html
+from dash import dcc, html
 from webviz_config import WebvizConfigTheme
 
 from webviz_subsurface._models import InplaceVolumesModel
@@ -167,6 +167,7 @@ def settings_layout(
             remove_fluid_annotation(volumemodel, uuid=uuid, tab=tab),
             subplot_xaxis_range(uuid=uuid, tab=tab),
             histogram_options(uuid=uuid, tab=tab),
+            bar_text_options(uuid=uuid, tab=tab),
             html.Span("Colors", style={"font-weight": "bold"}),
             wcc.ColorScales(
                 id={"id": uuid, "tab": tab, "settings": "Colorscale"},
@@ -227,6 +228,7 @@ def remove_fluid_annotation(
 
 def histogram_options(uuid: str, tab: str) -> html.Div:
     return html.Div(
+        style={"margin-bottom": "10px"},
         children=[
             wcc.RadioItems(
                 label="Barmode:",
@@ -247,6 +249,49 @@ def histogram_options(uuid: str, tab: str) -> html.Div:
                 marks={1: 1, 10: 10, 20: 20, 30: 30},
                 min=1,
                 max=30,
+            ),
+        ],
+    )
+
+
+def bar_text_options(uuid: str, tab: str) -> html.Div:
+    return html.Div(
+        children=[
+            html.Span("Bar label format:", style={"font-weight": "bold"}),
+            html.Div(
+                style={"margin-bottom": "15px"},
+                children=[
+                    wcc.RadioItems(
+                        id={"id": uuid, "tab": tab, "selector": "textformat"},
+                        options=[
+                            {"label": "No label", "value": False},
+                            {"label": "Default", "value": "default"},
+                            {"label": "SI", "value": "s"},
+                            {"label": "Float", "value": "f"},
+                        ],
+                        labelStyle={"display": "inline-flex", "margin-right": "5px"},
+                        value="default",
+                    ),
+                    wcc.FlexBox(
+                        children=[
+                            wcc.Label(
+                                "Label precision:",
+                                style={"flex": 1, "minWidth": "40px"},
+                            ),
+                            dcc.Input(
+                                id={"id": uuid, "tab": tab, "selector": "decimals"},
+                                style={"flex": 1, "minWidth": "40px"},
+                                type="number",
+                                required=True,
+                                value=3,
+                                step=1,
+                                max=6,
+                                persistence=True,
+                                persistence_type="session",
+                            ),
+                        ],
+                    ),
+                ],
             ),
         ]
     )


### PR DESCRIPTION
PR that adds new functionality to compute facies fractions per individual facies in the `VolumetricAnalysis` plugin.
To compute facies fractions, FACIES needs to be included as a groupby selector. To inform users text is outputted to the screen.
The fractions is calculated as the sum of bulk for a facies divided by the total bulk sum - this gives exact results as weighting on bulk volumes inside RMS.

Other smaller improvements in this PR:
- added text label to bar plots, and possibility to control the number formatting from settings. Note the Default option will try to guess the format based on the selected responses.
- added more fluid representative coloring to plots if the "FLUID_ZONE" is used as Color by. 

![image](https://github.com/equinor/webviz-subsurface/assets/61694854/e44131dd-ed65-46d4-aad8-42888bc58144)
![image](https://github.com/equinor/webviz-subsurface/assets/61694854/d4f9962b-72a5-4789-b8c3-cbc66dcb2820)

Other smaller bug fixes in this PR:
- ensure that the boxmode is always valid for box plots
- ensure the plot type is never None when the page is "Custom plotting"
- changed the check for Water volumes computation to only check the required "BULK", "NET", and "PORV" columns.
- removed duplicate "Reference" column in tornado table, it is now given as default by the `TornadoTable`

