### PR TITLE
fix(seismic_misfit): correct string formatting and variable usage

### DIFF
--- a/webviz_subsurface/plugins/_seismic_misfit.py
+++ b/webviz_subsurface/plugins/_seismic_misfit.py
@@ -235,8 +235,7 @@ class SeismicMisfit(WebvizPluginABC):
 
             obsinfo = _compare_dfs_obs(self.dframeobs[attribute_name], self.ens_names)
             self.caseinfo = (
-                f"{self.caseinfo}Attribute: {attribute_name}"
-                f"\n{obsinfo}\n-----------\n"
+                f"{self.caseinfo}Attribute: {attribute_name}\n{obsinfo}\n-----------\n"
             )
 
             # get sorted list of unique region values
@@ -2441,7 +2440,7 @@ def update_obs_sim_map_plot(
                 mode="markers",
                 marker={
                     "size": marker_size,
-                    "color": ensdf_stat["coverage"],
+                    "color": ensdf_stat[coverage],
                     "cmin": -1.0,
                     "cmax": 2.0,
                     "colorscale": SEISMIC_COVERAGE,


### PR DESCRIPTION
Adjusted string formatting in `caseinfo` construction to ensure proper newline placement. Fixed incorrect variable reference in `update_obs_sim_map_plot` by replacing `coverage` string with the correct variable `ensdf_stat[coverage]`.

*Insert a description of your pull request (PR) here, and check off the boxes below when they are done.*

---

### Contributor checklist

- [ ] :tada: This PR closes #1336 
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
