### PR TITLE
Add volume change analysis plot to VolumetricAnalysis

### DIFF
--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from dash import Input, Output, State, callback, callback_context, dash_table, html
+from dash import Input, Output, State, callback, dash_table, html
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._figures import create_figure
@@ -32,51 +32,34 @@ def comparison_controllers(
     @callback(
         Output({"id": get_uuid("main-src-comp"), "wrapper": "table"}, "children"),
         Input(get_uuid("selections"), "data"),
-        Input({"id": get_uuid("main-src-comp"), "element": "display-option"}, "value"),
         State(get_uuid("page-selected"), "data"),
     )
-    def _update_page_src_comp(
-        selections: dict,
-        display_option: str,
-        page_selected: str,
-    ) -> html.Div:
-        ctx = callback_context.triggered[0]
-
+    def _update_page_src_comp(selections: dict, page_selected: str) -> html.Div:
         if page_selected != "src-comp":
             raise PreventUpdate
 
         selections = selections[page_selected]
-        if not "display-option" in ctx["prop_id"]:
-            if not selections["update"]:
-                raise PreventUpdate
+        if not selections["update"]:
+            raise PreventUpdate
 
         return comparison_callback(
             compare_on="SOURCE",
             volumemodel=volumemodel,
             selections=selections,
-            display_option=display_option,
         )
 
     @callback(
         Output({"id": get_uuid("main-ens-comp"), "wrapper": "table"}, "children"),
         Input(get_uuid("selections"), "data"),
-        Input({"id": get_uuid("main-ens-comp"), "element": "display-option"}, "value"),
         State(get_uuid("page-selected"), "data"),
     )
-    def _update_page_ens_comp(
-        selections: dict,
-        display_option: str,
-        page_selected: str,
-    ) -> html.Div:
-        ctx = callback_context.triggered[0]
-
+    def _update_page_ens_comp(selections: dict, page_selected: str) -> html.Div:
         if page_selected != "ens-comp":
             raise PreventUpdate
 
         selections = selections[page_selected]
-        if not "display-option" in ctx["prop_id"]:
-            if not selections["update"]:
-                raise PreventUpdate
+        if not selections["update"]:
+            raise PreventUpdate
 
         return comparison_callback(
             compare_on="SENSNAME_CASE"
@@ -84,7 +67,6 @@ def comparison_controllers(
             else "ENSEMBLE",
             volumemodel=volumemodel,
             selections=selections,
-            display_option=display_option,
         )
 
 
@@ -93,10 +75,11 @@ def comparison_callback(
     compare_on: str,
     volumemodel: InplaceVolumesModel,
     selections: dict,
-    display_option: str,
 ) -> html.Div:
     if selections["value1"] == selections["value2"]:
         return html.Div("Comparison between equal data")
+
+    display_option = selections["display_option"]
 
     # Handle None in highlight criteria input
     for key in ["Accept value", "Ignore <"]:

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -8,35 +8,7 @@ from webviz_subsurface._models import InplaceVolumesModel
 
 
 def comparison_main_layout(uuid: str) -> html.Div:
-    return [
-        html.Div(
-            style={"margin-bottom": "20px"},
-            children=wcc.RadioItems(
-                inline=True,
-                id={"id": uuid, "element": "display-option"},
-                options=[
-                    {
-                        "label": "QC plots",
-                        "value": "plots",
-                    },
-                    {
-                        "label": "Difference table for selected response",
-                        "value": "single-response table",
-                    },
-                    {
-                        "label": "Difference table for multiple responses",
-                        "value": "multi-response table",
-                    },
-                    {
-                        "label": "Volume change analysis plot (waterfall)",
-                        "value": "waterfall plot",
-                    },
-                ],
-                value="plots",
-            ),
-        ),
-        html.Div(id={"id": uuid, "wrapper": "table"}),
-    ]
+    return html.Div(id={"id": uuid, "wrapper": "table"})
 
 
 def comparison_qc_plots_layout(
@@ -119,7 +91,7 @@ def waterfall_plot_layout(
                     wcc.FlexColumn(
                         children=[
                             html.Div(
-                                "Note: If multiple plots, the plots are order by "
+                                "Note: If multiple plots, the plots are ordered by "
                                 "the largest absolute difference in percent."
                             ),
                             html.Div(
@@ -182,8 +154,37 @@ def comparison_selections(
     uuid: str, volumemodel: InplaceVolumesModel, tab: str, compare_on: str
 ) -> html.Div:
     options = comparison_options(compare_on, volumemodel)
+
     return html.Div(
         children=[
+            wcc.Selectors(
+                label="VISUALIZATION",
+                open_details=True,
+                children=[
+                    wcc.RadioItems(
+                        id={"id": uuid, "tab": tab, "selector": "display_option"},
+                        options=[
+                            {
+                                "label": "QC plots",
+                                "value": "plots",
+                            },
+                            {
+                                "label": "Difference table for selected response",
+                                "value": "single-response table",
+                            },
+                            {
+                                "label": "Difference table for multiple responses",
+                                "value": "multi-response table",
+                            },
+                            {
+                                "label": "Volume change analysis plot (waterfall)",
+                                "value": "waterfall plot",
+                            },
+                        ],
+                        value="plots",
+                    ),
+                ],
+            ),
             wcc.Selectors(
                 label="CONTROLS",
                 open_details=True,

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
@@ -12,7 +12,7 @@ def comparison_main_layout(uuid: str) -> html.Div:
         html.Div(
             style={"margin-bottom": "20px"},
             children=wcc.RadioItems(
-                vertical=False,
+                inline=True,
                 id={"id": uuid, "element": "display-option"},
                 options=[
                     {
@@ -26,6 +26,10 @@ def comparison_main_layout(uuid: str) -> html.Div:
                     {
                         "label": "Difference table for multiple responses",
                         "value": "multi-response table",
+                    },
+                    {
+                        "label": "Volume change analysis plot (waterfall)",
+                        "value": "waterfall plot",
                     },
                 ],
                 value="plots",
@@ -99,22 +103,61 @@ def comparison_table_layout(
         header = f"Table showing differences in {diff_mode} for multiple responses"
 
     return html.Div(
+        children=[wcc.Header(header), filter_info_text(selections, filter_info), table]
+    )
+
+
+def waterfall_plot_layout(
+    selections: dict, filter_info: str, figures: List[go.Figure]
+) -> html.Div:
+    return html.Div(
         children=[
-            wcc.Header(header),
-            html.Div(
-                style={"margin-bottom": "30px", "font-weight": "bold"},
+            wcc.Header("Waterfall plots showing contributions to volume change"),
+            wcc.FlexBox(
                 children=[
-                    html.Div(
-                        f"From {selections['value1'].replace('|', ':  ')} "
-                        f"to {selections['value2'].replace('|', ':  ')}"
-                    ),
-                    html.Div(
-                        f"{filter_info.capitalize()} {selections['filters'][filter_info][0]}"
+                    wcc.FlexColumn(filter_info_text(selections, filter_info)),
+                    wcc.FlexColumn(
+                        children=[
+                            html.Div(
+                                "Note: If multiple plots, the plots are order by "
+                                "the largest absolute difference in percent."
+                            ),
+                            html.Div(
+                                "A maximum of 10 plots will be displayed, "
+                                "use the filters to swap the selection."
+                            ),
+                        ],
+                        style={"font-size": "15px"},
                     ),
                 ],
             ),
-            table,
+            html.Div(
+                style={"height": "74vh", "overflow-y": "auto"},
+                children=[
+                    wcc.Graph(
+                        config={"displayModeBar": False},
+                        style={"height": "37vh"},
+                        figure=fig,
+                    )
+                    for fig in figures
+                ],
+            ),
         ]
+    )
+
+
+def filter_info_text(selections: dict, filter_info: str) -> html.Div:
+    return html.Div(
+        style={"margin-bottom": "30px", "font-weight": "bold"},
+        children=[
+            html.Div(
+                f"From {selections['value1'].replace('|', ':  ')} "
+                f"to {selections['value2'].replace('|', ':  ')}"
+            ),
+            html.Div(
+                f"{filter_info.capitalize()} {selections['filters'][filter_info][0]}"
+            ),
+        ],
     )
 
 
@@ -230,7 +273,7 @@ def diff_mode_selector(uuid: str, tab: str) -> html.Div:
                 {"label": "Percent", "value": "diff (%)"},
                 {"label": "True value", "value": "diff"},
             ],
-            labelStyle={"display": "inline-flex", "margin-right": "5px"},
+            inline=True,
             value="diff (%)",
         ),
     )


### PR DESCRIPTION
PR which resolves #1264, and adds waterfall plots for analyzing a volumetric change to the existing `comparison` tabs in `VolumetricAnalysis` .

The waterfall plot functionality is only supported for static volumes, and will only work for STOIIP or GIIP response.
If a `NET` column is present in the dataset `NTG` and `PORO_NET` will be used in the waterfall plot otherwise the `PORO `column is used.

The waterfall functionality will work both for `ensemble`, `source` and `sensitivity` volumes comparisons.


![image](https://github.com/equinor/webviz-subsurface/assets/61694854/ac2414bf-29a2-4607-9bb2-464c3d925668)

