### PR TITLE
No Active Rfts error message

### DIFF
--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_rft_plotter_data_model.py
@@ -116,6 +116,9 @@ class RftPlotterDataModel:
         self.ertdatadf_inactive = filter_frame(self.ertdatadf, {"ACTIVE": 0})
         self.ertdatadf = filter_frame(self.ertdatadf, {"ACTIVE": 1})
 
+        if self.ertdatadf.empty:
+            raise ValueError("There are no active RFT points in the input data.")
+
         self.ertdatadf["STDDEV"] = self.ertdatadf.groupby(
             ["WELL", "DATE", "ZONE", "ENSEMBLE", "TVD"]
         )["SIMULATED"].transform("std")


### PR DESCRIPTION
Improved Error message in the corner case that there is no active RFTs in the input data. F.ex if all the RFTs are inactivated due to zone mismatch.

---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
