### PR TITLE
Avoid `try/except` on `import`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 TESTS_REQUIRE = [
     "bandit",
-    "black>=22.1",
+    "black>=22.1,<24",
     "dash[testing]",
     "flaky",
     "isort",

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
@@ -37,6 +37,7 @@
 ########################################
 
 import abc
+import sys
 import warnings
 from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple, Union
@@ -51,10 +52,8 @@ from scipy import interpolate
 #
 # NOTE: Functions in this file cannot be used
 #       on non-Linux OSes.
-try:
+if sys.platform == "linux":
     from opm.io.ecl import EclFile
-except ImportError:
-    pass
 
 from ..eclipse_unit import ConvertUnits, EclUnitEnum, EclUnits
 from ..units import Unit

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
@@ -45,6 +45,9 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import numpy as np
 from scipy import interpolate
 
+from ..eclipse_unit import ConvertUnits, EclUnitEnum, EclUnits
+from ..units import Unit
+
 # opm is only available for Linux,
 # hence, ignore any import exception here to make
 # it still possible to use the PvtPlugin on
@@ -54,9 +57,6 @@ from scipy import interpolate
 #       on non-Linux OSes.
 if sys.platform == "linux":
     from opm.io.ecl import EclFile
-
-from ..eclipse_unit import ConvertUnits, EclUnitEnum, EclUnits
-from ..units import Unit
 
 
 class EclPropertyTableRawData:  # pylint: disable=too-few-public-methods

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
@@ -36,6 +36,7 @@
 #
 ########################################
 
+import sys
 from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
@@ -47,10 +48,8 @@ import numpy as np
 #
 # NOTE: Functions in this file cannot be used
 #       on non-Linux OSes.
-try:
+if sys.platform == "linux":
     from opm.io.ecl import EclFile
-except ImportError:
-    pass
 
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
@@ -41,16 +41,6 @@ from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
 
-# opm is only available for Linux,
-# hence, ignore any import exception here to make
-# it still possible to use the PvtPlugin on
-# machines with other OSes.
-#
-# NOTE: Functions in this file cannot be used
-#       on non-Linux OSes.
-if sys.platform == "linux":
-    from opm.io.ecl import EclFile
-
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (
     EclPhaseIndex,
@@ -62,6 +52,16 @@ from .pvt_common import (
     PvxOBase,
     surface_mass_density,
 )
+
+# opm is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+if sys.platform == "linux":
+    from opm.io.ecl import EclFile
 
 
 class WetGas(PvxOBase):

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
@@ -36,6 +36,7 @@
 #
 ########################################
 
+import sys
 from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
@@ -47,10 +48,8 @@ import numpy as np
 #
 # NOTE: Functions in this file cannot be used
 #       on non-Linux OSes.
-try:
+if sys.platform == "linux":
     from opm.io.ecl import EclFile
-except ImportError:
-    pass
 
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
@@ -41,16 +41,6 @@ from typing import Any, Callable, Optional, Tuple, Union
 
 import numpy as np
 
-# opm is only available for Linux,
-# hence, ignore any import exception here to make
-# it still possible to use the PvtPlugin on
-# machines with other OSes.
-#
-# NOTE: Functions in this file cannot be used
-#       on non-Linux OSes.
-if sys.platform == "linux":
-    from opm.io.ecl import EclFile
-
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (
     EclPhaseIndex,
@@ -63,6 +53,16 @@ from .pvt_common import (
     is_const_compr_index,
     surface_mass_density,
 )
+
+# opm is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+if sys.platform == "linux":
+    from opm.io.ecl import EclFile
 
 
 class LiveOil(PvxOBase):

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_water.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_water.py
@@ -41,16 +41,6 @@ from typing import Any, Callable, List, Optional, Union
 
 import numpy as np
 
-# opm is only available for Linux,
-# hence, ignore any import exception here to make
-# it still possible to use the PvtPlugin on
-# machines with other OSes.
-#
-# NOTE: Functions in this file cannot be used
-#       on non-Linux OSes.
-if sys.platform == "linux":
-    from opm.io.ecl import EclFile
-
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (
     EclPhaseIndex,
@@ -60,6 +50,16 @@ from .pvt_common import (
     PvxOBase,
     surface_mass_density,
 )
+
+# opm is only available for Linux,
+# hence, ignore any import exception here to make
+# it still possible to use the PvtPlugin on
+# machines with other OSes.
+#
+# NOTE: Functions in this file cannot be used
+#       on non-Linux OSes.
+if sys.platform == "linux":
+    from opm.io.ecl import EclFile
 
 
 class WaterImpl(PvxOBase):

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_water.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_water.py
@@ -36,6 +36,7 @@
 #
 ########################################
 
+import sys
 from typing import Any, Callable, List, Optional, Union
 
 import numpy as np
@@ -47,10 +48,8 @@ import numpy as np
 #
 # NOTE: Functions in this file cannot be used
 #       on non-Linux OSes.
-try:
+if sys.platform == "linux":
     from opm.io.ecl import EclFile
-except ImportError:
-    pass
 
 from ..eclipse_unit import ConvertUnits, CreateUnitConverter, EclUnitEnum, EclUnits
 from .pvt_common import (

--- a/webviz_subsurface/_datainput/pvt_data.py
+++ b/webviz_subsurface/_datainput/pvt_data.py
@@ -18,11 +18,9 @@ import pandas as pd
 #
 # NOTE: Functions in this file cannot be used
 #       on non-Linux OSes.
-try:
+if sys.platform == "linux":
     import res2df
     from opm.io.ecl import EclFile
-except ImportError:
-    pass
 
 from webviz_config.common_cache import CACHE
 from webviz_config.webviz_store import webvizstore

--- a/webviz_subsurface/_datainput/pvt_data.py
+++ b/webviz_subsurface/_datainput/pvt_data.py
@@ -10,6 +10,13 @@ from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
+from webviz_config.common_cache import CACHE
+from webviz_config.webviz_store import webvizstore
+
+from .eclipse_init_io.pvt_gas import Gas
+from .eclipse_init_io.pvt_oil import Oil
+from .eclipse_init_io.pvt_water import Water
+from .fmu_input import load_csv, load_ensemble_set
 
 # opm and res2df are only available for Linux,
 # hence, ignore any import exception here to make
@@ -21,14 +28,6 @@ import pandas as pd
 if sys.platform == "linux":
     import res2df
     from opm.io.ecl import EclFile
-
-from webviz_config.common_cache import CACHE
-from webviz_config.webviz_store import webvizstore
-
-from .eclipse_init_io.pvt_gas import Gas
-from .eclipse_init_io.pvt_oil import Oil
-from .eclipse_init_io.pvt_water import Water
-from .fmu_input import load_csv, load_ensemble_set
 
 
 @CACHE.memoize()


### PR DESCRIPTION
It seems like there is an error importing `opm` in Docker Python 3.8 for some reason. Since we use `try/except` to support Windows/MacOS we do not get the traceback and the CI tests do not fail.

Trying to change from `try/except` to explicitly saying we only want `opm` to be imported if platform is Linux.