### PR TITLE
Remove use of `wcc.ColorScales`

### DIFF
--- a/webviz_subsurface/plugins/_segy_viewer.py
+++ b/webviz_subsurface/plugins/_segy_viewer.py
@@ -324,7 +324,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             ]
 
             zslice_arr = get_zslice(cube, state["zslice"])
-            print(self.colors)
+
             fig = make_heatmap(
                 zslice_arr,
                 self.plotly_theme,

--- a/webviz_subsurface/plugins/_segy_viewer.py
+++ b/webviz_subsurface/plugins/_segy_viewer.py
@@ -49,7 +49,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
 
         self.zunit = zunit
         self.segyfiles: List[str] = [str(segy) for segy in segyfiles]
-        self.initial_colors = (
+        self.colors = (
             colors
             if colors
             else [
@@ -68,7 +68,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             ]
         )
         self.init_state = self.update_state(self.segyfiles[0])
-        self.init_state.get("colorscale", self.initial_colors)
         self.init_state.get("uirevision", str(uuid4()))
 
         self.plotly_theme = webviz_settings.theme.plotly_theme
@@ -86,7 +85,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             "color_min_value": float(f"{round(cube.values.min(), 2):2f}"),
             "color_max_value": float(f"{round(cube.values.max(), 2):2f}"),
             "uirevision": str(uuid4()),
-            "colorscale": self.initial_colors,
         }
         if kwargs:
             for key, value in kwargs.items():
@@ -120,10 +118,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             {
                 "id": self.uuid("zslice"),
                 "content": "Selected zslice for the seismic cube.",
-            },
-            {
-                "id": self.uuid("color-scale"),
-                "content": "Click this button to change colorscale",
             },
             {
                 "id": self.uuid("color-values"),
@@ -162,18 +156,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 ),
                 html.Div(
                     children=[
-                        wcc.Label(
-                            children="Set colorscale",
-                        ),
-                        wcc.ColorScales(
-                            id=self.uuid("color-scale"),
-                            colorscale=self.initial_colors,
-                            nSwatches=12,
-                        ),
-                    ],
-                ),
-                html.Div(
-                    children=[
                         wcc.RangeSlider(
                             label="Color range",
                             id=self.uuid("color-values"),
@@ -183,7 +165,8 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                                 self.init_state["min_value"],
                                 self.init_state["max_value"],
                             ],
-                            tooltip={"placement": "bottom"},
+                            marks=None,
+                            tooltip={"placement": "bottom", "always_visible": True},
                             step=calculate_slider_step(
                                 min_value=self.init_state["min_value"],
                                 max_value=self.init_state["max_value"],
@@ -257,7 +240,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 Input(self.uuid("xline"), "clickData"),
                 Input(self.uuid("zslice"), "clickData"),
                 Input(self.uuid("color-values"), "value"),
-                Input(self.uuid("color-scale"), "colorscale"),
                 Input(self.uuid("zoom"), "n_clicks"),
                 Input(self.uuid("color-reset"), "n_clicks"),
             ],
@@ -272,7 +254,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             xcd: Union[dict, None],
             zcd: Union[dict, None],
             color_values: List[float],
-            colorscale: List[float],
             _zoom_btn: Union[int, None],
             _reset_range_btn: Union[int, None],
             zfig: Union[dict, None],
@@ -311,7 +292,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             else:
                 store["color_min_value"] = color_values[0]
                 store["color_max_value"] = color_values[1]
-            store["colorscale"] = colorscale
             return json.dumps(store)
 
         @app.callback(
@@ -344,7 +324,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             ]
 
             zslice_arr = get_zslice(cube, state["zslice"])
-
+            print(self.colors)
             fig = make_heatmap(
                 zslice_arr,
                 self.plotly_theme,
@@ -358,7 +338,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 reverse_y=False,
                 zmin=state["color_min_value"],
                 zmax=state["color_max_value"],
-                colorscale=state["colorscale"],
+                colorscale=self.colors,
                 uirevision=state["uirevision"],
             )
             fig["layout"]["shapes"] = shapes
@@ -406,7 +386,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 yaxis_title=self.zunit,
                 zmin=state["color_min_value"],
                 zmax=state["color_max_value"],
-                colorscale=state["colorscale"],
+                colorscale=self.colors,
                 uirevision=state["uirevision"],
             )
             fig["layout"]["shapes"] = shapes
@@ -451,7 +431,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 yaxis_title=self.zunit,
                 zmin=state["color_min_value"],
                 zmax=state["color_max_value"],
-                colorscale=state["colorscale"],
+                colorscale=self.colors,
                 uirevision=state["uirevision"],
             )
             fig["layout"]["shapes"] = shapes

--- a/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_grid_cross_section.py
@@ -93,7 +93,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 Path(gridfile).stem for gridfile in gridparameterfiles
             ]
         self.plotly_theme = webviz_settings.theme.plotly_theme
