### PR TITLE
fix(running_time_analysis_fmu): handle missing keys in status JSON files

### DIFF
--- a/webviz_subsurface/plugins/_running_time_analysis_fmu.py
+++ b/webviz_subsurface/plugins/_running_time_analysis_fmu.py
@@ -602,7 +602,12 @@ def make_status_df(
         # Load each json-file to a DataFrame for the realization
         with open(row.FULLPATH) as fjson:
             status_dict = json.load(fjson)
-        real_df = pd.DataFrame(status_dict["jobs"])
+        if "steps" in status_dict:
+            real_df = pd.DataFrame(status_dict["steps"])
+        elif "jobs" in status_dict:
+            real_df = pd.DataFrame(status_dict["jobs"])
+        else:
+            raise KeyError(f"Neither 'steps' nor 'jobs' found in {status_file}")
 
         # If new ensemble, calculate ensemble scaled runtimes
         # for previous ensemble and reset temporary ensemble data


### PR DESCRIPTION
Newer versions of ERT uses "steps" instead of "jobs" in the status.json file.
- Updated logic to check for "steps" and "jobs" keys in status JSON files and raise a KeyError if neither is found.
- Ensures robust handling of unexpected JSON structures.

---

### Contributor checklist

- [ ] :tada: This PR closes #1335 
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [ ] :book: I have considered adding a new entry in `CHANGELOG.md`, and added it if should be communicated there.
