### PR TITLE
Adjust naming according to new property names after splitting GroupTree-component view/settings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
         "vtk>=9.2.2,<9.3",
         "webviz-config",
         "webviz-core-components>=0.6",
-        "webviz-subsurface-components==1.0.1",
+        "webviz-subsurface-components==1.0.2",
     ],
     extras_require={"tests": TESTS_REQUIRE},
     setup_requires=["setuptools_scm~=3.2"],

--- a/webviz_subsurface/plugins/_group_tree/_utils/_ensemble_group_tree_data.py
+++ b/webviz_subsurface/plugins/_group_tree/_utils/_ensemble_group_tree_data.py
@@ -84,8 +84,7 @@ class EnsembleGroupTreeData:
         grouptree data, before the filtered data is sent to the function that is
         actually creating the dataset.
 
-        Returns the group tree data and two lists with dropdown options for what
-        to display on the edges and nodes.
+        Returns the group tree data and two lists with metadata for edges and nodes in the tree data structure
 
         A sample data set can be found here:
         https://github.com/equinor/webviz-subsurface-components/blob/master/react/src/demo/example-data/group-tree.json
@@ -130,13 +129,16 @@ class EnsembleGroupTreeData:
             dfs.append(gruptree_filtered[gruptree_filtered[f"IS_{tpe.value}".upper()]])
         gruptree_filtered = pd.concat(dfs).drop_duplicates()
 
+        # Metadata for node: {key: str, label: str, unit: Optional[str]}
+        # The "key" correspond to the key for node data in the tree data set.
+        node_metadata_list = [
+                {"key": datatype, "label": get_label(datatype)}
+                for datatype in [DataType.PRESSURE, DataType.BHP, DataType.WMCTL]
+            ]
         return (
             create_dataset(smry, gruptree_filtered, self._sumvecs, self._terminal_node),
-            self.get_edge_options(node_types),
-            [
-                {"name": datatype, "label": get_label(datatype)}
-                for datatype in [DataType.PRESSURE, DataType.BHP, DataType.WMCTL]
-            ],
+            self.create_edge_metadata_list(node_types),
+            node_metadata_list,
         )
 
     @CACHE.memoize()
@@ -217,32 +219,35 @@ class EnsembleGroupTreeData:
             )
 
     @CACHE.memoize()
-    def get_edge_options(self, node_types: List[NodeType]) -> List[Dict[str, str]]:
-        """Returns a list with edge node options for the dropdown
-        menu in the GroupTree component. The output list has the format:
+    def create_edge_metadata_list(self, node_types: List[NodeType]) -> List[Dict[str, str]]:
+        """Creates a list with edge metadata for both dropdowns and tree data
+        in the GroupTree component. The "key" correspond to the key for edge data
+        in the tree data set.
+        
+        The output list has the format:
         [
-            {"name": DataType.OILRATE, "label": "Oil Rate"},
-            {"name": DataType.GasRATE, "label": "Gas Rate"},
+            {"key": DataType.OILRATE, "label": "Oil Rate", "unit": "m3/d"},
+            {"key": DataType.GasRATE, "label": "Gas Rate", "unit": "m3/d"},
         ]
         """
         options = []
         if NodeType.PROD in node_types:
             for rate in [DataType.OILRATE, DataType.GASRATE, DataType.WATERRATE]:
-                options.append({"name": rate, "label": get_label(rate)})
+                options.append({"key": rate, "label": get_label(rate)})
         if NodeType.INJ in node_types and self._has_waterinj:
             options.append(
                 {
-                    "name": DataType.WATERINJRATE,
+                    "key": DataType.WATERINJRATE,
                     "label": get_label(DataType.WATERINJRATE),
                 }
             )
         if NodeType.INJ in node_types and self._has_gasinj:
             options.append(
-                {"name": DataType.GASINJRATE, "label": get_label(DataType.GASINJRATE)}
+                {"key": DataType.GASINJRATE, "label": get_label(DataType.GASINJRATE)}
             )
         if options:
             return options
-        return [{"name": DataType.OILRATE, "label": get_label(DataType.OILRATE)}]
+        return [{"key": DataType.OILRATE, "label": get_label(DataType.OILRATE)}]
 
 
 def get_edge_label(row: pd.Series) -> str:

--- a/webviz_subsurface/plugins/_group_tree/_utils/_ensemble_group_tree_data.py
+++ b/webviz_subsurface/plugins/_group_tree/_utils/_ensemble_group_tree_data.py
@@ -84,9 +84,11 @@ class EnsembleGroupTreeData:
         grouptree data, before the filtered data is sent to the function that is
         actually creating the dataset.
 
-        Returns the group tree data and two lists with metadata for edges and nodes in the tree data structure
+        Returns the group tree data and two lists with metadata for edges and nodes
+        in the tree data structure
 
         A sample data set can be found here:
+        # pylint: disable=line-too-long
         https://github.com/equinor/webviz-subsurface-components/blob/master/react/src/demo/example-data/group-tree.json
         """  # noqa
 

