### PR TITLE
Remove non-working lgtm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![PyPI version](https://badge.fury.io/py/webviz-subsurface.svg)](https://badge.fury.io/py/webviz-subsurface)
 [![Build Status](https://github.com/equinor/webviz-subsurface/workflows/webviz-subsurface/badge.svg)](https://github.com/equinor/webviz-subsurface/actions?query=branch%3Amaster)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/equinor/webviz-subsurface.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/equinor/webviz-subsurface/alerts/)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/equinor/webviz-subsurface.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/equinor/webviz-subsurface/context:python)
 [![Python 3.8 | 3.9 | 3.10](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10-blue.svg)](https://www.python.org/)
 ![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)
 


### PR DESCRIPTION
These stopped working back in 2022.
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/

Resolves #1279

---

### Contributor checklist

- [x] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
