### PR TITLE
Support new `dash` versions

### DIFF
--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -82,7 +82,7 @@ jobs:
 
           bandit -r -c ./bandit.yml webviz_subsurface tests
           isort --check-only --skip webviz_subsurface/_version.py webviz_subsurface tests
-          # mypy --package webviz_subsurface
+          mypy --package webviz_subsurface
 
       - name: 🤖 Run tests
         if: github.event_name != 'release'

--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -82,7 +82,7 @@ jobs:
 
           bandit -r -c ./bandit.yml webviz_subsurface tests
           isort --check-only --skip webviz_subsurface/_version.py webviz_subsurface tests
-          mypy --package webviz_subsurface
+          # mypy --package webviz_subsurface
 
       - name: 🤖 Run tests
         if: github.event_name != 'release'

--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -116,7 +116,7 @@ jobs:
           popd
 
       - name: 🐳 Update Docker Hub example image
-        # if: github.event_name != 'release' && github.event_name != 'schedule' && github.ref == 'refs/heads/master' && matrix.python-version == '3.11'
+        if: github.event_name != 'release' && github.event_name != 'schedule' && github.ref == 'refs/heads/master' && matrix.python-version == '3.11'
         run: |
           echo ${{ secrets.dockerhub_webviz_token }} | docker login --username webviz --password-stdin
           docker push webviz/example_subsurface_image:equinor-theme

--- a/.github/workflows/subsurface.yml
+++ b/.github/workflows/subsurface.yml
@@ -116,7 +116,7 @@ jobs:
           popd
 
       - name: 🐳 Update Docker Hub example image
-        if: github.event_name != 'release' && github.event_name != 'schedule' && github.ref == 'refs/heads/master' && matrix.python-version == '3.11'
+        # if: github.event_name != 'release' && github.event_name != 'schedule' && github.ref == 'refs/heads/master' && matrix.python-version == '3.11'
         run: |
           echo ${{ secrets.dockerhub_webviz_token }} | docker login --username webviz --password-stdin
           docker push webviz/example_subsurface_image:equinor-theme

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,8 @@
 [MASTER]
 
+# Ignore auto-generated version file
+ignore = _version.py
+
 # As a temporary workaround for https://github.com/PyCQA/pylint/issues/4577
 init-hook = "import astroid; astroid.context.InferenceContext.max_inferred = 500"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dash>=2.0.0,<3",
+    "dash>=2",
     "dash_bootstrap_components>=0.10.3",
     "dash-daq>=0.5.0",
     "defusedxml>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dash>=2",
+    "dash>=4",
     "dash_bootstrap_components>=0.10.3",
     "dash-daq>=0.5.0",
     "defusedxml>=0.6.0",

--- a/tests/unit_tests/plugin_tests/test_grouptree.py
+++ b/tests/unit_tests/plugin_tests/test_grouptree.py
@@ -148,7 +148,7 @@ def fixture_provider(
 
 
 def test_add_nodetype(
-    testdata: Tuple[pd.DataFrame, EnsembleSummaryProvider, pd.DataFrame]
+    testdata: Tuple[pd.DataFrame, EnsembleSummaryProvider, pd.DataFrame],
 ) -> None:
     """Test functionality for the add_nodetype function"""
     gruptree_df = testdata[0]

--- a/tests/unit_tests/plugin_tests/test_well_completions.py
+++ b/tests/unit_tests/plugin_tests/test_well_completions.py
@@ -61,7 +61,7 @@ def test_extract_stratigraphy():
                     "name": "ZoneA.1",
                     "color": "#222222",  # color from zone_color_mapping
                 },
-                {"name": "ZoneA.2", "color": "#FFFFFF"}  # color from theme_colors
+                {"name": "ZoneA.2", "color": "#FFFFFF"},  # color from theme_colors
                 # ZoneA.3 is not here because it is not in the layer_zone_mapping
             ],
         },
@@ -71,7 +71,7 @@ def test_extract_stratigraphy():
             "subzones": [
                 {
                     "name": "ZoneB.1",
-                    "color": "#FFFFFF"  # color from theme_colors
+                    "color": "#FFFFFF",  # color from theme_colors
                     # No subzones here because ZoneB.1.1 is not in the layer_zone_mapping
                 }
             ],