-        self.initial_colors = (
+        self.colors = (
             colors
             if colors is not None
             else [
@@ -153,10 +153,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             {
                 "id": self.ids("gridparameter"),
                 "content": "The visualized grid parameter.",
-            },
-            {
-                "id": self.ids("color-scale"),
-                "content": ("Click this button to change colorscale"),
             },
             {
                 "id": self.ids("color-values"),
@@ -223,14 +219,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                                     ],
                                     value=self.gridparafiles[0],
                                     clearable=False,
-                                ),
-                                wcc.Label(
-                                    children="Set colorscale",
-                                ),
-                                wcc.ColorScales(
-                                    id=self.ids("color-scale"),
-                                    colorscale=self.initial_colors,
-                                    nSwatches=12,
                                 ),
                                 wcc.RangeSlider(
                                     label="Set color range",
@@ -335,10 +323,9 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 Input(self.ids("gridparameter"), "value"),
                 Input(self.ids("surface"), "value"),
                 Input(self.ids("color-values"), "value"),
-                Input(self.ids("color-scale"), "colorscale"),
             ],
         )
-        def _render_fence(coords, gridparameter, surfacepath, color_values, colorscale):
+        def _render_fence(coords, gridparameter, surfacepath, color_values):
             if not coords:
                 raise PreventUpdate
             grid = load_grid(get_path(self.gridfile))
@@ -369,7 +356,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 s_arr=s_arr,
                 theme=self.plotly_theme,
                 s_name=self.surfacenames[self.surfacefiles.index(surfacepath)],
-                colorscale=colorscale,
+                colorscale=self.colors,
                 xmin=hmin,
                 xmax=hmax,
                 ymin=vmin,

--- a/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
+++ b/webviz_subsurface/plugins/_surface_with_seismic_cross_section.py
@@ -85,7 +85,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
         else:
             self.segynames = [Path(segyfile).stem for segyfile in segyfiles]
         self.plotly_theme = webviz_settings.theme.plotly_theme
-        self.initial_colors = (
+        self.colors = (
             colors
             if colors is not None
             else [
@@ -147,10 +147,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
             {
                 "id": self.ids("cube"),
                 "content": "The visualized cube.",
-            },
-            {
-                "id": self.ids("color-scale"),
-                "content": ("Click this button to change colorscale"),
             },
             {
                 "id": self.ids("color-values"),
@@ -215,14 +211,6 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                                     ],
                                     value=self.segyfiles[0],
                                     clearable=False,
-                                ),
-                                wcc.Label(
-                                    children="Set colorscale",
-                                ),
-                                wcc.ColorScales(
-                                    id=self.ids("color-scale"),
-                                    colorscale=self.initial_colors,
-                                    nSwatches=12,
                                 ),
                                 wcc.RangeSlider(
                                     label="Set color range",
@@ -320,10 +308,9 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 Input(self.ids("cube"), "value"),
                 Input(self.ids("surface"), "value"),
                 Input(self.ids("color-values"), "value"),
-                Input(self.ids("color-scale"), "colorscale"),
             ],
         )
-        def _render_fence(coords, cubepath, surfacepath, color_values, colorscale):
+        def _render_fence(coords, cubepath, surfacepath, color_values):
             if not coords:
                 raise PreventUpdate
             cube = load_cube_data(get_path(cubepath))
@@ -337,7 +324,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                 s_arr=s_arr,
                 theme=self.plotly_theme,
                 s_name=self.surfacenames[self.surfacefiles.index(surfacepath)],
-                colorscale=colorscale,
+                colorscale=self.colors,
                 xmin=hmin,
                 xmax=hmax,
                 ymin=vmin,

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Optional, List
 
 import numpy as np
 import pandas as pd
@@ -32,7 +32,7 @@ from ..views.distribution_main_layout import (
 
 # pylint: disable=too-many-statements
 def distribution_controllers(
-    get_uuid: Callable, volumemodel: InplaceVolumesModel
+    get_uuid: Callable, volumemodel: InplaceVolumesModel, colors: List[str]
 ) -> None:
     @callback(
         Output({"id": get_uuid("main-voldist"), "page": "custom"}, "children"),
@@ -105,18 +105,18 @@ def distribution_controllers(
                 nbins=selections["hist_bins"],
                 facet_col=selections["Subplots"],
                 color=selections["Color by"],
-                color_discrete_sequence=selections["Colorscale"],
-                color_continuous_scale=selections["Colorscale"],
-                color_discrete_map=FLUID_COLORS
-                if selections["Color by"] == "FLUID_ZONE"
-                else None,
+                color_discrete_sequence=colors,
+                color_continuous_scale=colors,
+                color_discrete_map=(
+                    FLUID_COLORS if selections["Color by"] == "FLUID_ZONE" else None
+                ),
                 barmode=selections["barmode"],
                 boxmode=selections["barmode"],
-                text_auto=get_text_format_bar_plot(
-                    selected_data, selections, volumemodel
-                )
-                if selections["Plot type"] == "bar"
-                else False,
+                text_auto=(
+                    get_text_format_bar_plot(selected_data, selections, volumemodel)
+                    if selections["Plot type"] == "bar"
+                    else False
+                ),
                 layout={
                     "title": (
                         {
@@ -151,18 +151,22 @@ def distribution_controllers(
 
         return custom_plotting_layout(
             figure=figure,
-            tables=make_tables(
-                dframe=dframe,
-                responses=list({selections["X Response"], selections["Y Response"]}),
-                groups=groups,
-                volumemodel=volumemodel,
-                page_selected=page_selected,
-                selections=selections,
-                table_type="Statistics table",
-                view_height=37,
-            )
-            if selections["bottom_viz"] == "table"
-            else None,
+            tables=(
+                make_tables(
+                    dframe=dframe,
+                    responses=list(
+                        {selections["X Response"], selections["Y Response"]}
+                    ),
+                    groups=groups,
+                    volumemodel=volumemodel,
+                    page_selected=page_selected,
+                    selections=selections,
+                    table_type="Statistics table",
+                    view_height=37,
+                )
+                if selections["bottom_viz"] == "table"
+                else None
+            ),
         )
 
     @callback(
@@ -233,7 +237,7 @@ def distribution_controllers(
                         data_frame=dframe,
                         values=selections["X Response"],
                         names=selector,
-                        color_discrete_sequence=selections["Colorscale"],
+                        color_discrete_sequence=colors,
                         color=selector,
                     )
                     .update_traces(marker_line={"color": "#000000", "width": 1})
@@ -250,7 +254,7 @@ def distribution_controllers(
                 title=f"{selections['X Response']} per {selector}",
                 barmode="overlay" if selector == selections["Color by"] else "group",
                 layout={"bargap": 0.05},
-                color_discrete_sequence=selections["Colorscale"],
+                color_discrete_sequence=colors,
                 color=selections["Color by"],
                 xaxis={
                     "type": "category",
@@ -263,9 +267,9 @@ def distribution_controllers(
                     selections=selections,
                     volumemodel=volumemodel,
                 ),
-                color_discrete_map=FLUID_COLORS
-                if selections["Color by"] == "FLUID_ZONE"
-                else None,
+                color_discrete_map=(
+                    FLUID_COLORS if selections["Color by"] == "FLUID_ZONE" else None
+                ),
             ).update_layout(margin_t=35)
 
             if selections["X Response"] not in volumemodel.hc_responses:

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, List
+from typing import Any, Callable, Dict, Optional
 
 import webviz_core_components as wcc
 from dash import ALL, Input, Output, State, callback, callback_context, no_update

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, List
 
 import webviz_core_components as wcc
 from dash import ALL, Input, Output, State, callback, callback_context, no_update
@@ -21,10 +21,6 @@ def selections_controllers(
             {"id": get_uuid("filters"), "tab": ALL, "selector": ALL, "type": ALL},
             "value",
         ),
-        Input(
-            {"id": get_uuid("selections"), "tab": ALL, "settings": "Colorscale"},
-            "colorscale",
-        ),
         Input(get_uuid("initial-load-info"), "data"),
         State(get_uuid("page-selected"), "data"),
         State(get_uuid("tabs"), "value"),
@@ -37,7 +33,6 @@ def selections_controllers(
     def _update_selections(
         selectors: list,
         filters: list,
-        colorscale: str,
         initial_load: dict,
         selected_page: str,
         selected_tab: str,
@@ -63,7 +58,6 @@ def selections_controllers(
             if id_value["tab"] == selected_tab
         }
 
-        page_selections.update(Colorscale=colorscale[0] if colorscale else None)
         page_selections.update(ctx_clicked=ctx["prop_id"])
 
         # check if a page needs to be updated due to page refresh or
@@ -240,9 +234,9 @@ def selections_controllers(
 
         settings["bottom_viz"] = {
             "options": visualization_options,
-            "value": "none"
-            if selected_page != "custom"
-            else selections.get("bottom_viz"),
+            "value": (
+                "none" if selected_page != "custom" else selections.get("bottom_viz")
+            ),
         }
 
         return tuple(
@@ -336,9 +330,11 @@ def selections_controllers(
             selector_is_multi = page_filter_settings[selector]["multi"]
             if not multi and selector_is_multi:
                 values = [
-                    "rms_seed"
-                    if selector == "SENSNAME_CASE" and "rms_seed" in options
-                    else options[0]
+                    (
+                        "rms_seed"
+                        if selector == "SENSNAME_CASE" and "rms_seed" in options
+                        else options[0]
+                    )
                 ]
             elif multi and not selector_is_multi:
                 values = options

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/selections_view.py
@@ -159,7 +159,7 @@ def plot_selector_dropdowns(
 def settings_layout(
     volumemodel: InplaceVolumesModel, uuid: str, theme: WebvizConfigTheme, tab: str
 ) -> wcc.Selectors:
-    theme_colors = theme.plotly_theme.get("layout", {}).get("colorway", [])
+
     return wcc.Selectors(
         label="⚙️ SETTINGS",
         open_details=False,
@@ -168,13 +168,6 @@ def settings_layout(
             subplot_xaxis_range(uuid=uuid, tab=tab),
             histogram_options(uuid=uuid, tab=tab),
             bar_text_options(uuid=uuid, tab=tab),
-            html.Span("Colors", style={"font-weight": "bold"}),
-            wcc.ColorScales(
-                id={"id": uuid, "tab": tab, "settings": "Colorscale"},
-                colorscale=theme_colors,
-                fixSwatches=True,
-                nSwatches=12,
-            ),
         ],
     )
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
@@ -94,6 +94,7 @@ Only relevant if `ensembles` is defined. The key (e.g. `geogrid`) will be used a
 * **`non_net_facies`:** List of facies which are non-net.
 * **`fipfile`:** Path to a yaml-file that defines a match between FIPNUM regions
     and human readable regions, zones and etc to be used as filters.
+* **`colors`:** List of hex colors use.
 ---
 
 ?> The input files must follow FMU standards.
@@ -153,6 +154,7 @@ reek_test_data/aggregated_data/parameters.csv)
         non_net_facies: Optional[List[str]] = None,
         fipfile: Path = None,
         drop_failed_realizations: bool = True,
+        colors: List[str] = None,
     ):
         super().__init__()
         WEBVIZ_ASSETS.add(
@@ -169,7 +171,46 @@ reek_test_data/aggregated_data/parameters.csv)
             f" Plugin argument drop_failed_realizations is set to {drop_failed_realizations}. "
             "An 'OK' file in the realization runpath is used as success criteria"
         )
-
+        self.colors = (
+            colors
+            if colors is not None
+            else [
+                "#1F77B4",
+                "#FF7F0E",
+                "#2CA02C",
+                "#D62728",
+                "#9467BD",
+                "#8C564B",
+                "#E377C2",
+                "#7F7F7F",
+                "#BCBD22",
+                "#17BECF",
+                "#FD3216",
+                "#00FE35",
+                "#6A76FC",
+                "#FED4C4",
+                "#FE00CE",
+                "#0DF9FF",
+                "#F6F926",
+                "#FF9616",
+                "#479B55",
+                "#EEA6FB",
+                "#DC587D",
+                "#D626FF",
+                "#6E899C",
+                "#00B5F7",
+                "#B68E00",
+                "#C9FBE5",
+                "#FF0092",
+                "#22FFA7",
+                "#E3EE9E",
+                "#86CE00",
+                "#BC7196",
+                "#7E7DCD",
+                "#FC6955",
+                "#E48F72",
+            ]
+        )
         if csvfile_vol:
             table_provider = EnsembleTableProviderFactory.instance()
             volumes_table = table_provider.create_from_ensemble_csv_file(csvfile_vol)
@@ -229,7 +270,9 @@ reek_test_data/aggregated_data/parameters.csv)
 
     def set_callbacks(self) -> None:
         selections_controllers(get_uuid=self.uuid, volumemodel=self.volmodel)
-        distribution_controllers(get_uuid=self.uuid, volumemodel=self.volmodel)
+        distribution_controllers(
+            get_uuid=self.uuid, volumemodel=self.volmodel, colors=self.colors
+        )
         tornado_controllers(
             get_uuid=self.uuid, volumemodel=self.volmodel, theme=self.theme
         )


### PR DESCRIPTION
Remove use of wcc.ColorScales as it is not compatible with React 18

Changes:
- Not longer possible to interactively change color scales in `VolumetricsAnalysis`, `SegyViewer` and Map with intersection (grid/seismic)
- Added new optional config variable to specify list of hex colors to `VolumetricsAnalysis`. The other modules already has this.