### PR TITLE
Pandas 2 compatibility for RFT plotter

### DIFF
--- a/webviz_subsurface/plugins/_rft_plotter/_views/_sim_vs_obs_view/_utils/_crossplot_figure.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_sim_vs_obs_view/_utils/_crossplot_figure.py
@@ -17,7 +17,10 @@ def update_crossplot(
 
     for _ens, ensdf in df.groupby("ENSEMBLE"):
         dframe = (
-            ensdf.groupby(["WELL", "DATE", "ZONE", "TVD"]).mean(numeric_only=True).reset_index().copy()
+            ensdf.groupby(["WELL", "DATE", "ZONE", "TVD"])
+            .mean(numeric_only=True)
+            .reset_index()
+            .copy()
         )
         trace = {
             "x": dframe["OBSERVED"],


### PR DESCRIPTION
Explicitly set `numerical_only` to `True` for aggregations as pandas >=2.0 changed the default from `True` to `False`.