### PR TITLE
Fix res2df import common

### DIFF
--- a/webviz_subsurface/_datainput/well_completions.py
+++ b/webviz_subsurface/_datainput/well_completions.py
@@ -15,7 +15,8 @@ import pandas as pd
 # NOTE: Functions in this file cannot be used
 #       on non-Linux OSes.
 try:
-    from res2df.resdatafiles import ResdataFiles, common
+    from res2df import common
+    from res2df.resdatafiles import ResdataFiles
 except ImportError:
     pass
 


### PR DESCRIPTION
Resolves problem where:

```
----> 1 from res2df.resdatafiles import common

ImportError: cannot import name 'common' from 'res2df.resdatafiles' (/prog/res/komodo/2025.04.01-py311-rhel8/root/lib64/python3.11/site-packages/res2df/resdatafiles.py)

```


---

### Contributor checklist

- [ ] :tada: This PR closes #ISSUE_NUMBER.
- [ ] :scroll: I have broken down my PR into the following tasks:
   - [ ] Task 1
   - [ ] Task 2
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
