### PR TITLE
Add column with total oil/gas volumes to VolumetricAnalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Added
+- [#1293](https://github.com/equinor/webviz-subsurface/pull/1293) - Added automatic calculation of `STOIIP_TOTAL` / `GIIP_TOTAL` in `VolumetricAnalysis`.
+
 ### Fixed
 - [#1287](https://github.com/equinor/webviz-subsurface/pull/1287) - Fixed bug when grouping on FACIES for non-standard static sources.
 

--- a/webviz_subsurface/_models/inplace_volumes_model.py
+++ b/webviz_subsurface/_models/inplace_volumes_model.py
@@ -36,6 +36,8 @@ class InplaceVolumesModel:
         "GIIP",
         "ASSOCIATEDOIL",
         "ASSOCIATEDGAS",
+        "STOIIP_TOTAL",
+        "GIIP_TOTAL",
         "BULK",
         "NET",
         "PORV",
@@ -92,6 +94,16 @@ class InplaceVolumesModel:
             self._dataframe = pd.merge(
                 self._dataframe, self.pmodel.sens_df, on=["ENSEMBLE", "REAL"]
             )
+
+        # create HC_TOTAL columns
+        if "STOIIP" in self._dataframe and "ASSOCIATEDOIL" in self._dataframe:
+            self._dataframe["STOIIP_TOTAL"] = self._dataframe["STOIIP"].fillna(
+                0
+            ) + self._dataframe["ASSOCIATEDOIL"].fillna(0)
+        if "GIIP" in self._dataframe and "ASSOCIATEDGAS" in self._dataframe:
+            self._dataframe["GIIP_TOTAL"] = self._dataframe["GIIP"].fillna(
+                0
+            ) + self._dataframe["ASSOCIATEDGAS"].fillna(0)
 
         # set column order
         colorder = self.selectors + self.VOLCOL_ORDER

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -103,7 +103,8 @@ def comparison_callback(
         responses = [selections["Response"]] + [
             col
             for col in volumemodel.responses
-            if col not in volumemodel.hc_responses and col != selections["Response"]
+            if col not in volumemodel.hc_responses + ["STOIIP_TOTAL", "GIIP_TOTAL"]
+            and col != selections["Response"]
         ]
         df = create_comparison_df(
             volumemodel,
@@ -135,9 +136,11 @@ def comparison_callback(
         require_response = selections["Response"] in ("STOIIP", "GIIP")
         required_columns = ["BULK", "PORO", "SW"]
         required_columns.append("BO" if selections["Response"] == "STOIIP" else "BG")
-        if not require_response or all(col in df for col in required_columns):
+        if not (
+            require_response and all(f"{col} diff" in df for col in required_columns)
+        ):
             return html.Div(
-                "Waterfall plot is only available for analyzing STOIIP/GIIP changes from static"
+                "Waterfall plot is only available for analyzing STOIIP/GIIP changes from static "
                 f"sources containing all {required_columns=}."
             )
         return waterfall_plot_layout(

--- a/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
@@ -199,6 +199,10 @@ reek_test_data/aggregated_data/parameters.csv)
             volumes_table=volumes_table,
             fipfile=get_path(self.fipfile) if self.fipfile else None,
         )
+        if self.fipfile and vcomb.dframe.empty:
+            raise ValueError(
+                "Not possible to obtain any results using the provided fipfile."
+            )
         self.disjoint_set_df = vcomb.disjoint_set_df
         self.volmodel = InplaceVolumesModel(
             volumes_table=vcomb.dframe,


### PR DESCRIPTION
Add automatic calculation of `STOIIP_TOTAL` and `GIIP_TOTAL` columns to `VolumetricAnalysis`.

Drogon example:
![image](https://github.com/equinor/webviz-subsurface/assets/61694854/11df1a61-1621-4f5b-ae2f-60bcabc07a47)

Also included a bugfix on the logic for evaluating if the data is compatible for a water fall plot