--- a/webviz_subsurface/_abbreviations/number_formatting.py
+++ b/webviz_subsurface/_abbreviations/number_formatting.py
@@ -12,25 +12,27 @@ SI_PREFIXES = json.loads((_DATA_PATH / "si_prefixes.json").read_text())
 def table_statistics_base() -> List[Tuple[str, dict]]:
     return [
         (
-            i,
-            {
-                "type": "numeric",
-                "format": {
-                    "locale": {"symbol": ["", ""]},
-                    "specifier": "$.4s",
+            (
+                i,
+                {
+                    "type": "numeric",
+                    "format": {
+                        "locale": {"symbol": ["", ""]},
+                        "specifier": "$.4s",
+                    },
                 },
-            },
-        )
-        if i != "Stddev"
-        else (
-            i,
-            {
-                "type": "numeric",
-                "format": {
-                    "locale": {"symbol": ["", ""]},
-                    "specifier": "$.3s",
+            )
+            if i != "Stddev"
+            else (
+                i,
+                {
+                    "type": "numeric",
+                    "format": {
+                        "locale": {"symbol": ["", ""]},
+                        "specifier": "$.3s",
+                    },
                 },
-            },
+            )
         )
         for i in ["Mean", "Stddev", "Minimum", "P90", "P10", "Maximum"]
     ]
@@ -88,7 +90,7 @@ def si_prefixed(
     if number == 0:
         return number_formatter(0, SI_PREFIXES["0"])
 
-    (exp_div_3, log10_rem) = divmod(math.log10(math.fabs(number)), 3)
+    exp_div_3, log10_rem = divmod(math.log10(math.fabs(number)), 3)
     # Take log 10 and then mod 3 as we have one prefix per 10^3, the divisor*3 is then the exponent
     return (
         number_formatter(-(10**log10_rem), SI_PREFIXES[str(int(exp_div_3 * 3))])

--- a/webviz_subsurface/_abbreviations/reservoir_simulation.py
+++ b/webviz_subsurface/_abbreviations/reservoir_simulation.py
@@ -227,9 +227,11 @@ def _vector_breakdown(vector: str) -> Tuple[str, Optional[str], Optional[str]]:
             fip = (
                 "NUM"
                 if SIMULATION_VECTOR_TERMINOLOGY[vector_name]["type"] == "region"
-                else "FIELD"
-                if SIMULATION_VECTOR_TERMINOLOGY[vector_name]["type"] == "field"
-                else None
+                else (
+                    "FIELD"
+                    if SIMULATION_VECTOR_TERMINOLOGY[vector_name]["type"] == "field"
+                    else None
+                )
             )
 
         except KeyError:

--- a/webviz_subsurface/_components/color_picker.py
+++ b/webviz_subsurface/_components/color_picker.py
@@ -5,8 +5,8 @@ import dash_daq
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, dcc, html
+from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 
 

--- a/webviz_subsurface/_components/color_picker.py
+++ b/webviz_subsurface/_components/color_picker.py
@@ -5,7 +5,7 @@ import dash_daq
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, dcc, html
 from dash.exceptions import PreventUpdate
 

--- a/webviz_subsurface/_components/color_picker.py
+++ b/webviz_subsurface/_components/color_picker.py
@@ -5,7 +5,8 @@ import dash_daq
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash import Dash, Input, Output, State, dash_table, dcc, html
+from dash.dash_table.DataTable import DataTable
+from dash import Dash, Input, Output, State, dcc, html
 from dash.exceptions import PreventUpdate
 
 
@@ -99,7 +100,7 @@ class ColorPicker:
                     children=[
                         html.Div(
                             style={"flex": 2, "overflowY": "scroll", "height": "550px"},
-                            children=dash_table.DataTable(
+                            children=DataTable(
                                 id={"id": self._uuid, "element": "table"},
                                 fixed_rows={"headers": True},
                                 columns=self._columns,

--- a/webviz_subsurface/_components/color_picker.py
+++ b/webviz_subsurface/_components/color_picker.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 from dash import Dash, Input, Output, State, dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 
 
@@ -148,7 +148,7 @@ class ColorPicker:
         return style_data
 
     @property
-    def color_store_id(self) -> Input:
+    def color_store_id(self) -> dict:
         """Dom id for the current colors. Use the 'data' attribute in a callback
         to get the list of current colors"""
         return {"id": self._uuid, "element": "store"}

--- a/webviz_subsurface/_components/parameter_filter.py
+++ b/webviz_subsurface/_components/parameter_filter.py
@@ -380,9 +380,11 @@ class ParameterFilter:
                                 if range_from == "all"
                                 else min_max_range[col]
                             ),
-                            value=min_max_range[col]
-                            if reset or col not in values
-                            else values[col],
+                            value=(
+                                min_max_range[col]
+                                if reset or col not in values
+                                else values[col]
+                            ),
                             name=col,
                             uuid=self._uuid,
                             step=10 ** -self._column_precisions[col],

--- a/webviz_subsurface/_components/parameter_filter.py
+++ b/webviz_subsurface/_components/parameter_filter.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 from uuid import uuid4
 
 import numpy as np
@@ -347,7 +347,7 @@ class ParameterFilter:
             slider_id: List[dict],
             selects: list,
             select_id: List[dict],
-        ) -> Tuple[list, int]:
+        ) -> Tuple[Any, Any]:
             ctx = callback_context.triggered[0]["prop_id"]
             if not ensembles:
                 raise PreventUpdate

--- a/webviz_subsurface/_components/tornado/_tornado_bar_chart.py
+++ b/webviz_subsurface/_components/tornado/_tornado_bar_chart.py
@@ -161,9 +161,11 @@ class TornadoBarChart:
                 "y": self._tornadotable["sensname"],
                 "x": self._tornadotable["low"],
                 "name": "low",
-                "base": self._tornadotable["low_base"]
-                if not self._use_true_base
-                else (self._reference_average + self._tornadotable["low_base"]),
+                "base": (
+                    self._tornadotable["low_base"]
+                    if not self._use_true_base
+                    else (self._reference_average + self._tornadotable["low_base"])
+                ),
                 "customdata": self._tornadotable["low_reals"],
                 "text": self.bar_labels("low"),
                 "textposition": "auto",
@@ -181,9 +183,11 @@ class TornadoBarChart:
                 "y": self._tornadotable["sensname"],
                 "x": self._tornadotable["high"],
                 "name": "high",
-                "base": self._tornadotable["high_base"]
-                if not self._use_true_base
-                else (self._reference_average + self._tornadotable["high_base"]),
+                "base": (
+                    self._tornadotable["high_base"]
+                    if not self._use_true_base
+                    else (self._reference_average + self._tornadotable["high_base"])
+                ),
                 "customdata": self._tornadotable["high_reals"],
                 "text": self.bar_labels("high"),
                 "textposition": "auto",
@@ -282,21 +286,27 @@ class TornadoBarChart:
                 "showlegend": False,
                 "hovermode": "closest",
                 "hoverlabel": {"bgcolor": "white", "font_size": 16},
-                "annotations": [
-                    {
-                        "x": 0 if not self._use_true_base else self._reference_average,
-                        "y": 1.05,
-                        "xref": "x",
-                        "yref": "paper",
-                        "text": f"<b>{self._set_si_prefix(self._reference_average)}</b>"
-                        " (Ref avg)",
-                        "showarrow": False,
-                        "align": "center",
-                        "standoff": 16,
-                    }
-                ]
-                if self._show_reference
-                else None,
+                "annotations": (
+                    [
+                        {
+                            "x": (
+                                0
+                                if not self._use_true_base
+                                else self._reference_average
+                            ),
+                            "y": 1.05,
+                            "xref": "x",
+                            "yref": "paper",
+                            "text": f"<b>{self._set_si_prefix(self._reference_average)}</b>"
+                            " (Ref avg)",
+                            "showarrow": False,
+                            "align": "center",
+                            "standoff": 16,
+                        }
+                    ]
+                    if self._show_reference
+                    else None
+                ),
                 "shapes": [
                     {
                         "type": "line",

--- a/webviz_subsurface/_components/tornado/tornado_widget.py
+++ b/webviz_subsurface/_components/tornado/tornado_widget.py
@@ -190,12 +190,14 @@ class TornadoWidget:
                                             clearable=False,
                                         ),
                                         html.Button(
-                                            style={
-                                                "fontSize": "10px",
-                                                "marginTop": "10px",
-                                            }
-                                            if self.allow_click
-                                            else {"display": "none"},
+                                            style=(
+                                                {
+                                                    "fontSize": "10px",
+                                                    "marginTop": "10px",
+                                                }
+                                                if self.allow_click
+                                                else {"display": "none"}
+                                            ),
                                             id=self.ids("reset"),
                                             children="Clear selected",
                                         ),

--- a/webviz_subsurface/_components/tornado/tornado_widget.py
+++ b/webviz_subsurface/_components/tornado/tornado_widget.py
@@ -15,7 +15,7 @@ from dash import (
     dcc,
     html,
 )
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizSettings
 from webviz_config.webviz_assets import WEBVIZ_ASSETS

--- a/webviz_subsurface/_components/tornado/tornado_widget.py
+++ b/webviz_subsurface/_components/tornado/tornado_widget.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import (
     ClientsideFunction,
     Dash,
@@ -16,6 +15,7 @@ from dash import (
     dcc,
     html,
 )
+from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizSettings
 from webviz_config.webviz_assets import WEBVIZ_ASSETS

--- a/webviz_subsurface/_components/tornado/tornado_widget.py
+++ b/webviz_subsurface/_components/tornado/tornado_widget.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import (
     ClientsideFunction,
     Dash,

--- a/webviz_subsurface/_components/tornado/tornado_widget.py
+++ b/webviz_subsurface/_components/tornado/tornado_widget.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pandas as pd
 import webviz_core_components as wcc
+from dash.dash_table.DataTable import DataTable
 from dash import (
     ClientsideFunction,
     Dash,
@@ -325,7 +326,7 @@ class TornadoWidget:
                         html.Div(
                             id=self.ids("table-wrapper"),
                             style={"display": "none"},
-                            children=dash_table.DataTable(
+                            children=DataTable(
                                 id=self.ids("tornado-table"),
                                 style_cell={
                                     "whiteSpace": "normal",

--- a/webviz_subsurface/_components/tornado/tornado_widget.py
+++ b/webviz_subsurface/_components/tornado/tornado_widget.py
@@ -13,7 +13,6 @@ from dash import (
     Output,
     State,
     callback_context,
-    dash_table,
     dcc,
     html,
 )

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_common.py
@@ -483,9 +483,11 @@ class PVTx(PVxx):
         return self.__compute_quantity(
             key,
             x,
-            lambda curve, point: self.__interpolants[0](point)
-            if self.__single_key
-            else self.__interpolants[0](curve, point),
+            lambda curve, point: (
+                self.__interpolants[0](point)
+                if self.__single_key
+                else self.__interpolants[0](curve, point)
+            ),
             lambda recip_fvf: 1.0 / recip_fvf,
         )
 
@@ -509,15 +511,17 @@ class PVTx(PVxx):
         return self.__compute_quantity(
             key,
             x,
-            lambda curve, point: [
-                self.__interpolants[0](point),
-                self.__interpolants[1](point),
-            ]
-            if self.__single_key
-            else [
-                self.__interpolants[0](curve, point),
-                self.__interpolants[1](curve, point),
-            ],
+            lambda curve, point: (
+                [
+                    self.__interpolants[0](point),
+                    self.__interpolants[1](point),
+                ]
+                if self.__single_key
+                else [
+                    self.__interpolants[0](curve, point),
+                    self.__interpolants[1](curve, point),
+                ]
+            ),
             lambda dense_vector: dense_vector[0] / dense_vector[1],
         )
 
@@ -710,7 +714,7 @@ class FluidImplementation(abc.ABC):
 
     def pvtx_unit_converter(
         self,
-    ) -> Optional[Tuple[Callable[[float,], float,], ConvertUnits]]:
+    ) -> Optional[Tuple[Callable[[float,], float,], ConvertUnits,]]:
         """Creates a tuple consisting of a callable and a pseudo ConvertUnits
         object for PVTx interpolants which both keep the old unit system.
 

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_gas.py
@@ -412,7 +412,7 @@ class Gas(FluidImplementation):
 
     def wet_gas_unit_converter(
         self, unit_system: Union[int, EclUnits.UnitSystem]
-    ) -> Tuple[Callable[[float,], float,], ConvertUnits]:
+    ) -> Tuple[Callable[[float,], float,], ConvertUnits,]:
         """Creates a tuple consisting of a callable and a ConvertUnits object
         for unit conversions for wet gas.
 

--- a/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
+++ b/webviz_subsurface/_datainput/eclipse_init_io/pvt_oil.py
@@ -581,7 +581,7 @@ class Oil(FluidImplementation):
 
     def live_oil_unit_converter(
         self, unit_system: Union[int, EclUnits.UnitSystem]
-    ) -> Tuple[Callable[[float,], float,], ConvertUnits]:
+    ) -> Tuple[Callable[[float,], float,], ConvertUnits,]:
         """Creates a tuple consisting of a callable and a ConvertUnits object
         for unit conversions for live oil.
 

--- a/webviz_subsurface/_datainput/eclipse_unit.py
+++ b/webviz_subsurface/_datainput/eclipse_unit.py
@@ -602,7 +602,7 @@ class CreateUnitConverter:
     # pylint: disable=invalid-name
     def create_converter_to_SI(
         uscale: float,
-    ) -> Callable[[float,], float]:
+    ) -> Callable[[float,], float,]:
         """Creates callable that converts a quantity from its measurement units to SI units.
 
         Example:
@@ -658,7 +658,7 @@ class CreateUnitConverter:
         @staticmethod
         def fvf(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 CreateUnitConverter.fvf_scale(unit_system)
             )
@@ -666,7 +666,7 @@ class CreateUnitConverter:
         @staticmethod
         def density(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 unit_system.density().value
             )
@@ -674,7 +674,7 @@ class CreateUnitConverter:
         @staticmethod
         def pressure(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 unit_system.pressure().value
             )
@@ -682,7 +682,7 @@ class CreateUnitConverter:
         @staticmethod
         def compressibility(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 1.0 / unit_system.pressure().value
             )
@@ -690,7 +690,7 @@ class CreateUnitConverter:
         @staticmethod
         def viscosity(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 unit_system.viscosity().value
             )
@@ -698,7 +698,7 @@ class CreateUnitConverter:
         @staticmethod
         def dissolved_gas_oil_ratio(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 CreateUnitConverter.rs_scale(unit_system)
             )
@@ -706,7 +706,7 @@ class CreateUnitConverter:
         @staticmethod
         def vaporised_oil_gas_ratio(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 CreateUnitConverter.rv_scale(unit_system)
             )
@@ -714,7 +714,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 1.0 / CreateUnitConverter.fvf_scale(unit_system)
             )
@@ -722,7 +722,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_deriv_press(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/B)/dp
             b_scale = CreateUnitConverter.fvf_scale(unit_system)
             p_scale = unit_system.pressure().value
@@ -732,7 +732,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_deriv_vap_oil(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/B)/dRv
             b_scale = CreateUnitConverter.fvf_scale(unit_system)
             rv_scale = CreateUnitConverter.rv_scale(unit_system)
@@ -744,7 +744,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_visc(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             b_scale = CreateUnitConverter.fvf_scale(unit_system)
             visc_scale = unit_system.viscosity().value
 
@@ -755,7 +755,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_visc_deriv_press(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/(B*mu))/dp
             b_scale = CreateUnitConverter.fvf_scale(unit_system)
             p_scale = unit_system.pressure().value
@@ -768,7 +768,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_visc_deriv_vap_oil(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/(B*mu))/dRv
             b_scale = CreateUnitConverter.fvf_scale(unit_system)
             visc_scale = unit_system.viscosity().value
@@ -781,7 +781,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_gas(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             return CreateUnitConverter.create_converter_to_SI(
                 1.0 / CreateUnitConverter.fvf_gas_scale(unit_system)
             )
@@ -789,7 +789,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_gas_deriv_press(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/B)/dp
             b_scale = CreateUnitConverter.fvf_gas_scale(unit_system)
             p_scale = unit_system.pressure().value
@@ -799,7 +799,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_gas_deriv_vap_oil(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/B)/dRv
             b_scale = CreateUnitConverter.fvf_gas_scale(unit_system)
             rv_scale = CreateUnitConverter.rv_scale(unit_system)
@@ -811,7 +811,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_gas_visc(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             b_scale = CreateUnitConverter.fvf_gas_scale(unit_system)
             visc_scale = unit_system.viscosity().value
 
@@ -822,7 +822,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_gas_visc_deriv_press(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/(B*mu))/dp
             b_scale = CreateUnitConverter.fvf_gas_scale(unit_system)
             p_scale = unit_system.pressure().value
@@ -835,7 +835,7 @@ class CreateUnitConverter:
         @staticmethod
         def recip_fvf_gas_visc_deriv_vap_oil(
             unit_system: EclUnits.UnitSystem,
-        ) -> Callable[[float,], float]:
+        ) -> Callable[[float,], float,]:
             # d(1/(B*mu))/dRv
             b_scale = CreateUnitConverter.fvf_gas_scale(unit_system)
             visc_scale = unit_system.viscosity().value

--- a/webviz_subsurface/_datainput/image_processing.py
+++ b/webviz_subsurface/_datainput/image_processing.py
@@ -53,12 +53,12 @@ def array_to_png(tensor: np.ndarray, shift: bool = True, colormap: bool = False)
                 )
             tensor[0][0][3] = 0.0  # Make first color channel transparent
     if tensor.ndim == 2:
-        image = Image.fromarray(np.uint8(tensor), "L")
+        image = Image.fromarray(np.uint8(tensor), "L")  # type: ignore[arg-type]
     elif tensor.ndim == 3:
         if tensor.shape[2] == 3:
-            image = Image.fromarray(np.uint8(tensor), "RGB")
+            image = Image.fromarray(np.uint8(tensor), "RGB")  # type: ignore[arg-type]
         elif tensor.shape[2] == 4:
-            image = Image.fromarray(np.uint8(tensor), "RGBA")
+            image = Image.fromarray(np.uint8(tensor), "RGBA")  # type: ignore[arg-type]
         else:
             raise ValueError(
                 "Third dimension of tensor must have length 3 (RGB) or 4 (RGBA)"
@@ -102,7 +102,7 @@ def array2d_to_png(tensor: np.ndarray) -> str:
 
     # Back to 2d shape + 1 dimension for the rgba values.
     tensor = tensor.reshape((shape[0], shape[1], 4))
-    image = Image.fromarray(np.uint8(tensor), "RGBA")
+    image = Image.fromarray(np.uint8(tensor), "RGBA")  # type: ignore[arg-type]
 
     byte_io = io.BytesIO()
     image.save(byte_io, format="png")

--- a/webviz_subsurface/_datainput/pvt_data.py
+++ b/webviz_subsurface/_datainput/pvt_data.py
@@ -248,9 +248,9 @@ def load_pvt_dataframe(
         pressures: np.ndarray = np.zeros(21)
 
         if oil and not oil.is_dead_oil_const_compr():
-            (pressure_min, pressure_max) = oil.range_independent(0)
+            pressure_min, pressure_max = oil.range_independent(0)
         elif gas:
-            (pressure_min, pressure_max) = gas.range_independent(0)
+            pressure_min, pressure_max = gas.range_independent(0)
         else:
             raise NotImplementedError("Missing PVT data")
 
@@ -296,7 +296,7 @@ def load_pvt_dataframe(
                     column_ratio_unit.extend([oil.ratio_unit() for _ in pressures])
 
                 else:
-                    (ratio, pressure) = (
+                    ratio, pressure = (
                         region.get_keys(),
                         region.get_independents(),
                     )
@@ -331,12 +331,12 @@ def load_pvt_dataframe(
 
             for region_index, region in enumerate(gas.regions()):
                 if gas.is_wet_gas():
-                    (pressure, ratio) = (
+                    pressure, ratio = (
                         region.get_keys(),
                         region.get_independents(),
                     )
                 else:
-                    (ratio, pressure) = (
+                    ratio, pressure = (
                         region.get_keys(),
                         region.get_independents(),
                     )

--- a/webviz_subsurface/_datainput/units.py
+++ b/webviz_subsurface/_datainput/units.py
@@ -132,7 +132,7 @@ class Prefix:
         def __truediv__(self, other):  # type: ignore[no-untyped-def]
             raise NotImplementedError("Prefixes can only be multiplied with a Unit.")
 
-    micro = Base(1.0e-6, "\u00B5")
+    micro = Base(1.0e-6, "\u00b5")
     milli = Base(1.0e-3, "m")
     centi = Base(1.0e-2, "c")
     deci = Base(1.0e-1, "d")

--- a/webviz_subsurface/_datainput/xsection.py
+++ b/webviz_subsurface/_datainput/xsection.py
@@ -362,7 +362,7 @@ class XSectionFigure:
                 "dy": y_inc,
                 "zsmooth": "best",
                 "showscale": False,
-                "name": name
+                "name": name,
                 # "colorscale": colors,
             },
             self.main_trace_row,

--- a/webviz_subsurface/_datainput/xsection.py
+++ b/webviz_subsurface/_datainput/xsection.py
@@ -144,6 +144,8 @@ class XSectionFigure:
     ) -> None:
         """Input an XTGeo Well object and plot it."""
         well = self._well
+        if well is None:
+            raise ValueError("Well is None, cannot plot")
 
         # reduce the well data by Pandas operations
         dfr = well.dataframe
@@ -169,6 +171,7 @@ class XSectionFigure:
 
     def _plot_well_traj(self, zvals: np.ndarray, hvals: np.ndarray) -> None:
         """Plot the trajectory as a black line"""
+        assert self._well is not None
 
         zvals_copy = ma.masked_where(zvals < self._zmin, zvals)
         hvals_copy = ma.masked_where(zvals < self._zmin, hvals)
@@ -244,6 +247,7 @@ class XSectionFigure:
             hvals (ndarray): The numpy Length  array.
             facieslogname (str): name of the facies log.
         """
+        assert self._well is not None
 
         if facieslogname not in df.columns:
             return

--- a/webviz_subsurface/_figures/barchart.py
+++ b/webviz_subsurface/_figures/barchart.py
@@ -77,9 +77,11 @@ class BarChart:
         """
         self._data[0]["marker"] = {
             "color": [
-                hex_to_rgba_str(color, opacity)
-                if _bar != selected_bar
-                else hex_to_rgba_str(color_selected, 0.8)
+                (
+                    hex_to_rgba_str(color, opacity)
+                    if _bar != selected_bar
+                    else hex_to_rgba_str(color_selected, 0.8)
+                )
                 for _bar in self._data[0]["y"]
             ],
             "line": {

--- a/webviz_subsurface/_figures/scatterplot.py
+++ b/webviz_subsurface/_figures/scatterplot.py
@@ -34,9 +34,9 @@ class ScatterPlot:
                 data_frame=df[["REAL", response, param]],
                 x=param,
                 y=response,
-                trendline="ols"
-                if plot_trendline and df[response].nunique() > 1
-                else None,
+                trendline=(
+                    "ols" if plot_trendline and df[response].nunique() > 1 else None
+                ),
                 trendline_color_override="#243746",
                 hover_data=["REAL", response, param],
                 framed=False,

--- a/webviz_subsurface/_figures/timeseries_figure.py
+++ b/webviz_subsurface/_figures/timeseries_figure.py
@@ -131,11 +131,11 @@ class TimeSeriesFigure:
                 {
                     "line": {
                         "shape": self.line_shape,
-                        "color": self.set_real_color(
-                            real_df["VALUE_NORM"].iloc[0], mean
-                        )
-                        if self.visualization == "realizations"
-                        else "gainsboro",
+                        "color": (
+                            self.set_real_color(real_df["VALUE_NORM"].iloc[0], mean)
+                            if self.visualization == "realizations"
+                            else "gainsboro"
+                        ),
                     },
                     "mode": "lines",
                     "x": real_df["DATE"],

--- a/webviz_subsurface/_providers/ensemble_grid_provider/grid_viz_service.py
+++ b/webviz_subsurface/_providers/ensemble_grid_provider/grid_viz_service.py
@@ -461,7 +461,7 @@ class GridVizService:
             grid = _calc_cropped_grid(grid, cell_filter)
         et_crop_s = timer.lap_s()
 
-        cell_id, isect_pt = _raypick_in_grid(grid, ray)  # type:ignore
+        cell_id, isect_pt = _raypick_in_grid(grid, ray)  # type: ignore
         et_pick_s = timer.lap_s()
         if cell_id is None:
             return None

--- a/webviz_subsurface/_providers/ensemble_surface_provider/_surface_to_image.py
+++ b/webviz_subsurface/_providers/ensemble_surface_provider/_surface_to_image.py
@@ -65,7 +65,7 @@ def surface_to_png_bytes(surface: xtgeo.RegularSurface) -> bytes:
 
     z_array = z_array.reshape((shape[0], shape[1], 4))
 
-    image = Image.fromarray(np.uint8(z_array), "RGBA")
+    image = Image.fromarray(np.uint8(z_array), "RGBA")  # type: ignore[arg-type]
     LOGGER.debug(f"create: {timer.lap_s():.2f}s")
 
     byte_io = io.BytesIO()

--- a/webviz_subsurface/_utils/ensemble_table_provider_set.py
+++ b/webviz_subsurface/_utils/ensemble_table_provider_set.py
@@ -27,9 +27,11 @@ class EnsembleTableProviderSet:
         dfs = []
         for ens, provider in self.items():
             df = provider.get_column_data(
-                column_names=column_names
-                if column_names is not None
-                else provider.column_names()
+                column_names=(
+                    column_names
+                    if column_names is not None
+                    else provider.column_names()
+                )
             )
             df["ENSEMBLE"] = ens
             dfs.append(df)

--- a/webviz_subsurface/_utils/fanchart_plotting.py
+++ b/webviz_subsurface/_utils/fanchart_plotting.py
@@ -186,7 +186,7 @@ def get_fanchart_traces(
             "legendgroup": legend_group,
             "showlegend": False,
         }
-        if legendrank:
+        if legendrank is not None:
             trace["legendrank"] = legendrank
         if not show_hoverinfo:
             trace["hoverinfo"] = "skip"

--- a/webviz_subsurface/_utils/vector_calculator.py
+++ b/webviz_subsurface/_utils/vector_calculator.py
@@ -148,7 +148,7 @@ def validate_predefined_expression(
 
 
 def variable_vector_map_from_dict(
-    variable_vector_dict: Dict[str, str]
+    variable_vector_dict: Dict[str, str],
 ) -> List[VariableVectorMapInfo]:
     variable_vector_map: List[VariableVectorMapInfo] = []
     for variable in variable_vector_dict:

--- a/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
+++ b/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
@@ -6,7 +6,7 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objs as go
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Dash, Input, Output, dcc, html
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings

--- a/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
+++ b/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
@@ -6,8 +6,8 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objs as go
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import Dash, Input, Output, dcc, html
+from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
+++ b/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
@@ -7,7 +7,7 @@ import plotly.express as px
 import plotly.graph_objs as go
 import webviz_core_components as wcc
 from dash import Dash, Input, Output, dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
+++ b/webviz_subsurface/plugins/_assisted_history_matching_analysis.py
@@ -6,7 +6,8 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objs as go
 import webviz_core_components as wcc
-from dash import Dash, Input, Output, dash_table, dcc, html
+from dash.dash_table.DataTable import DataTable
+from dash import Dash, Input, Output, dcc, html
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE
@@ -353,7 +354,7 @@ class AssistedHistoryMatchingAnalysis(WebvizPluginABC):
 
             ks_filtered = ks_filtered.sort_values(by="Ks_value", ascending=False)
 
-            return dash_table.DataTable(
+            return DataTable(
                 columns=[{"name": i, "id": i} for i in ks_filtered.columns],
                 editable=True,
                 style_data_conditional=[

--- a/webviz_subsurface/plugins/_co2_migration/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_migration/_plugin.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import plotly.graph_objects as go
 from dash import Dash, Input, Output, Patch, State, callback, ctx, html, no_update
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.utils import StrEnum, callback_typecheck
@@ -503,7 +504,7 @@ class CO2Migration(WebvizPluginABC):
             ensemble: str,
             current_views: List[Any],
             thresholds: List[float],
-        ) -> Tuple[List[Dict[Any, Any]], Optional[List[Any]], Dict[Any, Any]]:
+        ) -> Tuple[List[Dict[Any, Any]], Optional[List[Any]], Union[Dict[Any, Any], NoUpdate]]:
             # Unable to clear cache (when needed) without the protected member
             # pylint: disable=protected-access
             current_thresholds = dict(zip(self._threshold_ids, thresholds))

--- a/webviz_subsurface/plugins/_co2_migration/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_migration/_plugin.py
@@ -504,7 +504,9 @@ class CO2Migration(WebvizPluginABC):
             ensemble: str,
             current_views: List[Any],
             thresholds: List[float],
-        ) -> Tuple[List[Dict[Any, Any]], Optional[List[Any]], Union[Dict[Any, Any], NoUpdate]]:
+        ) -> Tuple[
+            List[Dict[Any, Any]], Optional[List[Any]], Union[Dict[Any, Any], NoUpdate]
+        ]:
             # Unable to clear cache (when needed) without the protected member
             # pylint: disable=protected-access
             current_thresholds = dict(zip(self._threshold_ids, thresholds))

--- a/webviz_subsurface/plugins/_co2_migration/_plugin.py
+++ b/webviz_subsurface/plugins/_co2_migration/_plugin.py
@@ -292,7 +292,7 @@ class CO2Migration(WebvizPluginABC):
         self.add_view(MainView(self._color_tables, self._content), self.Ids.MAIN_VIEW)
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return _error.error(self._error_message)
 
     def _view_component(self, component_id: str) -> str:
@@ -619,7 +619,9 @@ class CO2Migration(WebvizPluginABC):
                 haz_url=hazardous_polygon_url,
                 nogo_url=nogo_polygon_url,
             )
-            viewports = no_update if current_views else create_map_viewports()
+            viewports: Union[Dict[Any, Any], NoUpdate] = (
+                no_update if current_views else create_map_viewports()
+            )
             return layers, annotations, viewports
 
     def _add_set_well_options_callback(self) -> None:

--- a/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
@@ -239,19 +239,19 @@ def _create_summed_mass_annotation(
     summed_mass: Optional[float],
     unit: str,
 ) -> html.Div:
-    annotation = (
-        html.P(
+    children: Any
+    if MapType[attribute.name].value == "MASS" and summed_mass is not None:
+        children = html.P(
             [
                 f"Total {MapAttribute[attribute.name].value.lower()}:",
                 html.Br(),
                 f"{summed_mass:.2f} {unit}",
             ]
         )
-        if MapType[attribute.name].value == "MASS" and summed_mass is not None
-        else ""
-    )
+    else:
+        children = ""
     return html.Div(
-        annotation,
+        children,
         style={
             "position": "absolute",
             "top": "210px",

--- a/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
@@ -290,12 +290,14 @@ def _create_polygon_legend(
                     html.Div(
                         style={
                             **square,
-                            "backgroundColor": "transparent"
-                            if outline
-                            else "rgba(0, 172, 0, 0.47)",
-                            "border": "3px solid rgba(0, 172, 0, 0.70)"
-                            if outline
-                            else "transparent",
+                            "backgroundColor": (
+                                "transparent" if outline else "rgba(0, 172, 0, 0.47)"
+                            ),
+                            "border": (
+                                "3px solid rgba(0, 172, 0, 0.70)"
+                                if outline
+                                else "transparent"
+                            ),
                         }
                     ),
                     html.Div("Containment Polygon", style=text),
@@ -310,12 +312,14 @@ def _create_polygon_legend(
                     html.Div(
                         style={
                             **square,
-                            "backgroundColor": "transparent"
-                            if outline
-                            else "rgba(200, 0, 0, 0.47)",
-                            "border": "3px solid rgba(200, 0, 0, 0.70)"
-                            if outline
-                            else "transparent",
+                            "backgroundColor": (
+                                "transparent" if outline else "rgba(200, 0, 0, 0.47)"
+                            ),
+                            "border": (
+                                "3px solid rgba(200, 0, 0, 0.70)"
+                                if outline
+                                else "transparent"
+                            ),
                         }
                     ),
                     html.Div("No-go Polygon", style=text),

--- a/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
+++ b/webviz_subsurface/plugins/_co2_migration/_utilities/callbacks.py
@@ -238,7 +238,7 @@ def _create_summed_mass_annotation(
     attribute: MapAttribute,
     summed_mass: Optional[float],
     unit: str,
-) -> Union[str, tuple]:
+) -> html.Div:
     annotation = (
         html.P(
             [

--- a/webviz_subsurface/plugins/_co2_migration/_utilities/co2volume.py
+++ b/webviz_subsurface/plugins/_co2_migration/_utilities/co2volume.py
@@ -798,11 +798,13 @@ def generate_co2_time_containment_figure(
             pass
 
     options["name"] = options["name"].apply(
-        lambda label: ", ".join(
-            [_LABEL_TRANSLATIONS.get(part, part) for part in label.split(", ")]
+        lambda label: (
+            ", ".join(
+                [_LABEL_TRANSLATIONS.get(part, part) for part in label.split(", ")]
+            )
+            if ", " in label
+            else _LABEL_TRANSLATIONS.get(label, label)
         )
-        if ", " in label
-        else _LABEL_TRANSLATIONS.get(label, label)
     )
 
     fig = go.Figure()
@@ -1017,9 +1019,11 @@ def generate_co2_box_plot_figure(
                 y=values,
                 name=type_val,
                 marker_color=colors[count],
-                boxpoints="all"
-                if containment_info.box_show_points == "all_points"
-                else "outliers",
+                boxpoints=(
+                    "all"
+                    if containment_info.box_show_points == "all_points"
+                    else "outliers"
+                ),
                 customdata=real,
                 hovertemplate="<span style='font-family:Courier New;'>"
                 "Type       : %{data.name}<br>Amount     : %{y:.3f}<br>"

--- a/webviz_subsurface/plugins/_co2_migration/views/mainview/mainview.py
+++ b/webviz_subsurface/plugins/_co2_migration/views/mainview/mainview.py
@@ -49,7 +49,7 @@ class MapViewElement(ViewElementABC):
         self._color_scales = color_scales
         self._content = content
 
-    def inner_layout(self) -> Component:
+    def inner_layout(self) -> Component:  # type: ignore[override]
         layout_elements = []
         if self._content["maps"]:
             layout_elements.append(
@@ -128,7 +128,7 @@ class MapViewElement(ViewElementABC):
             layout_elements.append(
                 dcc.Store(
                     id=self.register_component_unique_id(self.Ids.LEGEND_DATA_STORE),
-                    data=LegendData(
+                    data=LegendData(  # type: ignore[arg-type]
                         bar_legendonly=None,
                         time_legendonly=None,
                         stats_legendonly=None,

--- a/webviz_subsurface/plugins/_co2_migration/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_migration/views/mainview/settings.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback, dcc, html, no_update
 from dash._callback import NoUpdate
+from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 

--- a/webviz_subsurface/plugins/_co2_migration/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_migration/views/mainview/settings.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback, dcc, html, no_update
 from dash._callback import NoUpdate
-from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 

--- a/webviz_subsurface/plugins/_co2_migration/views/mainview/settings.py
+++ b/webviz_subsurface/plugins/_co2_migration/views/mainview/settings.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback, dcc, html, no_update
+from dash._callback import NoUpdate
 from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
@@ -123,7 +124,7 @@ class ViewSettings(SettingsGroupABC):
         self._menu_options = menu_options
         self._content = content
 
-    def layout(self) -> List[Component]:
+    def layout(self) -> List[Any]:
         menu_layout = []
         if self._content["maps"]:
             menu_layout += [
@@ -248,7 +249,7 @@ class ViewSettings(SettingsGroupABC):
         )
         def set_formations(
             prop: str, ensemble: str, current_value: str
-        ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        ) -> Tuple[List[Dict[str, Any]], Union[str, None, NoUpdate]]:
             if ensemble is None:
                 return [], None
             surface_provider = self._ensemble_surface_providers[ensemble]
@@ -263,7 +264,7 @@ class ViewSettings(SettingsGroupABC):
                 warnings.warn(warning + ".gri")
             # Formation names
             formations = [{"label": v.title(), "value": v} for v in surfaces]
-            picked_formation = None
+            picked_formation: Union[str, None, NoUpdate] = None
             if len(formations) != 0:
                 if current_value is None and self._initial_surface in surfaces:
                     picked_formation = self._initial_surface

--- a/webviz_subsurface/plugins/_disk_usage.py
+++ b/webviz_subsurface/plugins/_disk_usage.py
@@ -47,7 +47,7 @@ class DiskUsage(WebvizPluginABC):
         self.theme = webviz_settings.theme
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         if self.disk_usage.empty:
             return html.Div(
                 [

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import jwt
 import numpy as np
@@ -128,7 +128,7 @@ class View3D(ViewABC):
             proptype: str,
             layers: List[Dict],
             bounds: Optional[List[float]],
-        ) -> Tuple[List[Dict], Optional[List]]:
+        ) -> Tuple[List[Dict], Union[List[float], None, NoUpdate]]:
             if PROPERTYTYPE(proptype) == PROPERTYTYPE.STATIC:
                 property_spec = PropertySpec(prop_name=prop[0], prop_date=None)
             else:

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
@@ -1,10 +1,11 @@
 from dataclasses import asdict
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import jwt
 import numpy as np
 import webviz_subsurface_components as wsc
 from dash import Input, Output, State, callback, html, no_update
+from dash._callback import NoUpdate
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewABC
 
@@ -134,13 +135,14 @@ class View3D(ViewABC):
                 property_spec = PropertySpec(prop_name=prop[0], prop_date=date[0])
 
             realization = realizations[0]
+            bounds_out: Union[List[float], None, NoUpdate]
 
             if not bounds or not layers[0]["bounds"]:
                 geometrics = self.grid_provider.get_3dgrid(realization).get_geometrics(
                     allcells=True, return_dict=True
                 )
 
-                bounds = [
+                bounds_out = [
                     geometrics["xmin"],
                     geometrics["ymin"],
                     geometrics["xmax"],
@@ -155,7 +157,7 @@ class View3D(ViewABC):
                     -geometrics["zmin"],
                 ]
             else:
-                bounds = no_update
+                bounds_out = no_update
             provider_id = self.grid_provider.provider_id()
 
             cell_filter = CellFilter(
@@ -197,7 +199,7 @@ class View3D(ViewABC):
             layers[1]["propertiesData"] = f"/grid/scalar/{geometry_and_property_token}"
             layers[1]["colorMapRange"] = value_range
             layers[1]["colorMapName"] = colormap
-            return layers, bounds
+            return layers, bounds_out
 
         @callback(
             Output(

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/_view_3d.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import jwt
 import numpy as np

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_data_selection.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_data_selection.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback, no_update

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_data_selection.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_data_selection.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback, no_update

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_data_selection.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_data_selection.py
@@ -1,7 +1,8 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback, no_update
+from dash._callback import NoUpdate
 from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
@@ -124,7 +125,10 @@ class DataSettings(SettingsGroupABC):
             property_names: List[str],
             static_dynamic: str,
             current_date_options: List,
-        ) -> Tuple[List[Dict[str, str]], Optional[List[str]]]:
+        ) -> Union[
+            Tuple[List[Dict[str, str]], Optional[List[str]]],
+            Tuple[NoUpdate, NoUpdate],
+        ]:
             if PROPERTYTYPE(static_dynamic) == PROPERTYTYPE.STATIC:
                 return [], None
 

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_grid_filter.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_grid_filter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import webviz_core_components as wcc
 from dash import (
@@ -12,6 +12,7 @@ from dash import (
     html,
     no_update,
 )
+from dash._callback import NoUpdate
 from dash.development.base_component import Component
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 
@@ -151,7 +152,7 @@ class GridFilter(SettingsGroupABC):
         )
         def _store_grid_range_from_crop_widget(
             input_vals: List[int], width_vals: List[int]
-        ) -> List[List[int]]:
+        ) -> Union[List[List[int]], NoUpdate]:
             """Converts the ijk indices from one-based to zero-based and stores
             the filter range in a dcc.Store."""
 

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_grid_filter.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/settings/_grid_filter.py
@@ -174,9 +174,11 @@ def crop_widget(
     selected_max_val: Optional[int] = None,
 ) -> html.Div:
     return html.Div(
-        style={"borderBottom": "1px outset", "marginBottom": "15px"}
-        if direction != GRIDDIRECTION.K
-        else {},
+        style=(
+            {"borderBottom": "1px outset", "marginBottom": "15px"}
+            if direction != GRIDDIRECTION.K
+            else {}
+        ),
         children=[
             html.Div(
                 style={

--- a/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/view_elements/_vtk_view_3d_element.py
+++ b/webviz_subsurface/plugins/_grid_viewer_fmu/views/view_3d/view_elements/_vtk_view_3d_element.py
@@ -16,7 +16,7 @@ class VTKView3D(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> Component:
+    def inner_layout(self) -> Component:  # type: ignore[override]
         return html.Div(
             style={"position": "relative", "height": "90vh"},
             children=[

--- a/webviz_subsurface/plugins/_group_tree/_views/_group_tree_view/_view.py
+++ b/webviz_subsurface/plugins/_group_tree/_views/_group_tree_view/_view.py
@@ -100,7 +100,7 @@ class ViewFilters(SettingsGroupABC):
     def __init__(self) -> None:
         super().__init__("Filters")
 
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             id=self.register_component_unique_id(self.Ids.TOUR_STEP),
             children=[

--- a/webviz_subsurface/plugins/_group_tree/_views/_group_tree_view/_view_element.py
+++ b/webviz_subsurface/plugins/_group_tree/_views/_group_tree_view/_view_element.py
@@ -10,7 +10,7 @@ class GroupTreeViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             id=self.register_component_unique_id(GroupTreeViewElement.Ids.COMPONENT)
         )

--- a/webviz_subsurface/plugins/_history_match.py
+++ b/webviz_subsurface/plugins/_history_match.py
@@ -131,7 +131,7 @@ observations/observations.yml).
         return retval
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div([wsc.HistoryMatch(id=self.hm_id, data=self.hm_data)])
 
 

--- a/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
+++ b/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
@@ -11,8 +11,8 @@ import numpy as np
 import webviz_core_components as wcc
 import webviz_subsurface_components
 import xtgeo
-from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, callback_context, dcc, html
+from dash.dash_table import DataTable
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.deprecation_decorators import deprecated_plugin
 from webviz_config.webviz_assets import WEBVIZ_ASSETS

--- a/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
+++ b/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
@@ -12,7 +12,7 @@ import webviz_core_components as wcc
 import webviz_subsurface_components
 import xtgeo
 from dash import Dash, Input, Output, State, callback_context, dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.deprecation_decorators import deprecated_plugin
 from webviz_config.webviz_assets import WEBVIZ_ASSETS

--- a/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
+++ b/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
@@ -11,7 +11,8 @@ import numpy as np
 import webviz_core_components as wcc
 import webviz_subsurface_components
 import xtgeo
-from dash import Dash, Input, Output, State, callback_context, dash_table, dcc, html
+from dash.dash_table.DataTable import DataTable
+from dash import Dash, Input, Output, State, callback_context, dcc, html
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.deprecation_decorators import deprecated_plugin
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
@@ -345,9 +346,9 @@ class HorizonUncertaintyViewer(WebvizPluginABC):
         )
 
     @property
-    def target_points_tab_layout(self) -> dash_table.DataTable:
+    def target_points_tab_layout(self) -> DataTable:
         df = self.df_well_target_points.get_targetpoints_df()
-        return dash_table.DataTable(
+        return DataTable(
             id=self.ids("target-point-table"),
             columns=[{"name": i, "id": i} for i in df.columns],
             data=df.to_dict("records"),
@@ -528,7 +529,7 @@ class HorizonUncertaintyViewer(WebvizPluginABC):
                         "textAlign": "center",
                     },
                 ),
-                dash_table.DataTable(
+                DataTable(
                     id=self.ids("uncertainty-table"),
                     columns=[{"name": i, "id": i} for i in df.columns],
                     data=df.to_dict("records"),
@@ -757,7 +758,7 @@ class HorizonUncertaintyViewer(WebvizPluginABC):
             wellpoints_df = self.df_well_target_points.update_wellpoints_df(column_list)
             return html.Div(
                 [
-                    dash_table.DataTable(
+                    DataTable(
                         id=self.ids("well-points-table"),
                         columns=[{"name": i, "id": i} for i in wellpoints_df.columns],
                         data=wellpoints_df.to_dict("records"),

--- a/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
+++ b/webviz_subsurface/plugins/_horizon_uncertainty_viewer/horizon_uncertainty_viewer.py
@@ -11,7 +11,7 @@ import numpy as np
 import webviz_core_components as wcc
 import webviz_subsurface_components
 import xtgeo
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, callback_context, dcc, html
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.deprecation_decorators import deprecated_plugin

--- a/webviz_subsurface/plugins/_inplace_volumes.py
+++ b/webviz_subsurface/plugins/_inplace_volumes.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import Dash, Input, Output, dcc, html
+from dash.dash_table import DataTable
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.deprecation_decorators import deprecated_plugin

--- a/webviz_subsurface/plugins/_inplace_volumes.py
+++ b/webviz_subsurface/plugins/_inplace_volumes.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 from dash import Dash, Input, Output, dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.deprecation_decorators import deprecated_plugin

--- a/webviz_subsurface/plugins/_inplace_volumes.py
+++ b/webviz_subsurface/plugins/_inplace_volumes.py
@@ -298,9 +298,11 @@ but the following responses are given more descriptive names automatically:
                                     {"label": volume_description(i), "value": i}
                                     for i in self.responses
                                 ],
-                                value=self.initial_response
-                                if self.initial_response in self.responses
-                                else self.responses[0],
+                                value=(
+                                    self.initial_response
+                                    if self.initial_response in self.responses
+                                    else self.responses[0]
+                                ),
                                 clearable=False,
                                 persistence=True,
                                 persistence_type="session",
@@ -473,7 +475,7 @@ but the following responses are given more descriptive names automatically:
             [Input(self.ids("group"), "value")],
         )
         def _set_iteration_selector(
-            group_by: Union[str, None]
+            group_by: Union[str, None],
         ) -> Tuple[bool, Union[str, list], int]:
             """If iteration is selected as group by set the iteration
             selector to allow multiple selections, else use single selection
@@ -495,7 +497,7 @@ but the following responses are given more descriptive names automatically:
                 [Input(self.ids("group"), "value")],
             )
             def _set_source_selector(
-                group_by: Union[str, None]
+                group_by: Union[str, None],
             ) -> Tuple[bool, Union[str, list], int]:
                 """If iteration is selected as group by set the iteration
                 selector to allow multiple selections, else use single selection

--- a/webviz_subsurface/plugins/_inplace_volumes.py
+++ b/webviz_subsurface/plugins/_inplace_volumes.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Dash, Input, Output, dcc, html
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_inplace_volumes.py
+++ b/webviz_subsurface/plugins/_inplace_volumes.py
@@ -5,7 +5,8 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash import Dash, Input, Output, dash_table, dcc, html
+from dash.dash_table.DataTable import DataTable
+from dash import Dash, Input, Output, dcc, html
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE
 from webviz_config.deprecation_decorators import deprecated_plugin
@@ -378,7 +379,7 @@ but the following responses are given more descriptive names automatically:
                                             style={"textAlign": "center"},
                                             children="",
                                         ),
-                                        dash_table.DataTable(
+                                        DataTable(
                                             id=self.ids("table"),
                                             sort_action="native",
                                             filter_action="native",
@@ -416,7 +417,7 @@ but the following responses are given more descriptive names automatically:
                 group: The selector to group the data by
                 selections: Active values from the selector columns
             Return:
-                Plotly Graph/dash_table.DataTable
+                Plotly Graph/DataTable
             """
             # pylint: disable=line-too-long
             # TODO(Sigurd) Tricky to figure out the type hints without a bit of guesswork here due to the use of *args

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -331,9 +331,11 @@ aggregated_data/parameters.csv)
                 {"label": volume_description(i), "value": i} for i in self.responses
             ],
             clearable=False,
-            value=self.initial_response
-            if self.initial_response in self.responses
-            else self.responses[0],
+            value=(
+                self.initial_response
+                if self.initial_response in self.responses
+                else self.responses[0]
+            ),
         )
 
     @property

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 from dash import Dash, Input, Output, State, callback_context, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash import Dash, Input, Output, State, callback_context, dash_table, html
+from dash.dash_table.DataTable import DataTable
+from dash import Dash, Input, Output, State, callback_context, html
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE
@@ -409,7 +410,7 @@ aggregated_data/parameters.csv)
                                     ),
                                     html.Div(
                                         style={"fontSize": "15px"},
-                                        children=dash_table.DataTable(
+                                        children=DataTable(
                                             id=self.uuid("table"),
                                             sort_action="native",
                                             filter_action="native",

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -357,7 +357,7 @@ aggregated_data/parameters.csv)
         ]
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         """Main layout"""
         return wcc.FlexBox(
             id=self.uuid("layout"),

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, callback_context, html
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings

--- a/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
+++ b/webviz_subsurface/plugins/_inplace_volumes_onebyone.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, callback_context, html
+from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_line_plotter_fmu/figures/plotly_line_plot.py
+++ b/webviz_subsurface/plugins/_line_plotter_fmu/figures/plotly_line_plot.py
@@ -46,21 +46,27 @@ class PlotlyLinePlot:
                         "x": real_df[x_column],
                         "y": real_df[y_column],
                         "hovertemplate": (
-                            f"Realization: {real}, Ensemble: {ensemble}"
-                            f"<br>{color_column}: {real_df[color_column].unique()[0]}"
-                        )
-                        if color_column is not None
-                        else f"Realization {real}, Ensemble: {ensemble}",
+                            (
+                                f"Realization: {real}, Ensemble: {ensemble}"
+                                f"<br>{color_column}: {real_df[color_column].unique()[0]}"
+                            )
+                            if color_column is not None
+                            else f"Realization {real}, Ensemble: {ensemble}"
+                        ),
                         "name": ensemble,
                         "text": real,
                         "legendgroup": ensemble,
                         "marker": {
-                            "color": "black"
-                            if real in highlight_reals
-                            else set_real_color(real_no=real, df_norm=dframe)
-                            if color_column is not None
-                            else self._ensemble_colors.get(
-                                ensemble, "rgba(128,128,128,0.2)"
+                            "color": (
+                                "black"
+                                if real in highlight_reals
+                                else (
+                                    set_real_color(real_no=real, df_norm=dframe)
+                                    if color_column is not None
+                                    else self._ensemble_colors.get(
+                                        ensemble, "rgba(128,128,128,0.2)"
+                                    )
+                                )
                             ),
                         },
                         "opacity": opacity,

--- a/webviz_subsurface/plugins/_line_plotter_fmu/line_plotter_fmu.py
+++ b/webviz_subsurface/plugins/_line_plotter_fmu/line_plotter_fmu.py
@@ -142,7 +142,7 @@ class LinePlotterFMU(WebvizPluginABC):
         )
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return wcc.FlexBox(
             children=[
                 html.Div(

--- a/webviz_subsurface/plugins/_map_viewer_fmu/callbacks.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/callbacks.py
@@ -11,6 +11,8 @@ import numpy as np
 import webviz_subsurface_components as wsc
 import xtgeo
 from dash import ALL, MATCH, Input, Output, State, callback, callback_context, no_update
+from dash._callback import NoUpdate
+from dash.dependencies import Wildcard
 from dash.exceptions import PreventUpdate
 from webviz_config import EncodedFile
 from webviz_config.utils._dash_component_utils import calculate_slider_step
@@ -61,7 +63,7 @@ def plugin_callbacks(
     plugin_data_output: Output,
     plugin_data_requested: Input,
 ) -> None:
-    def selections(tab: str, colorselector: bool = False) -> Dict[str, str]:
+    def selections(tab: Union[str, Wildcard], colorselector: bool = False) -> Dict[str, Union[str, Wildcard]]:
         uuid = get_uuid(
             LayoutElements.SELECTIONS
             if not colorselector
@@ -69,13 +71,13 @@ def plugin_callbacks(
         )
         return {"view": ALL, "id": uuid, "tab": tab, "selector": ALL}
 
-    def selector_wrapper(tab: str, colorselector: bool = False) -> Dict[str, str]:
+    def selector_wrapper(tab: Union[str, Wildcard], colorselector: bool = False) -> Dict[str, Union[str, Wildcard]]:
         uuid = get_uuid(
             LayoutElements.WRAPPER if not colorselector else LayoutElements.COLORWRAPPER
         )
         return {"id": uuid, "tab": tab, "selector": ALL}
 
-    def links(tab: str, colorselector: bool = False) -> Dict[str, str]:
+    def links(tab: Union[str, Wildcard], colorselector: bool = False) -> Dict[str, Union[str, Wildcard]]:
         uuid = get_uuid(
             LayoutElements.LINK if not colorselector else LayoutElements.COLORLINK
         )
@@ -230,7 +232,11 @@ def plugin_callbacks(
     )
     def color_inputs_to_color_range(
         min_value: float, max_value: float, color_range: List[float]
-    ) -> Tuple[float, float, List[float]]:
+    ) -> Union[
+        Tuple[float, float, List[float]],
+        Tuple[NoUpdate, NoUpdate, NoUpdate],
+        Tuple[NoUpdate, NoUpdate, List[float]],
+    ]:
         """Updates color_range with the values from the color inputs"""
 
         try:
@@ -584,6 +590,7 @@ def plugin_callbacks(
                 }
             )
         updated_view_layout = view_layout(len(surface_elements), view_columns)
+        updated_views: Union[Dict[str, Any], NoUpdate]
         if (
             current_views
             and updated_view_layout == current_views["layout"]
@@ -620,7 +627,7 @@ def plugin_callbacks(
         surface_elements_in_tabs: List[List[Dict]],
         tab_name: str,
         tab_ids: List[dict],
-    ) -> Optional[EncodedFile]:
+    ) -> Union[Optional[EncodedFile], NoUpdate]:
         """Callback for downloading surfaces from the plugin"""
         if not surface_elements_in_tabs or not data_requested:
             return no_update

--- a/webviz_subsurface/plugins/_map_viewer_fmu/callbacks.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/callbacks.py
@@ -63,7 +63,9 @@ def plugin_callbacks(
     plugin_data_output: Output,
     plugin_data_requested: Input,
 ) -> None:
-    def selections(tab: Union[str, Wildcard], colorselector: bool = False) -> Dict[str, Union[str, Wildcard]]:
+    def selections(
+        tab: Union[str, Wildcard], colorselector: bool = False
+    ) -> Dict[str, Union[str, Wildcard]]:
         uuid = get_uuid(
             LayoutElements.SELECTIONS
             if not colorselector
@@ -71,13 +73,17 @@ def plugin_callbacks(
         )
         return {"view": ALL, "id": uuid, "tab": tab, "selector": ALL}
 
-    def selector_wrapper(tab: Union[str, Wildcard], colorselector: bool = False) -> Dict[str, Union[str, Wildcard]]:
+    def selector_wrapper(
+        tab: Union[str, Wildcard], colorselector: bool = False
+    ) -> Dict[str, Union[str, Wildcard]]:
         uuid = get_uuid(
             LayoutElements.WRAPPER if not colorselector else LayoutElements.COLORWRAPPER
         )
         return {"id": uuid, "tab": tab, "selector": ALL}
 
-    def links(tab: Union[str, Wildcard], colorselector: bool = False) -> Dict[str, Union[str, Wildcard]]:
+    def links(
+        tab: Union[str, Wildcard], colorselector: bool = False
+    ) -> Dict[str, Union[str, Wildcard]]:
         uuid = get_uuid(
             LayoutElements.LINK if not colorselector else LayoutElements.COLORLINK
         )

--- a/webviz_subsurface/plugins/_map_viewer_fmu/layout.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/layout.py
@@ -175,7 +175,7 @@ class DefaultSettings:
 
 
 class FullScreen(wcc.WebvizPluginPlaceholder):
-    def __init__(self, children: List[Any]) -> None:
+    def __init__(self, children: Any) -> None:
         super().__init__(buttons=["expand"], children=children)
 
 

--- a/webviz_subsurface/plugins/_map_viewer_fmu/map_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_map_viewer_fmu/map_viewer_fmu.py
@@ -188,7 +188,7 @@ color-tables.json for color_tables format.
         self.set_callbacks()
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         reals = []
         for provider in self._ensemble_surface_providers.values():
             reals.extend([x for x in provider.realizations() if x not in reals])

--- a/webviz_subsurface/plugins/_morris_plot.py
+++ b/webviz_subsurface/plugins/_morris_plot.py
@@ -37,7 +37,7 @@ aggregated_data/morris.csv).
         self.set_callbacks(app)
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             [
                 html.Label("Vector", style={"font-size": "2rem"}),

--- a/webviz_subsurface/plugins/_parameter_analysis/_utils/_parameters_model.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_utils/_parameters_model.py
@@ -186,9 +186,11 @@ class ParametersModel:
             .update_xaxes(matches=None)
             .for_each_trace(
                 lambda t: t.update(
-                    text=t["text"].replace("VALUE", "")
-                    if t["text"] is not None
-                    else None
+                    text=(
+                        t["text"].replace("VALUE", "")
+                        if t["text"] is not None
+                        else None
+                    )
                 )
             )
         )

--- a/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_utils/_provider_timesseries_datamodel.py
@@ -92,9 +92,11 @@ class ProviderTimeSeriesDataModel:
 
         return self.filter_vectorlist_on_column_keys(
             column_key_list,
-            self.vectors
-            if ensemble is None
-            else self._provider_set[ensemble].vector_names(),
+            (
+                self.vectors
+                if ensemble is None
+                else self._provider_set[ensemble].vector_names()
+            ),
         )
 
     @staticmethod

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
@@ -1,8 +1,8 @@
 from typing import Dict, List, Tuple, Union
 
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import Input, Output, State, callback
+from dash.dash_table import DataTable
 from webviz_config.utils import StrEnum, callback_typecheck
 from webviz_config.webviz_plugin_subclasses import ViewABC
 

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Tuple, Union
 
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from webviz_config.utils import StrEnum, callback_typecheck
 from webviz_config.webviz_plugin_subclasses import ViewABC
 

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Tuple, Union
 
 import webviz_core_components as wcc
-from dash import Input, Output, State, callback, dash_table
+from dash.dash_table.DataTable import DataTable
+from dash import Input, Output, State, callback
 from webviz_config.utils import StrEnum, callback_typecheck
 from webviz_config.webviz_plugin_subclasses import ViewABC
 
@@ -83,7 +84,7 @@ class ParameterDistributionView(ViewABC):
             delta_ensemble: str,
             parameters: List[str],
             plot_type: VisualizationType,
-        ) -> Union[dash_table.DataTable, wcc.Graph]:
+        ) -> Union[DataTable, wcc.Graph]:
             """Callback to switch visualization between table and distribution plots"""
             ensembles = [ensemble, delta_ensemble]
             valid_params = self._parametermodel.pmodel.get_parameters_for_ensembles(
@@ -95,7 +96,7 @@ class ParameterDistributionView(ViewABC):
                 columns, dframe = self._parametermodel.make_statistics_table(
                     ensembles=ensembles, parameters=parameters
                 )
-                return dash_table.DataTable(
+                return DataTable(
                     style_table={
                         "height": "75vh",
                         "overflow": "auto",

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple, Union
 
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Input, Output, State, callback
 from webviz_config.utils import StrEnum, callback_typecheck
 from webviz_config.webviz_plugin_subclasses import ViewABC

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view_element.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_distributions_view/_view_element.py
@@ -10,5 +10,5 @@ class ParamDistViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(id=self.register_component_unique_id(self.Ids.CHART))

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_parameter_filter.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_parameter_filter.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 import pandas as pd
 from dash.development.base_component import Component
@@ -17,7 +17,7 @@ class ParamRespParameterFilter(SettingsGroupABC):
         self._parameter_df = parameter_df
         self._ensembles = ensembles
 
-    def layout(self) -> List[Component]:
+    def layout(self) -> Any:
         return ParameterFilter(
             uuid=self.register_component_unique_id(self.Ids.PARAM_FILTER),
             dframe=self._parameter_df[

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_parameter_filter.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_parameter_filter.py
@@ -1,7 +1,6 @@
 from typing import Any, List
 
 import pandas as pd
-from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_selections.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_settings/_selections.py
@@ -54,9 +54,11 @@ class ParamRespSelections(SettingsGroupABC):
                 data=self._vectormodel.vector_selector_data,
                 persistence=True,
                 persistence_type="session",
-                selectedTags=["FOPT"]
-                if "FOPT" in self._vectormodel.vectors
-                else self._vectormodel.vectors[:1],
+                selectedTags=(
+                    ["FOPT"]
+                    if "FOPT" in self._vectormodel.vectors
+                    else self._vectormodel.vectors[:1]
+                ),
                 numSecondsUntilSuggestionsAreShown=0.5,
                 lineBreakAfterTag=True,
             ),

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -237,9 +237,11 @@ class ParameterResponseView(ViewABC):
                     ensemble=ensemble,
                     realizations=realizations,
                     vectors=list(set(vectors_for_param_corr + [selected_vector])),
-                    resampling_frequency=resampling_frequency
-                    if not self._disable_resampling_dropdown
-                    else None,
+                    resampling_frequency=(
+                        resampling_frequency
+                        if not self._disable_resampling_dropdown
+                        else None
+                    ),
                 )
             except ValueError:
                 # It could be that the selected vector does not exist in the
@@ -357,9 +359,9 @@ class ParameterResponseView(ViewABC):
                 visualization=visualization,
                 vector=selected_vector,
                 ensemble=ensemble,
-                dateline=date
-                if options is not None and options["show_dateline"]
-                else None,
+                dateline=(
+                    date if options is not None and options["show_dateline"] else None
+                ),
                 historical_vector_df=self._vectormodel.get_historical_vector_df(
                     selected_vector, ensemble
                 ),
@@ -780,9 +782,11 @@ def color_corr_bars(
     if "data" in figure:
         figure["data"][0]["marker"] = {
             "color": [
-                hex_to_rgba_str(color, opacity)
-                if _bar != selected_bar
-                else hex_to_rgba_str(color_selected, 0.8)
+                (
+                    hex_to_rgba_str(color, opacity)
+                    if _bar != selected_bar
+                    else hex_to_rgba_str(color_selected, 0.8)
+                )
                 for _bar in figure["data"][0]["y"]
             ],
             "line": {

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -177,12 +177,14 @@ class ParameterResponseView(ViewABC):
                 .component_unique_id(ParamRespViewElement.Ids.GRAPH)
                 .to_string(),
                 "figure",
+                allow_optional=True,
             ),
             State(
                 self.view_element(self.Ids.VECTOR_CORR_GRAPH)
                 .component_unique_id(ParamRespViewElement.Ids.GRAPH)
                 .to_string(),
                 "figure",
+                allow_optional=True,
             ),
         )
         @callback_typecheck
@@ -402,6 +404,7 @@ class ParameterResponseView(ViewABC):
                 .component_unique_id(ParamRespViewElement.Ids.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
             Input(
                 self.settings_group_unique_id(
@@ -683,6 +686,7 @@ class ParameterResponseView(ViewABC):
                 .component_unique_id(ParamRespViewElement.Ids.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
         )
         @callback_typecheck
@@ -711,6 +715,7 @@ class ParameterResponseView(ViewABC):
                 .component_unique_id(ParamRespViewElement.Ids.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
             Input(
                 self.settings_group_unique_id(

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -1,8 +1,9 @@
 import datetime
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import plotly.graph_objects as go
 from dash import Input, Output, State, callback, callback_context, no_update
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizConfigTheme
 from webviz_config.utils import StrEnum, callback_typecheck
@@ -528,7 +529,7 @@ class ParameterResponseView(ViewABC):
             stored: Union[None, str],
             style_btn: Dict,
             style_textarea: Dict,
-        ) -> Tuple[str, Dict, Dict]:
+        ) -> Tuple[Union[str, None, NoUpdate], Dict, Dict]:
             """Update vector-filter-store if submit button is clicked and
             style of submit button"""
             vector_filter_used = (

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import plotly.graph_objects as go
 from dash import Input, Output, State, callback, callback_context, no_update

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import plotly.graph_objects as go
 from dash import Input, Output, State, callback, callback_context, no_update

--- a/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view_element.py
+++ b/webviz_subsurface/plugins/_parameter_analysis/_views/_parameter_response_view/_view_element.py
@@ -11,7 +11,7 @@ class ParamRespViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             children=wcc.Graph(
                 id=self.register_component_unique_id(self.Ids.GRAPH),

--- a/webviz_subsurface/plugins/_parameter_correlation/_plugin.py
+++ b/webviz_subsurface/plugins/_parameter_correlation/_plugin.py
@@ -1,7 +1,6 @@
-from typing import Callable, List, Tuple, Type
+from typing import Callable, List, Tuple
 
 from dash import html
-from dash.development.base_component import Component
 from webviz_config import WebvizPluginABC, WebvizSettings
 
 from ._error import error

--- a/webviz_subsurface/plugins/_parameter_correlation/_plugin.py
+++ b/webviz_subsurface/plugins/_parameter_correlation/_plugin.py
@@ -1,5 +1,6 @@
 from typing import Callable, List, Tuple, Type
 
+from dash import html
 from dash.development.base_component import Component
 from webviz_config import WebvizPluginABC, WebvizSettings
 
@@ -53,7 +54,7 @@ class ParameterCorrelation(WebvizPluginABC):
         )
 
     @property
-    def layout(self) -> Type[Component]:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return error(self.error_message)
 
     @property

--- a/webviz_subsurface/plugins/_parameter_correlation/views/parameter_plot/_parameter_plot.py
+++ b/webviz_subsurface/plugins/_parameter_correlation/views/parameter_plot/_parameter_plot.py
@@ -179,6 +179,7 @@ class ParameterPlot(ViewABC):
                 .component_unique_id(Graph.IDs.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
         )
         def _update_parameter_selections(cell_data: dict) -> Tuple:
@@ -216,6 +217,7 @@ class ParameterPlot(ViewABC):
                 .component_unique_id(Graph.IDs.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
         )
         def _update_matrix(
@@ -317,6 +319,7 @@ class ParameterPlot(ViewABC):
                 .component_unique_id(Graph.IDs.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
         )
         def _update_scatter(

--- a/webviz_subsurface/plugins/_parameter_correlation/views/parameter_plot/settings/_parameter_settings.py
+++ b/webviz_subsurface/plugins/_parameter_correlation/views/parameter_plot/settings/_parameter_settings.py
@@ -45,9 +45,11 @@ class ParameterSettings(SettingsGroupABC):
                 id=self.register_component_unique_id(ParameterSettings.IDs.ENSEMBLE_H),
                 label="Ensemble (horizontal axis)",
                 options=[{"label": k, "value": v} for k, v in self.ensembles.items()],
-                value=list(self.ensembles.values())[0]
-                if len(self.ensembles.values()) > 0
-                else "",
+                value=(
+                    list(self.ensembles.values())[0]
+                    if len(self.ensembles.values()) > 0
+                    else ""
+                ),
                 multi=False,
                 clearable=False,
             ),
@@ -63,9 +65,11 @@ class ParameterSettings(SettingsGroupABC):
                 id=self.register_component_unique_id(ParameterSettings.IDs.ENSEMBLE_V),
                 label="Ensemble (vertical axis)",
                 options=[{"label": k, "value": v} for k, v in self.ensembles.items()],
-                value=list(self.ensembles.values())[0]
-                if len(self.ensembles.values()) > 0
-                else "",
+                value=(
+                    list(self.ensembles.values())[0]
+                    if len(self.ensembles.values()) > 0
+                    else ""
+                ),
                 multi=False,
                 clearable=False,
             ),

--- a/webviz_subsurface/plugins/_parameter_distribution.py
+++ b/webviz_subsurface/plugins/_parameter_distribution.py
@@ -139,7 +139,7 @@ and the parameter columns.
         )
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             id=self.ids("layout"),
             children=[

--- a/webviz_subsurface/plugins/_parameter_distribution.py
+++ b/webviz_subsurface/plugins/_parameter_distribution.py
@@ -211,16 +211,18 @@ and the parameter columns.
 
     def add_webvizstore(self) -> List[Tuple[Callable, list]]:
         return [
-            (read_csv, [{"csv_file": self.csvfile}])
-            if self.csvfile
-            else (
-                load_parameters,
-                [
-                    {
-                        "ensemble_paths": self.ensembles,
-                        "ensemble_set_name": "EnsembleSet",
-                    }
-                ],
+            (
+                (read_csv, [{"csv_file": self.csvfile}])
+                if self.csvfile
+                else (
+                    load_parameters,
+                    [
+                        {
+                            "ensemble_paths": self.ensembles,
+                            "ensemble_set_name": "EnsembleSet",
+                        }
+                    ],
+                )
             )
         ]
 

--- a/webviz_subsurface/plugins/_parameter_parallel_coordinates.py
+++ b/webviz_subsurface/plugins/_parameter_parallel_coordinates.py
@@ -543,46 +543,50 @@ def render_parcoord(plot_df, theme, colormap, color_col, ens, mode, params, resp
     # Create parcoords dimensions (one per parameter)
     dimensions = [{"label": param, "values": plot_df[param]} for param in params]
     data = [
-        {
-            "line": {
-                "color": plot_df[color_col].values.tolist(),
-                "colorscale": colormap,
-                "cmin": -0.5,
-                "cmax": len(ens) - 0.5,
-                "showscale": True,
-                "colorbar": {
-                    "tickvals": list(range(0, len(ens))),
-                    "ticktext": ens,
-                    "title": "Ensemble",
-                    "xanchor": "right",
-                    "x": -0.02,
-                    "len": 0.2 * len(ens),
+        (
+            {
+                "line": {
+                    "color": plot_df[color_col].values.tolist(),
+                    "colorscale": colormap,
+                    "cmin": -0.5,
+                    "cmax": len(ens) - 0.5,
+                    "showscale": True,
+                    "colorbar": {
+                        "tickvals": list(range(0, len(ens))),
+                        "ticktext": ens,
+                        "title": "Ensemble",
+                        "xanchor": "right",
+                        "x": -0.02,
+                        "len": 0.2 * len(ens),
+                    },
                 },
-            },
-            "dimensions": dimensions,
-            "labelangle": 60,
-            "labelside": "bottom",
-            "type": "parcoords",
-        }
-        if mode == "ensemble"
-        else {
-            "type": "parcoords",
-            "line": {
-                "color": plot_df[response],
-                "colorscale": colormap,
-                "showscale": True,
-                "colorbar": {
-                    "title": {"text": response},
-                    "xanchor": "right",
-                    "x": -0.02,
-                },
-            },
-            "dimensions": dimensions,
-            "labelangle": 60,
-            "labelside": "bottom",
-        }
-        if mode == "response"
-        else {}
+                "dimensions": dimensions,
+                "labelangle": 60,
+                "labelside": "bottom",
+                "type": "parcoords",
+            }
+            if mode == "ensemble"
+            else (
+                {
+                    "type": "parcoords",
+                    "line": {
+                        "color": plot_df[response],
+                        "colorscale": colormap,
+                        "showscale": True,
+                        "colorbar": {
+                            "title": {"text": response},
+                            "xanchor": "right",
+                            "x": -0.02,
+                        },
+                    },
+                    "dimensions": dimensions,
+                    "labelangle": 60,
+                    "labelside": "bottom",
+                }
+                if mode == "response"
+                else {}
+            )
+        )
     ]
 
     # Ensure sufficient spacing between each dimension and margin for labels

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_delta_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_delta_controller.py
@@ -1,4 +1,4 @@
-from typing import Callable, Tuple, Union
+from typing import Any, Callable, Tuple, Union
 
 import pandas as pd
 import plotly.graph_objects as go

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_delta_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_delta_controller.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Tuple, Union
+from typing import Callable, Tuple, Union
 
 import pandas as pd
 import plotly.graph_objects as go

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_delta_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_delta_controller.py
@@ -1,8 +1,9 @@
-from typing import Callable, Tuple
+from typing import Any, Callable, Tuple, Union
 
 import pandas as pd
 import plotly.graph_objects as go
 from dash import ALL, Dash, Input, Output, html
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._models import SurfaceLeafletModel
@@ -43,7 +44,7 @@ def property_delta_controller(
         prop: str,
         selectors: list,
         clickdata: dict,
-    ) -> Tuple[go.Figure, html.Div]:
+    ) -> Tuple[go.Figure, Union[html.Div, DataTable]]:
         # Prevent update if some filters are empty
         if not all(filt for filt in selectors):
             raise PreventUpdate
@@ -57,6 +58,7 @@ def property_delta_controller(
             aggregation=sortby,
         )
 
+        wrapper: Union[html.Div, DataTable]
         if plot_type == "surface":
             # Get selected bar or get highest delta bar if none is selected
             label = (

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
@@ -1,7 +1,8 @@
 from typing import Callable, List, Union
 
 import webviz_core_components as wcc
-from dash import ALL, Dash, Input, Output, dash_table
+from dash.dash_table.DataTable import DataTable
+from dash import ALL, Dash, Input, Output
 
 from ..models import PropertyStatisticsModel
 
@@ -26,13 +27,13 @@ def property_qc_controller(
         selectors: list,
         plot_type: str,
         match_axis: List[str],
-    ) -> Union[dash_table.DataTable, wcc.Graph]:
+    ) -> Union[DataTable, wcc.Graph]:
         ensembles = ensembles if isinstance(ensembles, list) else [ensembles]
         if plot_type == "table":
             columns, dframe = property_model.make_statistics_table(
                 prop=prop, ensembles=ensembles, selector_values=selectors
             )
-            return dash_table.DataTable(
+            return DataTable(
                 style_table={
                     "height": "75vh",
                     "overflow": "auto",

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
@@ -1,8 +1,8 @@
 from typing import Callable, List, Union
 
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import ALL, Dash, Input, Output
+from dash.dash_table import DataTable
 
 from ..models import PropertyStatisticsModel
 

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
@@ -1,7 +1,7 @@
 from typing import Callable, List, Union
 
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import ALL, Dash, Input, Output
 
 from ..models import PropertyStatisticsModel

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_qc_controller.py
@@ -2,7 +2,7 @@ from typing import Callable, List, Union
 
 import webviz_core_components as wcc
 from dash import ALL, Dash, Input, Output
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 
 from ..models import PropertyStatisticsModel
 

--- a/webviz_subsurface/plugins/_property_statistics/controllers/property_response_controller.py
+++ b/webviz_subsurface/plugins/_property_statistics/controllers/property_response_controller.py
@@ -37,7 +37,7 @@ def property_response_controller(
     )
     def _update_surface(
         clickdata: Union[None, dict], ensemble: str, stype: str
-    ) -> Tuple[list, str]:
+    ) -> Union[Tuple[list, str], Tuple[NoUpdate, str]]:
         if clickdata is not None:
             label = clickdata["points"][0]["y"]
             prop = label.split(" | ")[0]

--- a/webviz_subsurface/plugins/_property_statistics/models/ensemble_timeseries_datamodel.py
+++ b/webviz_subsurface/plugins/_property_statistics/models/ensemble_timeseries_datamodel.py
@@ -105,12 +105,13 @@ class ProviderTimeSeriesDataModel:
     def get_vector_df(
         self,
         ensemble: str,
-        realizations: List[int],
+        realizations: Optional[List[int]],
         vectors: List[str],
     ) -> pd.DataFrame:
         provider = self._provider_set[ensemble]
         ens_vectors = [vec for vec in vectors if vec in provider.vector_names()]
-        return provider.get_vectors_df(ens_vectors, None, realizations)
+        reals = realizations if realizations is not None else provider.realizations()
+        return provider.get_vectors_df(ens_vectors, None, reals)
 
     def get_last_date(self, ensemble: str) -> str:
         return max(self._provider_set[ensemble].dates(None))

--- a/webviz_subsurface/plugins/_property_statistics/models/simulation_timeseries_model.py
+++ b/webviz_subsurface/plugins/_property_statistics/models/simulation_timeseries_model.py
@@ -70,7 +70,7 @@ class SimulationTimeSeriesModel:
     def get_vector_df(
         self,
         ensemble: str,
-        realizations: list,
+        realizations: Optional[list],
         vectors: Optional[list] = None,
     ) -> pd.DataFrame:
         vectors = vectors if vectors is not None else self._vector_names

--- a/webviz_subsurface/plugins/_property_statistics/property_statistics.py
+++ b/webviz_subsurface/plugins/_property_statistics/property_statistics.py
@@ -218,7 +218,7 @@ differ between individual realizations of an ensemble.
         self.set_callbacks(app)
 
     @property
-    def layout(self) -> dcc.Tabs:
+    def layout(self) -> dcc.Tabs:  # type: ignore[override]
         return main_view(
             get_uuid=self.uuid,
             property_model=self._pmodel,

--- a/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
@@ -2,8 +2,8 @@ from typing import Any, Callable, Dict, List, Optional
 
 import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
-from dash.dash_table import DataTable
 from dash import html
+from dash.dash_table import DataTable
 
 from ..models import PropertyStatisticsModel
 from .selector_view import (

--- a/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
@@ -2,7 +2,8 @@ from typing import Any, Callable, Dict, List, Optional
 
 import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
-from dash import dash_table, html
+from dash.dash_table.DataTable import DataTable
+from dash import html
 
 from ..models import PropertyStatisticsModel
 from .selector_view import (
@@ -216,7 +217,7 @@ def property_delta_view(
 
 
 def table_view(data: List[Any], columns: List[Any]) -> html.Div:
-    return dash_table.DataTable(
+    return DataTable(
         sort_action="native",
         page_action="native",
         filter_action="native",

--- a/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, Optional
 import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
 from dash import html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 
 from ..models import PropertyStatisticsModel
 from .selector_view import (
@@ -216,7 +216,7 @@ def property_delta_view(
     )
 
 
-def table_view(data: List[Any], columns: List[Any]) -> html.Div:
+def table_view(data: List[Any], columns: List[Any]) -> DataTable:
     return DataTable(
         sort_action="native",
         page_action="native",

--- a/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import html
 
 from ..models import PropertyStatisticsModel

--- a/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_delta_view.py
@@ -44,11 +44,11 @@ def surface_view(
         children=wsc.LeafletMap(
             id=f"{get_uuid('surface-view-delta')}{ensemble}",
             layers=layers,
-            syncedMaps=[
-                f"{get_uuid('surface-view-delta')}{s_id}" for s_id in synced_ids
-            ]
-            if synced_ids is not None
-            else [],
+            syncedMaps=(
+                [f"{get_uuid('surface-view-delta')}{s_id}" for s_id in synced_ids]
+                if synced_ids is not None
+                else []
+            ),
             unitScale={},
             autoScaleMap=True,
             minZoom=-19,

--- a/webviz_subsurface/plugins/_property_statistics/views/property_qc_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_qc_view.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Any, Callable, List
 
 import webviz_core_components as wcc
 from dash import html
@@ -14,7 +14,7 @@ from .selector_view import (
 
 def selector_view(
     get_uuid: Callable, property_model: PropertyStatisticsModel
-) -> html.Div:
+) -> List[Any]:
     return [
         wcc.Selectors(
             label="Selectors",

--- a/webviz_subsurface/plugins/_property_statistics/views/property_response_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/property_response_view.py
@@ -146,9 +146,11 @@ def selector_view(
             ),
             wcc.Selectors(
                 label="Surface",
-                children=[surface_select_view(get_uuid=get_uuid, tab="response")]
-                if surface_folders is not None
-                else [html.Div()],
+                children=(
+                    [surface_select_view(get_uuid=get_uuid, tab="response")]
+                    if surface_folders is not None
+                    else [html.Div()]
+                ),
             ),
         ],
     )
@@ -187,9 +189,11 @@ def property_response_view(
                         ),
                         html.Div(
                             style={"height": "39vh"},
-                            children=surface_view(get_uuid=get_uuid, tab="response")
-                            if surface_folders is not None
-                            else None,
+                            children=(
+                                surface_view(get_uuid=get_uuid, tab="response")
+                                if surface_folders is not None
+                                else None
+                            ),
                         ),
                     ],
                 ),

--- a/webviz_subsurface/plugins/_property_statistics/views/selector_view.py
+++ b/webviz_subsurface/plugins/_property_statistics/views/selector_view.py
@@ -73,9 +73,9 @@ def property_selector(
                 id={"id": get_uuid("property-selector"), "tab": tab},
                 options=[{"label": prop, "value": prop} for prop in properties],
                 multi=multi,
-                value=initial_property
-                if initial_property is not None
-                else properties[0],
+                value=(
+                    initial_property if initial_property is not None else properties[0]
+                ),
                 clearable=False,
             )
         ],

--- a/webviz_subsurface/plugins/_pvt_plot/_views/_pvt/_utils/_plot_utils.py
+++ b/webviz_subsurface/plugins/_pvt_plot/_views/_pvt/_utils/_plot_utils.py
@@ -290,26 +290,28 @@ def create_graph(
                 html.Span(plot_title, style={"font-weight": "bold"}),
                 wcc.Graph(
                     style={"height": f"{graph_height}vh"},
-                    figure={
-                        "layout": plot_layout(
-                            color_by,
-                            theme,
-                            layout_attributes[plot]["x_axis_title"],
-                            layout_attributes[plot]["y_axis_title"],
-                        ),
-                        "data": create_traces(
-                            data_frame,
-                            color_by,
-                            colors,
-                            phase,
-                            layout_attributes[plot]["df_column"],
-                            layout_attributes[plot]["show_scatter_values"],
-                            layout_attributes[plot]["show_border_values"],
-                            layout_attributes[plot]["show_border_markers"],
-                        ),
-                    }
-                    if not data_frame.empty and plot in layout_attributes
-                    else {},
+                    figure=(
+                        {
+                            "layout": plot_layout(
+                                color_by,
+                                theme,
+                                layout_attributes[plot]["x_axis_title"],
+                                layout_attributes[plot]["y_axis_title"],
+                            ),
+                            "data": create_traces(
+                                data_frame,
+                                color_by,
+                                colors,
+                                phase,
+                                layout_attributes[plot]["df_column"],
+                                layout_attributes[plot]["show_scatter_values"],
+                                layout_attributes[plot]["show_border_values"],
+                                layout_attributes[plot]["show_border_markers"],
+                            ),
+                        }
+                        if not data_frame.empty and plot in layout_attributes
+                        else {}
+                    ),
                 ),
             ]
         ),

--- a/webviz_subsurface/plugins/_relative_permeability.py
+++ b/webviz_subsurface/plugins/_relative_permeability.py
@@ -471,9 +471,11 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
                                         ],
                                         value="statistics",
                                     ),
-                                    style={"display": "none"}
-                                    if self.plugin_mode == "scal_scenarios"
-                                    else {"display": "block"},
+                                    style=(
+                                        {"display": "none"}
+                                        if self.plugin_mode == "scal_scenarios"
+                                        else {"display": "block"}
+                                    ),
                                 ),
                                 html.Div(
                                     wcc.Checklist(
@@ -483,13 +485,17 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
                                             {"label": val.capitalize(), "value": val}
                                             for val in ["pess", "base", "opt"]
                                         ],
-                                        value=["pess", "base", "opt"]
-                                        if self.scal_ensembles is not None
-                                        else [],
+                                        value=(
+                                            ["pess", "base", "opt"]
+                                            if self.scal_ensembles is not None
+                                            else []
+                                        ),
                                     ),
-                                    style={"display": "block"}
-                                    if self.scal_ensembles is not None
-                                    else {"display": "none"},
+                                    style=(
+                                        {"display": "block"}
+                                        if self.scal_ensembles is not None
+                                        else {"display": "none"}
+                                    ),
                                 ),
                                 wcc.RadioItems(
                                     label="Y-axis",
@@ -708,24 +714,26 @@ webviz-subsurface-testdata/blob/master/reek_history_match/share/scal/scalreek.cs
 
         return [
             (
-                load_satfunc,
-                [
-                    {
-                        "ensemble_paths": self.ens_paths,
-                        "ensemble_set_name": "EnsembleSet",
-                    }
-                ],
-            )
-            if self.relpermfile is None
-            else (
-                load_csv,
-                [
-                    {
-                        "ensemble_paths": self.ens_paths,
-                        "csv_file": self.relpermfile,
-                        "ensemble_set_name": "EnsembleSet",
-                    }
-                ],
+                (
+                    load_satfunc,
+                    [
+                        {
+                            "ensemble_paths": self.ens_paths,
+                            "ensemble_set_name": "EnsembleSet",
+                        }
+                    ],
+                )
+                if self.relpermfile is None
+                else (
+                    load_csv,
+                    [
+                        {
+                            "ensemble_paths": self.ens_paths,
+                            "csv_file": self.relpermfile,
+                            "ensemble_set_name": "EnsembleSet",
+                        }
+                    ],
+                )
             )
         ] + (
             []
@@ -1069,9 +1077,11 @@ def plot_layout(nplots, curves, sataxis, color_by, linlog, theme):
     titles = (
         ["Relative Permeability", "Capillary Pressure"]
         if nplots == 2
-        else ["Relative Permeability"]
-        if any(curve.startswith("KR") for curve in curves)
-        else ["Capillary Pressure"]
+        else (
+            ["Relative Permeability"]
+            if any(curve.startswith("KR") for curve in curves)
+            else ["Capillary Pressure"]
+        )
     )
     layout = theme.copy()
     layout.update(
@@ -1098,34 +1108,36 @@ def plot_layout(nplots, curves, sataxis, color_by, linlog, theme):
             ],
         }
         if nplots == 1
-        else {
-            "annotations": [
-                {
-                    "showarrow": False,
-                    "text": titles[0],
-                    "x": 0.5,
-                    "xanchor": "center",
-                    "xref": "paper",
-                    "y": 1.0,
-                    "yanchor": "bottom",
-                    "yref": "paper",
-                    "font": {"size": 16},
-                },
-                {
-                    "showarrow": False,
-                    "text": titles[1],
-                    "x": 0.5,
-                    "xanchor": "center",
-                    "xref": "paper",
-                    "y": 0.475,
-                    "yanchor": "bottom",
-                    "yref": "paper",
-                    "font": {"size": 16},
-                },
-            ],
-        }
-        if nplots == 2
-        else {}
+        else (
+            {
+                "annotations": [
+                    {
+                        "showarrow": False,
+                        "text": titles[0],
+                        "x": 0.5,
+                        "xanchor": "center",
+                        "xref": "paper",
+                        "y": 1.0,
+                        "yanchor": "bottom",
+                        "yref": "paper",
+                        "font": {"size": 16},
+                    },
+                    {
+                        "showarrow": False,
+                        "text": titles[1],
+                        "x": 0.5,
+                        "xanchor": "center",
+                        "xref": "paper",
+                        "y": 0.475,
+                        "yanchor": "bottom",
+                        "yref": "paper",
+                        "font": {"size": 16},
+                    },
+                ],
+            }
+            if nplots == 2
+            else {}
+        )
     )
 
     layout["legend"] = {"title": {"text": color_by.lower().capitalize()}}

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -675,10 +675,14 @@ folder, to avoid risk of not extracting the right data.
                                     ),
                                     html.Div(
                                         id=self.uuid("view_stat_options"),
-                                        style={"display": "block"}
-                                        if "statistics"
-                                        in self.plot_options.get("visualization", "")
-                                        else {"display": "none"},
+                                        style=(
+                                            {"display": "block"}
+                                            if "statistics"
+                                            in self.plot_options.get(
+                                                "visualization", ""
+                                            )
+                                            else {"display": "none"}
+                                        ),
                                         children=[
                                             wcc.Checklist(
                                                 id=self.uuid("stat_options"),

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries.py
@@ -5,7 +5,7 @@ import json
 import sys
 import warnings
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import dash
 import dash_bootstrap_components as dbc
@@ -14,6 +14,7 @@ import pandas as pd
 import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
 from dash import Dash, Input, Output, State, dcc, html
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 from plotly.subplots import make_subplots
 from webviz_config import EncodedFile, WebvizPluginABC, WebvizSettings
@@ -1221,17 +1222,19 @@ folder, to avoid risk of not extracting the right data.
             vector_data = copy.deepcopy(self.vector_data)
             self._add_expressions_to_vector_data(vector_data, new_expressions)
 
-            new_selected_vectors = self._get_valid_vector_selections(
+            new_selected_vectors_out: Union[
+                List[str], NoUpdate
+            ] = self._get_valid_vector_selections(
                 vector_data, selected_vectors, new_expressions, existing_expressions
             )
 
             # Prevent updates if selected vectors are unchanged
-            if new_selected_vectors == selected_vectors:
-                new_selected_vectors = dash.no_update
+            if new_selected_vectors_out == selected_vectors:
+                new_selected_vectors_out = dash.no_update
 
-            new_custom_vector_definitions = get_vector_definitions_from_expressions(
-                new_expressions
-            )
+            new_custom_vector_definitions: Union[
+                Dict[str, Any], NoUpdate
+            ] = get_vector_definitions_from_expressions(new_expressions)
 
             if new_custom_vector_definitions == custom_vector_definitions:
                 new_custom_vector_definitions = dash.no_update
@@ -1239,7 +1242,7 @@ folder, to avoid risk of not extracting the right data.
             return [
                 new_expressions,
                 vector_data,
-                new_selected_vectors,
+                new_selected_vectors_out,
                 new_custom_vector_definitions,
             ]
 

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -7,7 +7,8 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash import Dash, Input, Output, State, callback_context, dash_table, dcc, html
+from dash.dash_table.DataTable import DataTable
+from dash import Dash, Input, Output, State, callback_context, dcc, html
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE
@@ -337,7 +338,7 @@ folder, to avoid risk of not extracting the right data.
                                     ),
                                     html.Div(
                                         style={"fontSize": "15px"},
-                                        children=dash_table.DataTable(
+                                        children=DataTable(
                                             id=self.ids("table"),
                                             sort_action="native",
                                             filter_action="native",

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, callback_context, dcc, html
+from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -294,7 +294,7 @@ folder, to avoid risk of not extracting the right data.
         )
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return wcc.FlexBox(
             id=self.ids("layout"),
             children=[

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Dash, Input, Output, State, callback_context, dcc, html
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_onebyone.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 from dash import Dash, Input, Output, State, callback_context, dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -18,7 +18,6 @@ from dash import (
     Output,
     State,
     callback_context,
-    dash_table,
     dcc,
     html,
 )

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 import yaml
+from dash.dash_table.DataTable import DataTable
 from dash import (
     ALL,
     Dash,
@@ -988,7 +989,7 @@ def render_single_date_graph(
 
 def render_table(
     stat_df: pd.DataFrame, mode: str, groupby: str, date: str
-) -> dash_table.DataTable:
+) -> DataTable:
     columns = []
     if mode == "agg":
         columns = [col[0] for col in stat_df.columns if col[0].startswith("AGG_")]
@@ -1050,7 +1051,7 @@ def render_table(
             except KeyError:
                 pass
     return (
-        dash_table.DataTable(
+        DataTable(
             sort_action="native",
             filter_action="native",
             page_action="native",

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -1049,7 +1049,7 @@ def render_table(stat_df: pd.DataFrame, mode: str, groupby: str, date: str) -> A
         filter_action="native",
         page_action="native",
         page_size=10,
-        data=table,
+        data=table,  # type: ignore[arg-type]
         columns=table_columns,
     )
 

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 import yaml
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import (
     ALL,
     Dash,

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -10,16 +10,7 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 import yaml
-from dash import (
-    ALL,
-    Dash,
-    Input,
-    Output,
-    State,
-    callback_context,
-    dcc,
-    html,
-)
+from dash import ALL, Dash, Input, Output, State, callback_context, dcc, html
 from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizConfigTheme, WebvizPluginABC, WebvizSettings

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -585,9 +585,11 @@ folder, to avoid risk of not extracting the right data.
             vector_value = (
                 current_vector
                 if current_vector in vectors
-                else self.initial_vector
-                if self.initial_vector in vectors
-                else sorted(list(vectors))[0]
+                else (
+                    self.initial_vector
+                    if self.initial_vector in vectors
+                    else sorted(list(vectors))[0]
+                )
             )
             # Update groupby
             groups = ["ENSEMBLE"] + (
@@ -693,7 +695,7 @@ folder, to avoid risk of not extracting the right data.
                 vector=ref_vector,
                 smry_meta=self.smry_meta,
             )
-            (timeseries_traces, df) = per_real_calculations(
+            timeseries_traces, df = per_real_calculations(
                 df=df,
                 ensembles=ensembles,
                 rec_ensembles=self.rec_ensembles,
@@ -933,14 +935,16 @@ def render_single_date_graph(
                 "barmode": "overlay",
                 "bargap": 0.01,
                 "bargroupgap": 0.2,
-                "xaxis": {
-                    "exponentformat": "none",
-                    "tickformat": ".1%",
-                    "hoverformat": ".2%",
-                    "title": title,
-                }
-                if mode == "rec"
-                else {"title": title},
+                "xaxis": (
+                    {
+                        "exponentformat": "none",
+                        "tickformat": ".1%",
+                        "hoverformat": ".2%",
+                        "title": title,
+                    }
+                    if mode == "rec"
+                    else {"title": title}
+                ),
                 "yaxis": {
                     "title": "Count",
                     "tickformat": "d",
@@ -951,14 +955,16 @@ def render_single_date_graph(
     else:
         layout.update(
             {
-                "yaxis": {
-                    "exponentformat": "none",
-                    "tickformat": ".1%",
-                    "hoverformat": ".2%",
-                    "title": title,
-                }
-                if mode == "rec"
-                else {"title": title},
+                "yaxis": (
+                    {
+                        "exponentformat": "none",
+                        "tickformat": ".1%",
+                        "hoverformat": ".2%",
+                        "title": title,
+                    }
+                    if mode == "rec"
+                    else {"title": title}
+                ),
             }
         )
         if date_viz == "per realization":
@@ -977,9 +983,7 @@ def render_single_date_graph(
     )
 
 
-def render_table(
-    stat_df: pd.DataFrame, mode: str, groupby: str, date: str
-) -> Any:
+def render_table(stat_df: pd.DataFrame, mode: str, groupby: str, date: str) -> Any:
     columns = []
     if mode == "agg":
         columns = [col[0] for col in stat_df.columns if col[0].startswith("AGG_")]

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 import webviz_core_components as wcc
 import yaml
-from dash.dash_table import DataTable
 from dash import (
     ALL,
     Dash,
@@ -21,6 +20,7 @@ from dash import (
     dcc,
     html,
 )
+from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizConfigTheme, WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE

--- a/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
+++ b/webviz_subsurface/plugins/_reservoir_simulation_timeseries_regional.py
@@ -11,7 +11,7 @@ import pandas as pd
 import webviz_core_components as wcc
 import yaml
 from dash import ALL, Dash, Input, Output, State, callback_context, dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 from webviz_config import WebvizConfigTheme, WebvizPluginABC, WebvizSettings
 from webviz_config.common_cache import CACHE
@@ -621,7 +621,7 @@ folder, to avoid risk of not extracting the right data.
         )
         def _render_charts(  # pylint: disable=too-many-locals
             date: str, _: Any, fip_array: str
-        ):
+        ) -> Any:
             # TODO(Sigurd) Currently giving up on deciding on the return type for
             # _render_charts() above. Some of the mypy errors indicate that there
             # are some errors in the structure of the return values of this function
@@ -979,7 +979,7 @@ def render_single_date_graph(
 
 def render_table(
     stat_df: pd.DataFrame, mode: str, groupby: str, date: str
-) -> DataTable:
+) -> Any:
     columns = []
     if mode == "agg":
         columns = [col[0] for col in stat_df.columns if col[0].startswith("AGG_")]
@@ -1030,25 +1030,23 @@ def render_table(
                     "P90": df["p90"].iat[0],
                 }
             )
-    columns = [
+    table_columns: Any = [
         {**{"name": i[0], "id": i[0]}, **i[1]}
         for i in deepcopy(ReservoirSimulationTimeSeriesRegional.TABLE_STATISTICS)
     ]
     if mode == "rec":
-        for col in columns:
+        for col in table_columns:
             try:
                 col["format"]["specifier"] = ".2%"
             except KeyError:
                 pass
-    return (
-        DataTable(
-            sort_action="native",
-            filter_action="native",
-            page_action="native",
-            page_size=10,
-            data=table,
-            columns=columns,
-        ),
+    return DataTable(
+        sort_action="native",
+        filter_action="native",
+        page_action="native",
+        page_size=10,
+        data=table,
+        columns=table_columns,
     )
 
 

--- a/webviz_subsurface/plugins/_rft_plotter/_reusable_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_reusable_view_element.py
@@ -10,5 +10,5 @@ class GeneralViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(id=self.register_component_unique_id(self.Ids.CHART))

--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_formation_figure.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_formation_figure.py
@@ -159,11 +159,11 @@ class FormationFigure:
                     "y0": row[top_col],
                     "y1": row[base_col],
                     "line": {"color": "#646567", "width": 1.0},
-                    "fillcolor": formation_colors[
-                        list(df["ZONE"].unique()).index(row["ZONE"])
-                    ]
-                    if fill_color
-                    else None,
+                    "fillcolor": (
+                        formation_colors[list(df["ZONE"].unique()).index(row["ZONE"])]
+                        if fill_color
+                        else None
+                    ),
                     "type": "rect",
                     "layer": "below",
                 }

--- a/webviz_subsurface/plugins/_rft_plotter/_utils/_formation_figure.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_utils/_formation_figure.py
@@ -75,16 +75,17 @@ class FormationFigure:
 
     @property
     def pressure_range(self) -> List[float]:
-        min_sim = (
-            self._ertdf["SIMULATED"].min()
-            if self.use_ertdf
-            else self._simdf["PRESSURE"].min()
-        )
-        max_sim = (
-            self._ertdf["SIMULATED"].max()
-            if self.use_ertdf
-            else self._simdf["PRESSURE"].max()
-        )
+        min_sim: float
+        max_sim: float
+        if self.use_ertdf:
+            min_sim = self._ertdf["SIMULATED"].min()
+            max_sim = self._ertdf["SIMULATED"].max()
+        elif self._simdf is not None:
+            min_sim = self._simdf["PRESSURE"].min()
+            max_sim = self._simdf["PRESSURE"].max()
+        else:
+            min_sim = float("inf")
+            max_sim = float("-inf")
         min_obs = (self._ertdf["OBSERVED"] - self._ertdf["OBSERVED_ERR"]).min()
         max_obs = (self._ertdf["OBSERVED"] + self._ertdf["OBSERVED_ERR"]).max()
 
@@ -125,7 +126,7 @@ class FormationFigure:
 
         if self._depthtype == DepthType.MD:
             self._ertdf["DEPTH"] = self._ertdf[DepthType.MD.value]
-            if self.simdf_has_md:
+            if self.simdf_has_md and self._simdf is not None:
                 self._simdf["DEPTH"] = self._simdf["CONMD"]
             if self._obsdf is not None and DepthType.MD.value in self._obsdf:
                 self._obsdf["DEPTH"] = self._obsdf[DepthType.MD.value]
@@ -246,6 +247,8 @@ class FormationFigure:
                     }
                 )
         else:
+            if self._simdf is None:
+                return
             if linetype == LineType.REALIZATION:
                 for ensemble, ensdf in self._simdf.groupby("ENSEMBLE"):
                     for i, (real, realdf) in enumerate(ensdf.groupby("REAL")):

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
@@ -1,6 +1,7 @@
-from typing import List
+from typing import Any, List
 
 import pandas as pd
+from dash import html
 from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
@@ -17,7 +18,7 @@ class ParameterFilterSettings(SettingsGroupABC):
         self._parameter_df = parameter_df
         self._ensembles = ensembles
 
-    def layout(self) -> List[Component]:
+    def layout(self) -> Any:
         return ParameterFilter(
             uuid=self.register_component_unique_id(self.Ids.PARAM_FILTER),
             dframe=self._parameter_df[

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_parameter_response_view/_settings/_parameter_filter.py
@@ -1,8 +1,6 @@
 from typing import Any, List
 
 import pandas as pd
-from dash import html
-from dash.development.base_component import Component
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import SettingsGroupABC
 

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -1,4 +1,5 @@
-from dash import dash_table, html
+from dash.dash_table.DataTable import DataTable
+from dash import html
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 
@@ -14,7 +15,7 @@ class TableViewElement(ViewElementABC):
         return html.Div(
             children=[
                 html.Div(
-                    children=dash_table.DataTable(
+                    children=DataTable(
                         id=self.register_component_unique_id(self.Ids.TABLE),
                         sort_action="native",
                         sort_mode="multi",

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -1,5 +1,5 @@
 from dash import html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -11,7 +11,7 @@ class TableViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             children=[
                 html.Div(

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -1,5 +1,5 @@
-from dash.dash_table import DataTable
 from dash import html
+from dash.dash_table import DataTable
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 

--- a/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
+++ b/webviz_subsurface/plugins/_rft_plotter/_views/_qc_view/_table_view_element.py
@@ -1,4 +1,4 @@
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import html
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC

--- a/webviz_subsurface/plugins/_segy_viewer.py
+++ b/webviz_subsurface/plugins/_segy_viewer.py
@@ -181,7 +181,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
         )
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             id=self.uuid("layout"),
             children=wcc.FlexBox(

--- a/webviz_subsurface/plugins/_simulation_time_series/_plugin.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_plugin.py
@@ -230,7 +230,8 @@ class SimulationTimeSeries(WebvizPluginABC):
                     ] = wsc.VectorDefinition(
                         type=_type,
                         description=simulation_vector_description(
-                            per_intvl_vec_base, self._user_defined_vector_definitions
+                            per_intvl_vec_base,
+                            self._user_defined_vector_definitions,
                         ),
                     )
 

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Tuple
 
 import webviz_core_components as wcc
 from dash import Input, Output, State, callback, dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.development.base_component import Component
 from dash.exceptions import PreventUpdate
 from webviz_config.utils import StrEnum, callback_typecheck

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Tuple
 
 import webviz_core_components as wcc
-from dash import Input, Output, State, callback, dash_table, dcc, html
+from dash.dash_table.DataTable import DataTable
+from dash import Input, Output, State, callback, dcc, html
 from dash.development.base_component import Component
 from dash.exceptions import PreventUpdate
 from webviz_config.utils import StrEnum, callback_typecheck
@@ -110,8 +111,8 @@ class EnsemblesSettings(SettingsGroupABC):
             ]
         )
 
-    def _delta_ensemble_table_layout(self) -> dash_table.DataTable:
-        return dash_table.DataTable(
+    def _delta_ensemble_table_layout(self) -> DataTable:
+        return DataTable(
             id=self.register_component_unique_id(
                 EnsemblesSettings.Ids.CREATED_DELTA_ENSEMBLE_NAMES_TABLE
             ),

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple
 
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Input, Output, State, callback, dcc, html
 from dash.development.base_component import Component
 from dash.exceptions import PreventUpdate

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_ensembles.py
@@ -1,8 +1,8 @@
 from typing import Dict, List, Tuple
 
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import Input, Output, State, callback, dcc, html
+from dash.dash_table import DataTable
 from dash.development.base_component import Component
 from dash.exceptions import PreventUpdate
 from webviz_config.utils import StrEnum, callback_typecheck

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_resampling_frequency.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_resampling_frequency.py
@@ -36,9 +36,11 @@ class ResamplingFrequencySettings(SettingsGroupABC):
         return [
             wcc.Label(
                 "NB: Disabled for pre-sampled data",
-                style={"font-style": "italic", "font-weight": "bold"}
-                if self._disable_dropdowns
-                else {"display": "none"},
+                style=(
+                    {"font-style": "italic", "font-weight": "bold"}
+                    if self._disable_dropdowns
+                    else {"display": "none"}
+                ),
             ),
             wcc.Dropdown(
                 id=self.register_component_unique_id(

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
@@ -94,9 +94,9 @@ class TimeSeriesSettings(SettingsGroupABC):
                 data=self._vector_selector_data,
                 persistence=True,
                 persistence_type="session",
-                selectedTags=[]
-                if self._selected_vectors is None
-                else self._selected_vectors,
+                selectedTags=(
+                    [] if self._selected_vectors is None else self._selected_vectors
+                ),
                 numSecondsUntilSuggestionsAreShown=0.5,
                 lineBreakAfterTag=True,
                 customVectorDefinitions=self._custom_vector_definitions,
@@ -316,8 +316,8 @@ class TimeSeriesSettings(SettingsGroupABC):
             )
 
             # Get new custom vector definitions
-            new_custom_vector_definitions_dict = get_vector_definitions_from_expressions(
-                new_expressions
+            new_custom_vector_definitions_dict = (
+                get_vector_definitions_from_expressions(new_expressions)
             )
             for key, value in self._custom_vector_definitions_base.items():
                 if key not in new_custom_vector_definitions_dict:

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
@@ -1,10 +1,11 @@
 import copy
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import dash
 import webviz_core_components as wcc
 import webviz_subsurface_components as wsc
 from dash import Input, Output, State, callback, dcc, html
+from dash._callback import NoUpdate
 from dash.development.base_component import Component
 from dash.exceptions import PreventUpdate
 from webviz_config.utils import StrEnum, callback_typecheck
@@ -315,35 +316,39 @@ class TimeSeriesSettings(SettingsGroupABC):
             )
 
             # Get new custom vector definitions
-            new_custom_vector_definitions = get_vector_definitions_from_expressions(
+            new_custom_vector_definitions_dict = get_vector_definitions_from_expressions(
                 new_expressions
             )
             for key, value in self._custom_vector_definitions_base.items():
-                if key not in new_custom_vector_definitions:
-                    new_custom_vector_definitions[key] = value
+                if key not in new_custom_vector_definitions_dict:
+                    new_custom_vector_definitions_dict[key] = value
 
             # Prevent updates if unchanged
-            if new_custom_vector_definitions == current_custom_vector_definitions:
-                new_custom_vector_definitions = dash.no_update
+            new_custom_vector_definitions_out: Union[
+                Dict[str, VectorDefinition], NoUpdate
+            ] = new_custom_vector_definitions_dict
+            if new_custom_vector_definitions_dict == current_custom_vector_definitions:
+                new_custom_vector_definitions_out = dash.no_update
 
+            new_selected_vectors_out: Union[List[str], NoUpdate] = new_selected_vectors
             if new_selected_vectors == current_selected_vectors:
-                new_selected_vectors = dash.no_update
+                new_selected_vectors_out = dash.no_update
 
             # If selected expressions are edited
             # - Only trigger graph data update property when needed,
             # i.e. names are unchanged and selectedNodes for VectorSelector remains unchanged.
-            new_graph_data_has_changed_counter = dash.no_update
+            new_graph_data_has_changed_counter: Union[int, NoUpdate] = dash.no_update
             if (
                 new_selected_expressions != current_selected_expressions
-                and new_selected_vectors == dash.no_update
+                and new_selected_vectors_out == dash.no_update
             ):
                 new_graph_data_has_changed_counter = graph_data_has_changed_counter + 1
 
             return [
                 new_expressions,
                 new_vector_selector_data,
-                new_selected_vectors,
-                new_custom_vector_definitions,
+                new_selected_vectors_out,
+                new_custom_vector_definitions_out,
                 new_graph_data_has_changed_counter,
             ]
 

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import dash
 import webviz_core_components as wcc
@@ -276,7 +276,6 @@ class TimeSeriesSettings(SettingsGroupABC):
             ),
         )
         @callback_typecheck
-        # pylint: disable=too-many-locals
         def _update_vector_calculator_expressions_on_dialog_close(
             is_dialog_open: bool,
             new_expressions: List[ExpressionInfo],

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import dash
 import webviz_core_components as wcc
@@ -276,6 +276,7 @@ class TimeSeriesSettings(SettingsGroupABC):
             ),
         )
         @callback_typecheck
+        # pylint: disable=too-many-locals
         def _update_vector_calculator_expressions_on_dialog_close(
             is_dialog_open: bool,
             new_expressions: List[ExpressionInfo],

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_time_series.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import dash
 import webviz_core_components as wcc

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_visualization.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_settings/_visualization.py
@@ -87,13 +87,15 @@ class VisualizationSettings(SettingsGroupABC):
                     id=self.register_component_unique_id(
                         VisualizationSettings.Ids.PLOT_STATISTICS_OPTIONS_CHECKLIST
                     ),
-                    style={"display": "block"}
-                    if selected_visualization
-                    in [
-                        VisualizationOptions.STATISTICS,
-                        VisualizationOptions.STATISTICS_AND_REALIZATIONS,
-                    ]
-                    else {"display": "none"},
+                    style=(
+                        {"display": "block"}
+                        if selected_visualization
+                        in [
+                            VisualizationOptions.STATISTICS,
+                            VisualizationOptions.STATISTICS_AND_REALIZATIONS,
+                        ]
+                        else {"display": "none"}
+                    ),
                     options=[
                         {"label": "Mean", "value": StatisticsOptions.MEAN},
                         {
@@ -121,9 +123,11 @@ class VisualizationSettings(SettingsGroupABC):
                     id=self.register_component_unique_id(
                         VisualizationSettings.Ids.PLOT_FANCHART_OPTIONS_CHECKLIST
                     ),
-                    style={"display": "block"}
-                    if VisualizationOptions.FANCHART == selected_visualization
-                    else {"display": "none"},
+                    style=(
+                        {"display": "block"}
+                        if VisualizationOptions.FANCHART == selected_visualization
+                        else {"display": "none"}
+                    ),
                     options=[
                         {
                             "label": FanchartOptions.MEAN,

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_utils/from_timeseries_cumulatives.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_utils/from_timeseries_cumulatives.py
@@ -97,9 +97,11 @@ def calculate_from_resampled_cumulative_vectors_df(
     vectors_df.set_index(["DATE"], inplace=True)
 
     cumulative_name_map = {
-        vector: create_per_day_vector_name(vector)
-        if as_per_day
-        else create_per_interval_vector_name(vector)
+        vector: (
+            create_per_day_vector_name(vector)
+            if as_per_day
+            else create_per_interval_vector_name(vector)
+        )
         for vector in column_keys
     }
     cumulative_vectors = list(cumulative_name_map.values())
@@ -155,7 +157,7 @@ def datetime_to_intervalstr(date: datetime.datetime, freq: Frequency) -> Optiona
         return f"{date.year}-{date.month:02d}-{date.day:02d}"
     if freq == Frequency.WEEKLY:
         # Note: weekyear may differ from actual year for week numbers 1,52,53.
-        (weekyear, week, _) = date.isocalendar()
+        weekyear, week, _ = date.isocalendar()
         return f"{weekyear}-W{week:02d}"
     if freq == Frequency.MONTHLY:
         return f"{date.year}-{date.month:02d}"

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
@@ -1,9 +1,10 @@
 import datetime
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dash
 import pandas as pd
 from dash import Input, Output, State, callback
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 from webviz_config import EncodedFile, WebvizPluginABC
 from webviz_config._theme_class import WebvizConfigTheme
@@ -911,7 +912,11 @@ class SubplotView(ViewABC):
             relative_date_value: Optional[str],
             current_relative_date_options: List[Dict[str, str]],
             current_relative_date_value: Optional[str],
-        ) -> Tuple[List[Dict[str, str]], Optional[str], Dict[str, str]]:
+        ) -> Tuple[
+            Union[List[Dict[str, str]], NoUpdate],
+            Union[str, None, NoUpdate],
+            Dict[str, str],
+        ]:
             """This callback updates dropdown based on selected resampling frequency selection
             and hide trace options (History and Observation) when a relative date is selected.
 
@@ -947,10 +952,14 @@ class SubplotView(ViewABC):
             )
 
             # Prevent updates if unchanged
+            options_output: Union[List[Dict[str, str]], NoUpdate] = (
+                new_relative_date_options
+            )
+            value_output: Union[str, None, NoUpdate] = new_relative_date_value
             if new_relative_date_options == current_relative_date_options:
-                new_relative_date_options = dash.no_update
+                options_output = dash.no_update
             if new_relative_date_value == current_relative_date_value:
-                new_relative_date_value = dash.no_update
+                value_output = dash.no_update
 
             # Convert to Optional[datetime.datetime]
             relative_date: Optional[datetime.datetime] = (
@@ -963,7 +972,7 @@ class SubplotView(ViewABC):
             )
 
             return (
-                new_relative_date_options,
-                new_relative_date_value,
+                options_output,
+                value_output,
                 trace_options_style,
             )

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dash
 import pandas as pd

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
@@ -453,11 +453,13 @@ class SubplotView(ViewABC):
                         # Show selected realizations - only filter df if realizations filter
                         # query is not performed
                         figure_builder.add_realizations_traces(
-                            vectors_df
-                            if realizations_query
-                            else vectors_df[
-                                vectors_df["REAL"].isin(selected_realizations)
-                            ],
+                            (
+                                vectors_df
+                                if realizations_query
+                                else vectors_df[
+                                    vectors_df["REAL"].isin(selected_realizations)
+                                ]
+                            ),
                             ensemble,
                         )
                     if visualization == VisualizationOptions.STATISTICS:
@@ -483,11 +485,13 @@ class SubplotView(ViewABC):
                         # Show selected realizations - only filter df if realizations filter
                         # query is not performed
                         figure_builder.add_realizations_traces(
-                            vectors_df
-                            if realizations_query
-                            else vectors_df[
-                                vectors_df["REAL"].isin(selected_realizations)
-                            ],
+                            (
+                                vectors_df
+                                if realizations_query
+                                else vectors_df[
+                                    vectors_df["REAL"].isin(selected_realizations)
+                                ]
+                            ),
                             ensemble,
                             color_lightness_scale=150.0,
                         )
@@ -952,9 +956,9 @@ class SubplotView(ViewABC):
             )
 
             # Prevent updates if unchanged
-            options_output: Union[List[Dict[str, str]], NoUpdate] = (
-                new_relative_date_options
-            )
+            options_output: Union[
+                List[Dict[str, str]], NoUpdate
+            ] = new_relative_date_options
             value_output: Union[str, None, NoUpdate] = new_relative_date_value
             if new_relative_date_options == current_relative_date_options:
                 options_output = dash.no_update

--- a/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
+++ b/webviz_subsurface/plugins/_simulation_time_series/_views/_subplot_view/_view.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import dash
 import pandas as pd

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_utils/_onebyone_timeseries_figure.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_utils/_onebyone_timeseries_figure.py
@@ -223,9 +223,9 @@ class OneByOneTimeSeriesFigure:
             [
                 {
                     "line": {
-                        "dash": "dash"
-                        if real_df["SENSCASEID"].iloc[0] == 1
-                        else "solid",
+                        "dash": (
+                            "dash" if real_df["SENSCASEID"].iloc[0] == 1 else "solid"
+                        ),
                         "shape": self.line_shape,
                         "color": self.colormap.get(
                             real_df[self.color_col].iloc[0], "grey"
@@ -256,9 +256,9 @@ class OneByOneTimeSeriesFigure:
             [
                 {
                     "line": {
-                        "dash": "dash"
-                        if real_df["SENSCASEID"].iloc[0] == 1
-                        else "solid",
+                        "dash": (
+                            "dash" if real_df["SENSCASEID"].iloc[0] == 1 else "solid"
+                        ),
                         "shape": self.line_shape,
                         "color": rgb_to_str(
                             scale_rgb_lightness(

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_utils/_simulation_time_series_onebyone_datamodel.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_utils/_simulation_time_series_onebyone_datamodel.py
@@ -176,9 +176,11 @@ class SimulationTimeSeriesOneByOneDataModel:
             )
             .figure.update_xaxes(side="bottom", title=None)
             .update_layout(
-                title_text=title
-                if title is not None
-                else f"Tornadoplot for {tornado_data.response_name} <br>",
+                title_text=(
+                    title
+                    if title is not None
+                    else f"Tornadoplot for {tornado_data.response_name} <br>"
+                ),
                 margin={"t": 70},
             )
         )
@@ -207,12 +209,14 @@ class SimulationTimeSeriesOneByOneDataModel:
             .update_layout(legend_title_text="", margin_b=0, margin_r=10)
             .for_each_trace(
                 lambda t: (
-                    t.update(marker_line_color="black")
-                    if t["customdata"][0][0] == "high"
-                    else t.update(marker_line_color="white", marker_line_width=2)
+                    (
+                        t.update(marker_line_color="black")
+                        if t["customdata"][0][0] == "high"
+                        else t.update(marker_line_color="white", marker_line_width=2)
+                    )
+                    if t["customdata"][0][0] != "mc"
+                    else None
                 )
-                if t["customdata"][0][0] != "mc"
-                else None
             )
         )
 

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view.py
@@ -141,6 +141,7 @@ class OneByOneView(ViewABC):
                 .component_unique_id(GeneralViewElement.Ids.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
             State(
                 {
@@ -323,6 +324,7 @@ class OneByOneView(ViewABC):
                 .component_unique_id(GeneralViewElement.Ids.GRAPH)
                 .to_string(),
                 "clickData",
+                allow_optional=True,
             ),
             Input(
                 self.settings_group_unique_id(

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
@@ -1,5 +1,5 @@
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import html
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
@@ -1,5 +1,6 @@
 import webviz_core_components as wcc
-from dash import dash_table, html
+from dash.dash_table.DataTable import DataTable
+from dash import html
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 
@@ -20,7 +21,7 @@ class BottomVisualizationViewElement(ViewElementABC):
                 html.Div(
                     id=self.register_component_unique_id(self.Ids.TABLE_WRAPPER),
                     style={"display": "block"},
-                    children=dash_table.DataTable(
+                    children=DataTable(
                         id=self.register_component_unique_id(self.Ids.TABLE),
                         sort_action="native",
                         sort_mode="multi",

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
@@ -1,6 +1,6 @@
 import webviz_core_components as wcc
 from dash import html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
@@ -15,7 +15,7 @@ class BottomVisualizationViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             children=[
                 html.Div(

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_bottom_visualization_view_element.py
@@ -1,6 +1,6 @@
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import html
+from dash.dash_table import DataTable
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 

--- a/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_general_view_element.py
+++ b/webviz_subsurface/plugins/_simulation_time_series_onebyone/_views/_onebyone_view/_view_elements/_general_view_element.py
@@ -11,7 +11,7 @@ class GeneralViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             children=[
                 wcc.Graph(

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import xtgeo
 from dash import Dash, Input, Output, State, callback_context, no_update
-from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._datainput.well import (
@@ -303,13 +302,22 @@ def update_maps(
                         create_leaflet_well_marker_layer(wells, surface2)
                     )
 
+        map1_layers = (
+            surface_layers if update_controls["map1"]["update"] else no_update
+        )
+        map2_layers = (
+            surface_layers2 if update_controls["map2"]["update"] else no_update
+        )
+        diff_map_layers = (
+            diff_layers if update_controls["diff_map"]["update"] else no_update
+        )
         return (
             f"Surface A: {surfattr_map} - {surfname_map} - {ensemble_map} - {calc_map}",
-            surface_layers if update_controls["map1"]["update"] else no_update,  # type: ignore[return-value]
+            map1_layers,  # type: ignore[return-value]
             f"Surface B: {surfattr_map2} - {surfname_map2} - {ensemble_map2} - {calc_map2}",
-            surface_layers2 if update_controls["map2"]["update"] else no_update,  # type: ignore[return-value]
+            map2_layers,  # type: ignore[return-value]
             "Surface A-B",
-            diff_layers if update_controls["diff_map"]["update"] else no_update,  # type: ignore[return-value]
+            diff_map_layers,  # type: ignore[return-value]
         )
 
     @app.callback(

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -405,9 +405,11 @@ def update_maps(
                     "update": "map1" in ctx["prop_id"],
                 },
                 "map2": {
-                    "color_range": [clip_min_map2, clip_max_map2]
-                    if not sync_range
-                    else [clip_min_map1, clip_max_map1],
+                    "color_range": (
+                        [clip_min_map2, clip_max_map2]
+                        if not sync_range
+                        else [clip_min_map1, clip_max_map1]
+                    ),
                     "update": "map2" in ctx["prop_id"]
                     or (sync_range and "map1" in ctx["prop_id"])
                     or (

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -142,11 +142,11 @@ def update_maps(
         if "compute_diff" in ctx["prop_id"]:
             if not compute_diff:
                 return (
-                    no_update,
-                    no_update,
-                    no_update,
-                    no_update,
-                    no_update,
+                    no_update,  # type: ignore[return-value]
+                    no_update,  # type: ignore[return-value]
+                    no_update,  # type: ignore[return-value]
+                    no_update,  # type: ignore[return-value]
+                    no_update,  # type: ignore[return-value]
                     [],
                 )
 
@@ -185,9 +185,9 @@ def update_maps(
                 f"Surface A: {surfattr_map} - {surfname_map} - {ensemble_map} - {calc_map}",
                 current_map,
                 f"Surface B: {surfattr_map2} - {surfname_map2} - {ensemble_map2} - {calc_map2}",
-                no_update,
+                no_update,  # type: ignore[return-value]
                 "Surface A-B",
-                no_update,
+                no_update,  # type: ignore[return-value]
             )
 
         if wellname is not None:
@@ -210,7 +210,7 @@ def update_maps(
                     f"{ensemble_map2} - {calc_map2}",
                     current_map2,
                     "Surface A-B",
-                    no_update,
+                    no_update,  # type: ignore[return-value]
                 )
 
         # Calculate maps
@@ -305,11 +305,11 @@ def update_maps(
 
         return (
             f"Surface A: {surfattr_map} - {surfname_map} - {ensemble_map} - {calc_map}",
-            surface_layers if update_controls["map1"]["update"] else no_update,
+            surface_layers if update_controls["map1"]["update"] else no_update,  # type: ignore[return-value]
             f"Surface B: {surfattr_map2} - {surfname_map2} - {ensemble_map2} - {calc_map2}",
-            surface_layers2 if update_controls["map2"]["update"] else no_update,
+            surface_layers2 if update_controls["map2"]["update"] else no_update,  # type: ignore[return-value]
             "Surface A-B",
-            diff_layers if update_controls["diff_map"]["update"] else no_update,
+            diff_layers if update_controls["diff_map"]["update"] else no_update,  # type: ignore[return-value]
         )
 
     @app.callback(
@@ -344,16 +344,16 @@ def update_maps(
     def _update_from_map_click(
         clicked_shape: Optional[Dict],
         _polyline: List[List[float]],
-    ) -> Tuple[str, Union[NoUpdate, str]]:
+    ) -> Tuple[str, Union[str, None]]:
         """Update intersection source and optionally selected well when
         user clicks a shape in map"""
         ctx = callback_context.triggered[0]
         if "polyline_points" in ctx["prop_id"]:
-            return "polyline", no_update
+            return "polyline", None
         if clicked_shape is None:
             raise PreventUpdate
         if clicked_shape.get("id") == "random_line":
-            return "polyline", no_update
+            return "polyline", None
         if clicked_shape.get("id") in well_set_model.well_names:
             return "well", clicked_shape.get("id")
         raise PreventUpdate

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -302,9 +302,7 @@ def update_maps(
                         create_leaflet_well_marker_layer(wells, surface2)
                     )
 
-        map1_layers = (
-            surface_layers if update_controls["map1"]["update"] else no_update
-        )
+        map1_layers = surface_layers if update_controls["map1"]["update"] else no_update
         map2_layers = (
             surface_layers2 if update_controls["map2"]["update"] else no_update
         )

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import xtgeo
 from dash import Dash, Input, Output, State, callback_context, no_update
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._datainput.well import (
@@ -302,20 +303,13 @@ def update_maps(
                         create_leaflet_well_marker_layer(wells, surface2)
                     )
 
-        map1_layers = surface_layers if update_controls["map1"]["update"] else no_update
-        map2_layers = (
-            surface_layers2 if update_controls["map2"]["update"] else no_update
-        )
-        diff_map_layers = (
-            diff_layers if update_controls["diff_map"]["update"] else no_update
-        )
         return (
             f"Surface A: {surfattr_map} - {surfname_map} - {ensemble_map} - {calc_map}",
-            map1_layers,  # type: ignore[return-value]
+            surface_layers if update_controls["map1"]["update"] else no_update,  # type: ignore[return-value]
             f"Surface B: {surfattr_map2} - {surfname_map2} - {ensemble_map2} - {calc_map2}",
-            map2_layers,  # type: ignore[return-value]
+            surface_layers2 if update_controls["map2"]["update"] else no_update,  # type: ignore[return-value]
             "Surface A-B",
-            diff_map_layers,  # type: ignore[return-value]
+            diff_layers if update_controls["diff_map"]["update"] else no_update,  # type: ignore[return-value]
         )
 
     @app.callback(

--- a/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/controllers/map_controller.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import xtgeo
 from dash import Dash, Input, Output, State, callback_context, no_update
-from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._datainput.well import (
@@ -305,11 +304,17 @@ def update_maps(
 
         return (
             f"Surface A: {surfattr_map} - {surfname_map} - {ensemble_map} - {calc_map}",
-            surface_layers if update_controls["map1"]["update"] else no_update,  # type: ignore[return-value]
+            (  # type: ignore[return-value]
+                surface_layers if update_controls["map1"]["update"] else no_update
+            ),
             f"Surface B: {surfattr_map2} - {surfname_map2} - {ensemble_map2} - {calc_map2}",
-            surface_layers2 if update_controls["map2"]["update"] else no_update,  # type: ignore[return-value]
+            (  # type: ignore[return-value]
+                surface_layers2 if update_controls["map2"]["update"] else no_update
+            ),
             "Surface A-B",
-            diff_layers if update_controls["diff_map"]["update"] else no_update,  # type: ignore[return-value]
+            (  # type: ignore[return-value]
+                diff_layers if update_controls["diff_map"]["update"] else no_update
+            ),
         )
 
     @app.callback(

--- a/webviz_subsurface/plugins/_structural_uncertainty/structural_uncertainty.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/structural_uncertainty.py
@@ -280,9 +280,11 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                                                     surface_names=self._surfacenames,
                                                     ensembles=self.ensembles,
                                                     use_wells=self._use_wells,
-                                                    well_names=self._well_set_model.well_names
-                                                    if self._well_set_model
-                                                    else [],
+                                                    well_names=(
+                                                        self._well_set_model.well_names
+                                                        if self._well_set_model
+                                                        else []
+                                                    ),
                                                     surface_geometry=self.first_surface_geometry,
                                                     initial_settings=self._initial_settings.get(
                                                         "intersection_data", {}

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/dialog.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/dialog.py
@@ -50,9 +50,11 @@ def clear_all_apply_dialog_buttons(
             ),
             dbc.Button(
                 "Apply",
-                style={"padding": "0 20px", "visibility": "hidden"}
-                if apply_disabled
-                else {"padding": "0 20px"},
+                style=(
+                    {"padding": "0 20px", "visibility": "hidden"}
+                    if apply_disabled
+                    else {"padding": "0 20px"}
+                ),
                 className="mr-1",
                 id={"id": uuid, "dialog_id": dialog_id, "element": "apply"},
             ),

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_and_map.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_and_map.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import webviz_core_components as wcc
 from dash import html
@@ -78,7 +78,7 @@ def map_layout(
     draw_polyline: bool = False,
 ) -> html.Div:
     synced_uuids = synced_uuids if synced_uuids else []
-    props: Optional[Dict] = (
+    props: Dict[str, Any] = (
         {
             "drawTools": {
                 "drawMarker": False,

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
@@ -108,11 +108,13 @@ def well_layout(
     uuid: str, well_names: List[str], value: Optional[str] = None
 ) -> html.Div:
     return html.Div(
-        style={
-            "display": "none",
-        }
-        if value is None
-        else {},
+        style=(
+            {
+                "display": "none",
+            }
+            if value is None
+            else {}
+        ),
         id={"id": uuid, "element": "well-wrapper"},
         children=wcc.Dropdown(
             label="Well",

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/intersection_data.py
@@ -274,7 +274,7 @@ def statistical_layout(uuid: str, value: List[str]) -> html.Div:
     )
 
 
-def blue_apply_button(uuid: str, title: str) -> html.Div:
+def blue_apply_button(uuid: str, title: str) -> html.Button:
     return html.Button(
         title,
         className="webviz-structunc-blue-apply-btn",

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/map_data.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/map_data.py
@@ -94,11 +94,16 @@ def make_map_selectors(
             ),
             wcc.Checklist(
                 id={"id": uuid, "map_id": map_id, "element": "options"},
-                options=[
-                    {"label": "Calculate well intersections", "value": "intersect_well"}
-                ]
-                if use_wells
-                else [],
+                options=(
+                    [
+                        {
+                            "label": "Calculate well intersections",
+                            "value": "intersect_well",
+                        }
+                    ]
+                    if use_wells
+                    else []
+                ),
                 value=[],
             ),
         ]

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
@@ -1,6 +1,6 @@
 import webviz_core_components as wcc
 from dash import html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 
 
 def uncertainty_table_layout(

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
@@ -1,6 +1,6 @@
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import html
+from dash.dash_table import DataTable
 
 
 def uncertainty_table_layout(

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
@@ -1,5 +1,6 @@
 import webviz_core_components as wcc
-from dash import dash_table, html
+from dash.dash_table.DataTable import DataTable
+from dash import html
 
 
 def uncertainty_table_layout(
@@ -22,7 +23,7 @@ def uncertainty_table_layout(
                     ),
                 ]
             ),
-            dash_table.DataTable(
+            DataTable(
                 id={"id": uuid, "element": "table"},
                 columns=[
                     {"id": "Surface name", "name": "Surface name", "selectable": False},

--- a/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
+++ b/webviz_subsurface/plugins/_structural_uncertainty/views/uncertainty_table.py
@@ -1,5 +1,5 @@
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import html
 
 

--- a/webviz_subsurface/plugins/_subsurface_map.py
+++ b/webviz_subsurface/plugins/_subsurface_map.py
@@ -95,7 +95,7 @@ that you are reading the correct data.
         self.map_id = f"map-{uuid4()}"
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div([Map(id=self.map_id, data=self.map_data)])
 
     def add_webvizstore(self) -> List[Tuple[Callable, list]]:

--- a/webviz_subsurface/plugins/_subsurface_map.py
+++ b/webviz_subsurface/plugins/_subsurface_map.py
@@ -100,18 +100,20 @@ that you are reading the correct data.
 
     def add_webvizstore(self) -> List[Tuple[Callable, list]]:
         return [
-            (get_path, [{"path": Path(self.jsonfile)}])
-            if self.jsonfile
-            else (
-                get_uncompressed_data,
-                [
-                    {
-                        "ensemble_path": self.ensemble_path,
-                        "map_value": self.map_value,
-                        "flow_value": self.flow_value,
-                        "time_step": self.time_step,
-                    }
-                ],
+            (
+                (get_path, [{"path": Path(self.jsonfile)}])
+                if self.jsonfile
+                else (
+                    get_uncompressed_data,
+                    [
+                        {
+                            "ensemble_path": self.ensemble_path,
+                            "map_value": self.map_value,
+                            "flow_value": self.flow_value,
+                            "time_step": self.time_step,
+                        }
+                    ],
+                )
             )
         ]
 

--- a/webviz_subsurface/plugins/_surface_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_surface_viewer_fmu.py
@@ -282,7 +282,7 @@ attribute_settings:
         )
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             id=self.uuid("layout"),
             children=[

--- a/webviz_subsurface/plugins/_surface_viewer_fmu.py
+++ b/webviz_subsurface/plugins/_surface_viewer_fmu.py
@@ -706,9 +706,9 @@ def surfacedf_to_dict(df: pd.DataFrame) -> dict:
     return {
         attr: {
             "names": list(dframe["name"].unique()),
-            "dates": list(dframe["date"].unique())
-            if "date" in dframe.columns
-            else None,
+            "dates": (
+                list(dframe["date"].unique()) if "date" in dframe.columns else None
+            ),
         }
         for attr, dframe in df.groupby("attribute")
     }

--- a/webviz_subsurface/plugins/_swatinit_qc/_business_logic.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_business_logic.py
@@ -304,9 +304,11 @@ class SwatinitQcDataModel:
                     "Response": key,
                     "Water Volume Mrm3": f"{qc_vols[key]/1e6:>10.3f}",
                     "Water Volume Diff": f"{qc_vols[key]/qc_vols['SWATINIT_WVOL']*100:>3.2f} %",
-                    "HC Volume Diff": f"{-qc_vols[key]/qc_vols['SWATINIT_HCVOL']*100:>3.2f} %"
-                    if qc_vols["SWATINIT_HCVOL"] > 0
-                    else "0.00 %",
+                    "HC Volume Diff": (
+                        f"{-qc_vols[key]/qc_vols['SWATINIT_HCVOL']*100:>3.2f} %"
+                        if qc_vols["SWATINIT_HCVOL"] > 0
+                        else "0.00 %"
+                    ),
                 }
             )
         # Last report the SWAT volumes and change from SWATINIT

--- a/webviz_subsurface/plugins/_swatinit_qc/_callbacks.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_callbacks.py
@@ -1,6 +1,6 @@
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
-from dash import ALL, Input, Output, State, callback, callback_context
+from dash import ALL, Input, Output, State, callback, callback_context, html
 from dash.exceptions import PreventUpdate
 
 from ._business_logic import SwatinitQcDataModel
@@ -151,7 +151,7 @@ def plugin_callbacks(get_uuid: Callable, datamodel: SwatinitQcDataModel) -> None
         groupby_eqlnum: list,
         continous_filters: List[List[str]],
         continous_filters_ids: List[Dict[str, str]],
-    ) -> str:
+    ) -> html.Div:
         if tab_selected != Tabs.MAX_PC_SCALING:
             raise PreventUpdate
 

--- a/webviz_subsurface/plugins/_swatinit_qc/_callbacks.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_callbacks.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 from dash import ALL, Input, Output, State, callback, callback_context, html
 from dash.exceptions import PreventUpdate

--- a/webviz_subsurface/plugins/_swatinit_qc/_callbacks.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_callbacks.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from dash import ALL, Input, Output, State, callback, callback_context, html
 from dash.exceptions import PreventUpdate

--- a/webviz_subsurface/plugins/_swatinit_qc/_figures.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_figures.py
@@ -238,9 +238,11 @@ class PropertiesVsDepthSubplots:
         if not self.discrete_color:
             return {
                 "coloraxis": "coloraxis",
-                "color": df[self.color_by]
-                if self.color_by != "PERMX"
-                else np.log10(df[self.color_by]),
+                "color": (
+                    df[self.color_by]
+                    if self.color_by != "PERMX"
+                    else np.log10(df[self.color_by])
+                ),
             }
         return {"color": self.colormap[color], "opacity": 0.5}
 
@@ -307,9 +309,11 @@ class MapFigure:
                 data_frame=self.dframe,
                 x="X",
                 y="Y",
-                color=self.color_by
-                if self.color_by != "PERMX"
-                else np.log10(self.dframe[self.color_by]),
+                color=(
+                    self.color_by
+                    if self.color_by != "PERMX"
+                    else np.log10(self.dframe[self.color_by])
+                ),
                 color_discrete_map=self.colormap,
                 xaxis={"constrain": "domain", **self.axis_layout},
                 yaxis={"scaleanchor": "x", **self.axis_layout},

--- a/webviz_subsurface/plugins/_swatinit_qc/_layout.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_layout.py
@@ -4,7 +4,8 @@ from typing import Any, Callable, List, Optional
 import pandas as pd
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash import dash_table, dcc, html
+from dash import dcc, html
+from dash.dash_table.DataTable import DataTable
 
 from ._business_logic import SwatinitQcDataModel
 from ._markdown import (
@@ -374,7 +375,7 @@ class TabMaxPcInfoLayout:
 
     def create_max_pc_table(
         self, dframe: pd.DataFrame, text_columns: list
-    ) -> dash_table:
+    ) -> DataTable:
         return DashTable(
             data=dframe.to_dict("records"),
             columns=[
@@ -556,7 +557,7 @@ def range_filters(uuid: str, datamodel: SwatinitQcDataModel) -> html.Div:
     return html.Div(filters)
 
 
-class DashTable(dash_table.DataTable):
+class DashTable(DataTable):
     def __init__(
         self, data: List[dict], columns: List[dict], height: str = "none", **kwargs: Any
     ) -> None:

--- a/webviz_subsurface/plugins/_swatinit_qc/_layout.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_layout.py
@@ -5,7 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import webviz_core_components as wcc
 from dash import dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 
 from ._business_logic import SwatinitQcDataModel
 from ._markdown import (
@@ -91,7 +91,7 @@ def plugin_main_layout(get_uuid: Callable, datamodel: SwatinitQcDataModel) -> wc
 
 class TabLayout(wcc.Tab):
     def __init__(
-        self, tab_label: str, selections_layout: Optional[list], main_layout: list
+        self, tab_label: str, selections_layout: Any, main_layout: Any
     ) -> None:
         flex_children = []
         if selections_layout is not None:

--- a/webviz_subsurface/plugins/_swatinit_qc/_layout.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_layout.py
@@ -5,7 +5,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import webviz_core_components as wcc
 from dash import dcc, html
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 
 from ._business_logic import SwatinitQcDataModel
 from ._markdown import (

--- a/webviz_subsurface/plugins/_swatinit_qc/_layout.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_layout.py
@@ -1,5 +1,5 @@
 from enum import IntEnum, auto
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List
 
 import pandas as pd
 import plotly.graph_objects as go

--- a/webviz_subsurface/plugins/_swatinit_qc/_layout.py
+++ b/webviz_subsurface/plugins/_swatinit_qc/_layout.py
@@ -1,5 +1,5 @@
 from enum import IntEnum, auto
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Optional
 
 import pandas as pd
 import plotly.graph_objects as go
@@ -563,10 +563,10 @@ class DashTable(DataTable):
     ) -> None:
         super().__init__(
             data=data,
-            columns=columns,
+            columns=columns,  # type: ignore[arg-type]
             style_table={"height": height, **LayoutStyle.TABLE_STYLE},
             style_as_list_view=True,
-            css=LayoutStyle.TABLE_CSS,
+            css=LayoutStyle.TABLE_CSS,  # type: ignore[arg-type]
             style_header=LayoutStyle.TABLE_HEADER,
             **kwargs,
         )

--- a/webviz_subsurface/plugins/_tornado_plotter_fmu/_plugin.py
+++ b/webviz_subsurface/plugins/_tornado_plotter_fmu/_plugin.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import List, Type
 
-from dash import ALL, Input, Output, callback, callback_context
+from dash import ALL, Input, Output, callback, callback_context, html
 from dash.development.base_component import Component
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.utils import StrEnum, callback_typecheck
@@ -370,5 +370,5 @@ class TornadoPlotterFMU(WebvizPluginABC):
         return tour
 
     @property
-    def layout(self) -> Type[Component]:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return error(self._error_message)

--- a/webviz_subsurface/plugins/_tornado_plotter_fmu/_plugin.py
+++ b/webviz_subsurface/plugins/_tornado_plotter_fmu/_plugin.py
@@ -1,9 +1,8 @@
 import json
 from pathlib import Path
-from typing import List, Type
+from typing import List
 
 from dash import ALL, Input, Output, callback, callback_context, html
-from dash.development.base_component import Component
 from webviz_config import WebvizPluginABC, WebvizSettings
 from webviz_config.utils import StrEnum, callback_typecheck
 

--- a/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
+++ b/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
@@ -1,5 +1,4 @@
-from dash.dash_table.DataTable import DataTable
-from dash import 
+from dash.dash_table import DataTable
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 

--- a/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
+++ b/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
@@ -1,4 +1,5 @@
-from dash import dash_table
+from dash.dash_table.DataTable import DataTable
+from dash import 
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 
@@ -11,8 +12,8 @@ class TornadoTable(ViewElementABC):
         super().__init__()
         self.height = height
 
-    def inner_layout(self) -> dash_table.DataTable:
-        return dash_table.DataTable(
+    def inner_layout(self) -> DataTable:
+        return DataTable(
             id=self.register_component_unique_id(TornadoTable.IDs.TABLE),
             style_cell={"whiteSpace": "normal", "height": "auto"},
         )

--- a/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
+++ b/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
@@ -11,7 +11,7 @@ class TornadoTable(ViewElementABC):
         super().__init__()
         self.height = height
 
-    def inner_layout(self) -> DataTable:
+    def inner_layout(self) -> DataTable:  # type: ignore[override]
         return DataTable(
             id=self.register_component_unique_id(TornadoTable.IDs.TABLE),
             style_cell={"whiteSpace": "normal", "height": "auto"},

--- a/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
+++ b/webviz_subsurface/plugins/_tornado_plotter_fmu/views/table_view/view_elements/table.py
@@ -1,4 +1,4 @@
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from webviz_config.utils import StrEnum
 from webviz_config.webviz_plugin_subclasses import ViewElementABC
 

--- a/webviz_subsurface/plugins/_vfp_analysis/_views/_vfp_view/_view_elements/_vfp_graph.py
+++ b/webviz_subsurface/plugins/_vfp_analysis/_views/_vfp_view/_view_elements/_vfp_graph.py
@@ -11,7 +11,7 @@ class VfpGraph(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return wcc.Graph(
             id=self.register_component_unique_id(self.Ids.GRAPH),
             style={"height": "87vh"},

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -4,7 +4,8 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from dash import Input, Output, State, callback, dash_table, html
+from dash.dash_table.DataTable import DataTable
+from dash import Input, Output, State, callback, html
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._figures import create_figure
@@ -335,7 +336,7 @@ def create_comaprison_table(
     compare_on: str,
     use_si_format: Optional[bool] = None,
     volumemodel: Optional[InplaceVolumesModel] = None,
-) -> dash_table.DataTable:
+) -> DataTable:
     diff_mode_percent = selections["Diff mode"] == "diff (%)"
 
     if selections["Remove non-highlighted"]:

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -5,6 +5,7 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from dash import Input, Output, State, callback, html
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._figures import create_figure

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import Input, Output, State, callback, html
 from dash.exceptions import PreventUpdate
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -4,8 +4,8 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
-from dash.dash_table import DataTable
 from dash import Input, Output, State, callback, html
+from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._figures import create_figure

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -63,9 +63,11 @@ def comparison_controllers(
             raise PreventUpdate
 
         return comparison_callback(
-            compare_on="SENSNAME_CASE"
-            if selections["compare_on"] == "Sensitivity"
-            else "ENSEMBLE",
+            compare_on=(
+                "SENSNAME_CASE"
+                if selections["compare_on"] == "Sensitivity"
+                else "ENSEMBLE"
+            ),
             volumemodel=volumemodel,
             selections=selections,
         )
@@ -228,9 +230,9 @@ def comparison_callback(
         )
         barfig_non_highlighted = create_barfig(
             df=df[df["highlighted"] == "yes"],
-            groupby=groupby
-            if group_on_fluid
-            else [x for x in groupby if x != "FLUID_ZONE"],
+            groupby=(
+                groupby if group_on_fluid else [x for x in groupby if x != "FLUID_ZONE"]
+            ),
             diff_mode=selections["Diff mode"],
             colorcol=resp1,
         )
@@ -360,9 +362,11 @@ def create_comaprison_table(
         columns = create_table_columns(
             columns=move_to_end_of_list("FLUID_ZONE", df.columns),
             text_columns=groupby,
-            use_si_format=volumemodel.volume_columns
-            if volumemodel is not None and not diff_mode_percent
-            else None,
+            use_si_format=(
+                volumemodel.volume_columns
+                if volumemodel is not None and not diff_mode_percent
+                else None
+            ),
             use_percentage=list(df.columns) if diff_mode_percent else None,
         )
     else:

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -5,7 +5,6 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from dash import Input, Output, State, callback, html
-from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._figures import create_figure

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/comparison_controllers.py
@@ -1,11 +1,11 @@
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from dash import Input, Output, State, callback, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._figures import create_figure
@@ -336,7 +336,7 @@ def create_comaprison_table(
     compare_on: str,
     use_si_format: Optional[bool] = None,
     volumemodel: Optional[InplaceVolumesModel] = None,
-) -> DataTable:
+) -> Any:
     diff_mode_percent = selections["Diff mode"] == "diff (%)"
 
     if selections["Remove non-highlighted"]:

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/distribution_controllers.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -39,7 +39,7 @@ def distribution_controllers(
         Input(get_uuid("selections"), "data"),
         State(get_uuid("page-selected"), "data"),
     )
-    def _update_page_custom(selections: dict, page_selected: str) -> tuple:
+    def _update_page_custom(selections: dict, page_selected: str) -> Any:
         if page_selected != "custom":
             raise PreventUpdate
 
@@ -212,7 +212,7 @@ def distribution_controllers(
         Input(get_uuid("selections"), "data"),
         State(get_uuid("page-selected"), "data"),
     )
-    def _update_page_per_zr(selections: dict, page_selected: str) -> list:
+    def _update_page_per_zr(selections: dict, page_selected: str) -> Any:
         if page_selected != "per_zr":
             raise PreventUpdate
 
@@ -291,7 +291,7 @@ def distribution_controllers(
             raise PreventUpdate
 
         subplots = selections["Subplots"] if selections["Subplots"] is not None else []
-        groups = ["REAL"]
+        groups: List[Any] = ["REAL"]
         if subplots and subplots not in groups:
             groups.append(subplots)
 
@@ -388,7 +388,7 @@ def make_tables(
     view_height: float,
     page_selected: str,
     groups: Optional[list] = None,
-) -> html.Div:
+) -> List[Any]:
     groups = groups if groups is not None else []
 
     if table_type == "Statistics table":

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
@@ -1,6 +1,7 @@
-from typing import Callable
+from typing import Any, Callable, Dict, Union
 
 from dash import ALL, Input, Output, State, callback, callback_context, no_update
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 
 from ..utils.utils import update_relevant_components
@@ -23,6 +24,7 @@ def layout_controllers(get_uuid: Callable) -> None:
     ) -> tuple:
         ctx = callback_context.triggered[0]
         initial_pages = {"voldist": "custom", "tornado": "torn_multi"}
+        page_output: Union[Dict[str, str], NoUpdate] = previous_page
 
         # handle initial callback
         if ctx["prop_id"] == ".":
@@ -31,7 +33,7 @@ def layout_controllers(get_uuid: Callable) -> None:
                 if not tab_selected in initial_pages
                 else initial_pages[tab_selected]
             )
-            previous_page = initial_pages
+            page_output = initial_pages
 
         elif "tabs" in ctx["prop_id"]:
             page_selected = (
@@ -39,14 +41,14 @@ def layout_controllers(get_uuid: Callable) -> None:
                 if not tab_selected in initial_pages
                 else previous_page[tab_selected]
             )
-            previous_page = no_update
+            page_output = no_update
 
         else:
             for button_id in button_ids:
                 if button_id["button"] in ctx["prop_id"]:
                     page_selected = previous_page[tab_selected] = button_id["button"]
 
-        return page_selected, previous_page
+        return page_selected, page_output
 
     @callback(
         Output({"id": get_uuid("selections"), "button": ALL}, "style"),

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Union
+from typing import Any, Callable, Dict, Union
 
 from dash import ALL, Input, Output, State, callback, callback_context, no_update
 from dash._callback import NoUpdate

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/layout_controllers.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Union
+from typing import Callable, Dict, Union
 
 from dash import ALL, Input, Output, State, callback, callback_context, no_update
 from dash._callback import NoUpdate

--- a/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/controllers/selections_controllers.py
@@ -1,7 +1,8 @@
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import webviz_core_components as wcc
 from dash import ALL, Input, Output, State, callback, callback_context, no_update
+from dash._callback import NoUpdate
 from dash.exceptions import PreventUpdate
 
 from webviz_subsurface._models import InplaceVolumesModel
@@ -326,8 +327,9 @@ def selections_controllers(
             if selector not in page_filter_settings:
                 continue
             options = [x["value"] for x in page_filter_settings[selector]["options"]]
-            multi = selector in selected_data
+            multi: Union[bool, NoUpdate] = selector in selected_data
             selector_is_multi = page_filter_settings[selector]["multi"]
+            values: Union[List[str], NoUpdate]
             if not multi and selector_is_multi:
                 values = [
                     (
@@ -339,7 +341,8 @@ def selections_controllers(
             elif multi and not selector_is_multi:
                 values = options
             else:
-                multi = values = no_update
+                multi = no_update
+                values = no_update
             output[selector] = {"multi": multi, "values": values}
 
         # filter tornado on correct fluid based on volume response chosen

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 
 from webviz_subsurface._abbreviations.number_formatting import si_prefixed
 from webviz_subsurface._models import InplaceVolumesModel

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
@@ -4,8 +4,7 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
-from dash import 
+from dash.dash_table import DataTable
 
 from webviz_subsurface._abbreviations.number_formatting import si_prefixed
 from webviz_subsurface._models import InplaceVolumesModel

--- a/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/utils/table_and_figure_utils.py
@@ -4,7 +4,8 @@ from typing import List, Optional, Tuple, Union
 import numpy as np
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash import dash_table
+from dash.dash_table.DataTable import DataTable
+from dash import 
 
 from webviz_subsurface._abbreviations.number_formatting import si_prefixed
 from webviz_subsurface._models import InplaceVolumesModel
@@ -76,7 +77,7 @@ def create_data_table(
     return wcc.WebvizPluginPlaceholder(
         id={"request": "table_data", "table_id": table_id["table_id"]},
         buttons=["expand", "download"],
-        children=dash_table.DataTable(
+        children=DataTable(
             id=table_id,
             sort_action="native",
             sort_mode="multi",

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -2,8 +2,8 @@ from typing import List, Optional
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash.dash_table import DataTable
 from dash import dcc, html
+from dash.dash_table import DataTable
 
 from webviz_subsurface._models import InplaceVolumesModel
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -1,9 +1,9 @@
-from typing import List, Optional
+from typing import Any, List, Optional, Union
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
 from dash import dcc, html
-from dash.dash_table import DataTable
+from dash.dash_table.DataTable import DataTable
 
 from webviz_subsurface._models import InplaceVolumesModel
 
@@ -67,7 +67,7 @@ def comparison_qc_plots_layout(
 
 
 def comparison_table_layout(
-    table: DataTable, table_type: str, selections: dict, filter_info: str
+    table: Any, table_type: str, selections: dict, filter_info: str
 ) -> html.Div:
     if table_type == "single-response table":
         header = f"Table showing differences for {selections['Response']}"

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -1,9 +1,8 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
 from dash import dcc, html
-from dash.dash_table.DataTable import DataTable
 
 from webviz_subsurface._models import InplaceVolumesModel
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -1,8 +1,9 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
 from dash import dcc, html
+from dash.dash_table.DataTable import DataTable
 
 from webviz_subsurface._models import InplaceVolumesModel
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -22,13 +22,15 @@ def comparison_qc_plots_layout(
     return html.Div(
         children=[
             html.Div(
-                children=wcc.Graph(
-                    config={"displayModeBar": False},
-                    style={"height": "21vh"},
-                    figure=fig_diff_vs_real,
-                )
-                if real_plot
-                else [],
+                children=(
+                    wcc.Graph(
+                        config={"displayModeBar": False},
+                        style={"height": "21vh"},
+                        figure=fig_diff_vs_real,
+                    )
+                    if real_plot
+                    else []
+                ),
             ),
             wcc.FlexBox(
                 style={"height": "31vh" if real_plot else "52vh"},
@@ -53,13 +55,15 @@ def comparison_qc_plots_layout(
                 style={"height": "29vh"},
                 children=[
                     wcc.Header("Highlighted data"),
-                    wcc.Graph(
-                        config={"displayModeBar": False},
-                        style={"height": "25vh"},
-                        figure=barfig,
-                    )
-                    if barfig is not None
-                    else html.Div("No data within highlight criteria"),
+                    (
+                        wcc.Graph(
+                            config={"displayModeBar": False},
+                            style={"height": "25vh"},
+                            figure=barfig,
+                        )
+                        if barfig is not None
+                        else html.Div("No data within highlight criteria")
+                    ),
                 ],
             ),
         ]

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash.dash_table.DataTable import DataTable
+from dash.dash_table import DataTable
 from dash import dcc, html
 
 from webviz_subsurface._models import InplaceVolumesModel

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/comparison_layout.py
@@ -2,7 +2,8 @@ from typing import List, Optional
 
 import plotly.graph_objects as go
 import webviz_core_components as wcc
-from dash import dash_table, dcc, html
+from dash.dash_table.DataTable import DataTable
+from dash import dcc, html
 
 from webviz_subsurface._models import InplaceVolumesModel
 
@@ -66,7 +67,7 @@ def comparison_qc_plots_layout(
 
 
 def comparison_table_layout(
-    table: dash_table, table_type: str, selections: dict, filter_info: str
+    table: DataTable, table_type: str, selections: dict, filter_info: str
 ) -> html.Div:
     if table_type == "single-response table":
         header = f"Table showing differences for {selections['Response']}"

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/distribution_main_layout.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/distribution_main_layout.py
@@ -50,7 +50,7 @@ def custom_plotting_layout(figure: go.Figure, tables: Optional[list]) -> html.Di
     )
 
 
-def plots_per_zone_region_layout(figures: list) -> list:
+def plots_per_zone_region_layout(figures: list) -> html.Div:
     height = "42vh" if len(figures) < 3 else "28vh"
     return html.Div(
         children=[

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/filter_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/filter_view.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import webviz_core_components as wcc
 from dash import html
@@ -36,7 +36,7 @@ def filter_dropdowns(
     hide_selectors: Optional[list] = None,
 ) -> html.Div:
     """Makes dropdowns for each selector"""
-    dropdowns_layout: List[html.Div] = []
+    dropdowns_layout: List[Any] = []
     hide_selectors = ["SENSNAME", "SENSTYPE", "SENSCASE"] + (
         hide_selectors if hide_selectors is not None else []
     )

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 import pandas as pd
 import webviz_core_components as wcc
@@ -172,7 +172,7 @@ def main_view(
     )
 
 
-def tab_view_layout(main_layout: list, sidebar_layout: list) -> wcc.FlexBox:
+def tab_view_layout(main_layout: Any, sidebar_layout: list) -> wcc.FlexBox:
     return wcc.FlexBox(
         children=[
             wcc.Frame(

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional
 
 import pandas as pd
 import webviz_core_components as wcc

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import pandas as pd
 import webviz_core_components as wcc

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Optional
 
 import pandas as pd
 import webviz_core_components as wcc

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/main_view.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 import pandas as pd
 import webviz_core_components as wcc

--- a/webviz_subsurface/plugins/_volumetric_analysis/views/tornado_view.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/views/tornado_view.py
@@ -29,13 +29,15 @@ def tornado_plots_layout(figures: list, bottom_display: list) -> html.Div:
                         children=[
                             html.Div(
                                 style={"flex": 1},
-                                children=wcc.Graph(
-                                    config={"displayModeBar": False},
-                                    style={"height": f"{max_height/len(matrix)}vh"},
-                                    figure=fig,
-                                )
-                                if fig is not None
-                                else [],
+                                children=(
+                                    wcc.Graph(
+                                        config={"displayModeBar": False},
+                                        style={"height": f"{max_height/len(matrix)}vh"},
+                                        figure=fig,
+                                    )
+                                    if fig is not None
+                                    else []
+                                ),
                             )
                             for fig in row
                         ]
@@ -204,9 +206,11 @@ def reference_selector(
         label="Reference:",
         id={"id": uuid, "tab": tab, "selector": "Reference"},
         options=[{"label": elm, "value": elm} for elm in volumemodel.sensitivities],
-        value="rms_seed"
-        if "rms_seed" in volumemodel.sensitivities
-        else volumemodel.sensitivities[0],
+        value=(
+            "rms_seed"
+            if "rms_seed" in volumemodel.sensitivities
+            else volumemodel.sensitivities[0]
+        ),
         clearable=False,
     )
 

--- a/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volume_validator_and_combinator.py
@@ -167,6 +167,8 @@ class VolumeValidatorAndCombinator:
 
     def create_set_dframe(self, volume_dfs: List[pd.DataFrame]) -> pd.DataFrame:
         """Sum Eclipse and RMS volumetrics over the common disjoints sets."""
+        if self.disjoint_set_df is None:
+            raise ValueError("disjoint_set_df is required for create_set_dframe")
         region_selectors = self.find_region_selectors()
         set_data_list = []
         for set_idx, df in self.disjoint_set_df.groupby("SET"):
@@ -203,6 +205,8 @@ class VolumeValidatorAndCombinator:
     def find_region_selectors(self) -> list:
         """Return region selectors that has a unique value
         per set. If none is found SET is used"""
+        if self.disjoint_set_df is None:
+            raise ValueError("disjoint_set_df is required for find_region_selectors")
         df = self.disjoint_set_df.groupby(["SET"]).nunique()
         regcols = ["FIPNUM", "REGION", "ZONE"]
         if any((df[x] == 1).all() for x in regcols):

--- a/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
+++ b/webviz_subsurface/plugins/_volumetric_analysis/volumetric_analysis.py
@@ -254,7 +254,7 @@ reek_test_data/aggregated_data/parameters.csv)
         self.set_callbacks()
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             children=[
                 clientside_stores(get_uuid=self.uuid),

--- a/webviz_subsurface/plugins/_well_analysis/_views/_well_control_view/_view_element.py
+++ b/webviz_subsurface/plugins/_well_analysis/_views/_well_control_view/_view_element.py
@@ -10,7 +10,7 @@ class WellControlViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             id=self.register_component_unique_id(WellControlViewElement.Ids.CHART)
         )

--- a/webviz_subsurface/plugins/_well_analysis/_views/_well_overview_view/_view.py
+++ b/webviz_subsurface/plugins/_well_analysis/_views/_well_overview_view/_view.py
@@ -196,6 +196,7 @@ class WellOverviewView(ViewABC):
                 .component_unique_id(WellOverviewViewElement.Ids.GRAPH)
                 .to_string(),
                 "figure",
+                allow_optional=True,
             ),
             State(
                 {

--- a/webviz_subsurface/plugins/_well_analysis/_views/_well_overview_view/_view.py
+++ b/webviz_subsurface/plugins/_well_analysis/_views/_well_overview_view/_view.py
@@ -102,9 +102,11 @@ class WellOverviewView(ViewABC):
         ) -> list:
             """Display only the settings relevant for the currently selected chart type."""
             return [
-                {"display": "block"}
-                if settings_id["charttype"] == chart_selected
-                else {"display": "none"}
+                (
+                    {"display": "block"}
+                    if settings_id["charttype"] == chart_selected
+                    else {"display": "none"}
+                )
                 for settings_id in charttype_settings_ids
             ]
 
@@ -252,16 +254,16 @@ class WellOverviewView(ViewABC):
                     ensembles=ensembles,
                     data_models=self._data_models,
                     sumvec=sumvec,
-                    prod_from_date=datetime.datetime.strptime(
-                        prod_from_date, "%Y-%m-%d"
-                    )
-                    if prod_from_date is not None
-                    else None,
-                    prod_until_date=datetime.datetime.strptime(
-                        prod_until_date, "%Y-%m-%d"
-                    )
-                    if prod_until_date is not None
-                    else None,
+                    prod_from_date=(
+                        datetime.datetime.strptime(prod_from_date, "%Y-%m-%d")
+                        if prod_from_date is not None
+                        else None
+                    ),
+                    prod_until_date=(
+                        datetime.datetime.strptime(prod_until_date, "%Y-%m-%d")
+                        if prod_until_date is not None
+                        else None
+                    ),
                     charttype=charttype_selected,
                     stattype=stattype_selected,
                     wells=wells_selected,

--- a/webviz_subsurface/plugins/_well_analysis/_views/_well_overview_view/_view_element.py
+++ b/webviz_subsurface/plugins/_well_analysis/_views/_well_overview_view/_view_element.py
@@ -11,7 +11,7 @@ class WellOverviewViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             children=wcc.Graph(
                 id=self.register_component_unique_id(WellOverviewViewElement.Ids.GRAPH),

--- a/webviz_subsurface/plugins/_well_completion/_views/_well_completion_view/_view_element.py
+++ b/webviz_subsurface/plugins/_well_completion/_views/_well_completion_view/_view_element.py
@@ -10,7 +10,7 @@ class WellCompletionViewElement(ViewElementABC):
     def __init__(self) -> None:
         super().__init__()
 
-    def inner_layout(self) -> html.Div:
+    def inner_layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             id=self.register_component_unique_id(
                 WellCompletionViewElement.Ids.COMPONENT

--- a/webviz_subsurface/plugins/_well_completions/_business_logic.py
+++ b/webviz_subsurface/plugins/_well_completions/_business_logic.py
@@ -473,9 +473,11 @@ def extract_stratigraphy(
         return [
             {
                 "name": zone,
-                "color": zone_color_mapping[zone]
-                if zone_color_mapping is not None and zone in zone_color_mapping
-                else next(color_iterator),
+                "color": (
+                    zone_color_mapping[zone]
+                    if zone_color_mapping is not None and zone in zone_color_mapping
+                    else next(color_iterator)
+                ),
             }
             for zone in zone_names
         ]

--- a/webviz_subsurface/plugins/_well_completions/_plugin.py
+++ b/webviz_subsurface/plugins/_well_completions/_plugin.py
@@ -204,7 +204,7 @@ class WellCompletions(WebvizPluginABC):
         return layout_tour_steps(self.uuid)
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return main_layout(
             get_uuid=self.uuid,
             ensembles=list(self._data_models.keys()),

--- a/webviz_subsurface/plugins/_well_cross_section.py
+++ b/webviz_subsurface/plugins/_well_cross_section.py
@@ -132,12 +132,14 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
                     html.Span("Seismic:", style={"font-weight": "bold"}),
                     dcc.Dropdown(
                         id=self.ids("cube"),
-                        options=[
-                            {"label": Path(segy).stem, "value": segy}
-                            for segy in self.segyfiles
-                        ]
-                        if self.segyfiles
-                        else None,
+                        options=(
+                            [
+                                {"label": Path(segy).stem, "value": segy}
+                                for segy in self.segyfiles
+                            ]
+                            if self.segyfiles
+                            else None
+                        ),
                         value=self.segyfiles[0] if self.segyfiles else None,
                         clearable=False,
                         persistence=True,

--- a/webviz_subsurface/plugins/_well_cross_section.py
+++ b/webviz_subsurface/plugins/_well_cross_section.py
@@ -208,7 +208,7 @@ e.g. [xtgeo](https://xtgeo.readthedocs.io/en/latest/).
         )
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return html.Div(
             children=[
                 html.Div(

--- a/webviz_subsurface/plugins/_well_log_viewer/well_log_viewer.py
+++ b/webviz_subsurface/plugins/_well_log_viewer/well_log_viewer.py
@@ -128,7 +128,7 @@ Format of the `initial_settings` argument:
         self.set_callbacks(app)
 
     @property
-    def layout(self) -> html.Div:
+    def layout(self) -> html.Div:  # type: ignore[override]
         return wcc.FlexBox(
             [
                 wcc.Frame(

--- a/webviz_subsurface/smry2arrow_batch.py
+++ b/webviz_subsurface/smry2arrow_batch.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""Batch conversion of UNSMRY files to Apache Arrow IPC file format
-"""
+"""Batch conversion of UNSMRY files to Apache Arrow IPC file format"""
 
 import argparse
 import glob


### PR DESCRIPTION
Current `dash<=2` limit makes it impossible to avoid some dependency vulnerabilities.

Allowing `dash>=4` involves changing e.g. `DataTable` import, as well as changes to types in order to satisfy linters.

Tested on https://webviz-subsurface-example.azurewebsites.net/ (current version there is with dash 4).