--- a/webviz_subsurface/plugins/_group_tree/_utils/_ensemble_group_tree_data.py
+++ b/webviz_subsurface/plugins/_group_tree/_utils/_ensemble_group_tree_data.py
@@ -132,9 +132,9 @@ class EnsembleGroupTreeData:
         # Metadata for node: {key: str, label: str, unit: Optional[str]}
         # The "key" correspond to the key for node data in the tree data set.
         node_metadata_list = [
-                {"key": datatype, "label": get_label(datatype)}
-                for datatype in [DataType.PRESSURE, DataType.BHP, DataType.WMCTL]
-            ]
+            {"key": datatype, "label": get_label(datatype)}
+            for datatype in [DataType.PRESSURE, DataType.BHP, DataType.WMCTL]
+        ]
         return (
             create_dataset(smry, gruptree_filtered, self._sumvecs, self._terminal_node),
             self.create_edge_metadata_list(node_types),
@@ -219,11 +219,13 @@ class EnsembleGroupTreeData:
             )
 
     @CACHE.memoize()
-    def create_edge_metadata_list(self, node_types: List[NodeType]) -> List[Dict[str, str]]:
+    def create_edge_metadata_list(
+        self, node_types: List[NodeType]
+    ) -> List[Dict[str, str]]:
         """Creates a list with edge metadata for both dropdowns and tree data
         in the GroupTree component. The "key" correspond to the key for edge data
         in the tree data set.
-        
+
         The output list has the format:
         [
             {"key": DataType.OILRATE, "label": "Oil Rate", "unit": "m3/d"},

--- a/webviz_subsurface/plugins/_group_tree/_views/_group_tree_view/_view.py
+++ b/webviz_subsurface/plugins/_group_tree/_views/_group_tree_view/_view.py
@@ -299,7 +299,7 @@ class GroupTreeView(ViewABC):
             ensemble_name: str,
         ) -> list:
             """This callback updates the input dataset to the Grouptree component."""
-            data, edge_options, node_options = self._group_tree_data[
+            data, edge_metadata_list, node_metadata_list = self._group_tree_data[
                 ensemble_name
             ].create_grouptree_dataset(
                 tree_mode,
@@ -312,8 +312,8 @@ class GroupTreeView(ViewABC):
                 wsc.GroupTree(
                     id=self._group_tree_component_id,
                     data=data,
-                    edge_options=edge_options,
-                    node_options=node_options,
+                    edge_metadata_list=edge_metadata_list,
+                    node_metadata_list=node_metadata_list,
                 ),
             ]
 


### PR DESCRIPTION
Adjustments to match: https://github.com/equinor/webviz-subsurface-components/pull/1794

----

Await new release of `wsc` before finalizing this PR.