### PR TITLE
Add configurable styling for observations, realizations and statistics in `LinePlotterFMU`

### DIFF
--- a/webviz_subsurface/plugins/_line_plotter_fmu/controllers/build_figure.py
+++ b/webviz_subsurface/plugins/_line_plotter_fmu/controllers/build_figure.py
@@ -19,6 +19,7 @@ def build_figure(
     observationmodel: Optional[ObservationModel],
     parameterproviders: Dict[str, EnsembleTableProvider],
     colors: Dict,
+    line_style: Optional[Dict] = None,
 ) -> None:
     @app.callback(
         Output(
@@ -103,7 +104,10 @@ def build_figure(
         if df.empty:
             return [], {"title": "No data found with current filter"}
         figure = PlotlyLinePlot(
-            xaxis_title=x_column_name, yaxis_title=y_column_name, ensemble_colors=colors
+            xaxis_title=x_column_name,
+            yaxis_title=y_column_name,
+            ensemble_colors=colors,
+            line_style=line_style,
         )
         if "Realizations" in traces:
             figure.add_realization_traces(

--- a/webviz_subsurface/plugins/_line_plotter_fmu/figures/plotly_line_plot.py
+++ b/webviz_subsurface/plugins/_line_plotter_fmu/figures/plotly_line_plot.py
@@ -3,6 +3,33 @@ from typing import Dict, List, Optional, Tuple
 import pandas as pd
 import plotly.graph_objects as go
 
+# Defaults are kept as None where a dynamic/previous behaviour should be preserved
+# unless the user explicitly overrides the value through the `line_style` config.
+DEFAULT_LINE_STYLE: Dict[str, Dict] = {
+    "observations": {
+        "color": "black",
+        "opacity": 1,
+        "marker_size": 8,
+        "line_width": 2,
+    },
+    "realizations": {
+        "opacity": None,
+        "line_width": 0.5,
+    },
+    "statistics": {
+        "opacity": 1,
+        "line_width": 3,
+    },
+}
+
+
+def _merge_line_style(line_style: Optional[Dict]) -> Dict:
+    """Merge user provided line_style config with the defaults, per trace group"""
+    merged = {group: dict(values) for group, values in DEFAULT_LINE_STYLE.items()}
+    for group, values in (line_style or {}).items():
+        merged.setdefault(group, {}).update(values)
+    return merged
+
 
 class PlotlyLinePlot:
     def __init__(
@@ -10,8 +37,10 @@ class PlotlyLinePlot:
         xaxis_title: str = None,
         yaxis_title: str = None,
         ensemble_colors: Dict = None,
+        line_style: Dict = None,
     ) -> None:
         self._ensemble_colors = ensemble_colors if ensemble_colors else {}
+        self._line_style = _merge_line_style(line_style)
         self._realization_traces: List = []
         self._statistical_traces: List = []
         self._observation_traces: List = []
@@ -34,6 +63,13 @@ class PlotlyLinePlot:
     ) -> None:
         """Renders line trace for each realization"""
         # If color parameter is given, normalize values for coloring
+        style = self._line_style["realizations"]
+        # Explicit config value takes precedence, otherwise fall back to the
+        # dynamically computed opacity passed in from the caller.
+        trace_opacity = style.get("opacity")
+        if trace_opacity is None:
+            trace_opacity = opacity
+        line_width = style.get("line_width", 0.5)
         if color_column is not None:
             dframe["VALUE_NORM"] = (
                 dframe[color_column] - dframe[color_column].min()
@@ -63,8 +99,8 @@ class PlotlyLinePlot:
                                 ensemble, "rgba(128,128,128,0.2)"
                             ),
                         },
-                        "opacity": opacity,
-                        "line": {"width": 3 if real in highlight_reals else 0.5},
+                        "opacity": trace_opacity,
+                        "line": {"width": 3 if real in highlight_reals else line_width},
                         "mode": mode,
                         "showlegend": real_no == 0 and color_column is None,
                     }
@@ -107,12 +143,15 @@ class PlotlyLinePlot:
         traces: List,
         mode: str = "lines",
     ) -> None:
+        style = self._line_style["statistics"]
+        line_width = style.get("line_width", 3)
+        opacity = style.get("opacity", 1)
         for ensemble, ens_df in dframe.groupby("ENSEMBLE"):
             color = self._ensemble_colors.get(ensemble, "rgba(128,128,128,1)")
             if "Low/High" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dot", "width": 3},
+                        "line": {"dash": "dot", "width": line_width},
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "max")],
                         "hovertemplate": f"Calculation: {'mac'}, Ensemble: {ensemble}",
@@ -120,13 +159,14 @@ class PlotlyLinePlot:
                         "legendgroup": ensemble,
                         "showlegend": False,
                         "marker": {"color": color},
+                        "opacity": opacity,
                         "mode": mode,
                     }
                 )
             if "P10/P90" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dash"},
+                        "line": {"dash": "dash", "width": line_width},
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "high_p10")],
                         "hovertemplate": f"Calculation: {'high_p10'}, Ensemble: {ensemble}",
@@ -134,6 +174,7 @@ class PlotlyLinePlot:
                         "legendgroup": ensemble,
                         "showlegend": False,
                         "marker": {"color": color},
+                        "opacity": opacity,
                         "mode": mode,
                     }
                 )
@@ -147,14 +188,15 @@ class PlotlyLinePlot:
                         "legendgroup": ensemble,
                         # "fill": "tonexty",
                         "marker": {"color": color},
+                        "opacity": opacity,
                         "mode": mode,
-                        "line": {"width": 3},
+                        "line": {"width": line_width},
                     }
                 )
             if "P10/P90" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dash"},
+                        "line": {"dash": "dash", "width": line_width},
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "low_p90")],
                         "hovertemplate": f"Calculation: {'low_p90'}, Ensemble: {ensemble}",
@@ -163,13 +205,14 @@ class PlotlyLinePlot:
                         "showlegend": False,
                         # "fill": "tonexty",
                         "marker": {"color": color},
+                        "opacity": opacity,
                         "mode": mode,
                     }
                 )
             if "Low/High" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dot", "width": 1},
+                        "line": {"dash": "dot", "width": line_width},
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "min")],
                         "hovertemplate": f"Calculation: {'min'}, Ensemble: {ensemble}",
@@ -177,17 +220,21 @@ class PlotlyLinePlot:
                         "legendgroup": ensemble,
                         "showlegend": False,
                         "marker": {"color": color},
+                        "opacity": opacity,
                         "mode": mode,
                     }
                 )
 
     def add_observations(self, observations: list, x_value: str) -> None:
+        style = self._line_style["observations"]
+        color = style.get("color", "black")
         for obs in observations:
             self._observation_traces.append(
                 {
                     "x": [obs.get(x_value, [])],
                     "y": [obs.get("value", [])],
-                    "marker": {"color": "black"},
+                    "marker": {"color": color, "size": style.get("marker_size", 8)},
+                    "opacity": style.get("opacity", 1),
                     "text": obs.get("comment", None),
                     "hoverinfo": "y+x+text",
                     "showlegend": False,
@@ -195,6 +242,8 @@ class PlotlyLinePlot:
                         "type": "data",
                         "array": [obs.get("error"), []],
                         "visible": True,
+                        "color": color,
+                        "thickness": style.get("line_width", 2),
                     },
                 }
             )

--- a/webviz_subsurface/plugins/_line_plotter_fmu/figures/plotly_line_plot.py
+++ b/webviz_subsurface/plugins/_line_plotter_fmu/figures/plotly_line_plot.py
@@ -9,7 +9,7 @@ DEFAULT_LINE_STYLE: Dict[str, Dict] = {
     "observations": {
         "color": "black",
         "opacity": 1,
-        "marker_size": 8,
+        "marker_size": None,
         "line_width": 2,
     },
     "realizations": {
@@ -17,8 +17,8 @@ DEFAULT_LINE_STYLE: Dict[str, Dict] = {
         "line_width": 0.5,
     },
     "statistics": {
-        "opacity": 1,
-        "line_width": 3,
+        "opacity": None,
+        "line_width": None,
     },
 }
 
@@ -144,14 +144,25 @@ class PlotlyLinePlot:
         mode: str = "lines",
     ) -> None:
         style = self._line_style["statistics"]
-        line_width = style.get("line_width", 3)
+        # A configured width/opacity applies to all statistical traces, otherwise
+        # the original per-trace default (dash type/width) from before this option
+        # was added is kept as-is.
+        configured_width = style.get("line_width")
         opacity = style.get("opacity", 1)
+
+        def line(dash: str, default_width: Optional[float] = None) -> Dict:
+            width = configured_width if configured_width is not None else default_width
+            line_dict: Dict = {"dash": dash}
+            if width is not None:
+                line_dict["width"] = width
+            return line_dict
+
         for ensemble, ens_df in dframe.groupby("ENSEMBLE"):
             color = self._ensemble_colors.get(ensemble, "rgba(128,128,128,1)")
             if "Low/High" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dot", "width": line_width},
+                        "line": line("dot", 3),
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "max")],
                         "hovertemplate": f"Calculation: {'mac'}, Ensemble: {ensemble}",
@@ -166,7 +177,7 @@ class PlotlyLinePlot:
             if "P10/P90" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dash", "width": line_width},
+                        "line": line("dash"),
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "high_p10")],
                         "hovertemplate": f"Calculation: {'high_p10'}, Ensemble: {ensemble}",
@@ -190,13 +201,17 @@ class PlotlyLinePlot:
                         "marker": {"color": color},
                         "opacity": opacity,
                         "mode": mode,
-                        "line": {"width": line_width},
+                        "line": {
+                            "width": configured_width
+                            if configured_width is not None
+                            else 3
+                        },
                     }
                 )
             if "P10/P90" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dash", "width": line_width},
+                        "line": line("dash"),
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "low_p90")],
                         "hovertemplate": f"Calculation: {'low_p90'}, Ensemble: {ensemble}",
@@ -212,7 +227,7 @@ class PlotlyLinePlot:
             if "Low/High" in traces:
                 self._statistical_traces.append(
                     {
-                        "line": {"dash": "dot", "width": line_width},
+                        "line": line("dot", 1),
                         "x": ens_df[x_column],
                         "y": ens_df[(y_column, "min")],
                         "hovertemplate": f"Calculation: {'min'}, Ensemble: {ensemble}",
@@ -228,12 +243,15 @@ class PlotlyLinePlot:
     def add_observations(self, observations: list, x_value: str) -> None:
         style = self._line_style["observations"]
         color = style.get("color", "black")
+        marker: Dict = {"color": color}
+        if style.get("marker_size") is not None:
+            marker["size"] = style["marker_size"]
         for obs in observations:
             self._observation_traces.append(
                 {
                     "x": [obs.get(x_value, [])],
                     "y": [obs.get("value", [])],
-                    "marker": {"color": color, "size": style.get("marker_size", 8)},
+                    "marker": marker,
                     "opacity": style.get("opacity", 1),
                     "text": obs.get("comment", None),
                     "hoverinfo": "y+x+text",

--- a/webviz_subsurface/plugins/_line_plotter_fmu/line_plotter_fmu.py
+++ b/webviz_subsurface/plugins/_line_plotter_fmu/line_plotter_fmu.py
@@ -30,6 +30,14 @@ class LinePlotterFMU(WebvizPluginABC):
     * **`remap_observation_keys`:** Remap observation keys to columns in csv file
     * **`remap_observation_values`:** Remap observation values to columns in csv file
     * **`colors`:** Set colors for each ensemble
+    * **`line_style`:** Control color, opacity and line/marker width per trace group. \
+    Each group is optional and unset options fall back to their defaults. Available \
+    groups and options:
+        * `observations`: `color` (default `black`), `opacity` (default `1`), \
+        `marker_size` (default `8`), `line_width` (error bar thickness, default `2`)
+        * `realizations`: `opacity` (default: dimmed automatically if statistics or \
+        observations are also shown, otherwise fully opaque), `line_width` (default `0.5`)
+        * `statistics`: `opacity` (default `1`), `line_width` (default `3`)
     * **`initial_data`:** Initialize data selectors (x,y,ensemble, parameter)
     * **`initial_layout`:** Initialize plot layout (x and y axis direction and type)"""
 
@@ -49,6 +57,7 @@ class LinePlotterFMU(WebvizPluginABC):
         colors: Dict = None,
         initial_data: Dict = None,
         initial_layout: Dict = None,
+        line_style: Dict = None,
     ):
         super().__init__()
 
@@ -131,6 +140,7 @@ class LinePlotterFMU(WebvizPluginABC):
         self._colors: Dict = unique_colors(self._ensemble_names, webviz_settings.theme)
         if colors is not None:
             self._colors.update(colors)
+        self._line_style = line_style
 
         self.set_callbacks(app)
 
@@ -172,6 +182,7 @@ class LinePlotterFMU(WebvizPluginABC):
             observationmodel=self._observationmodel,
             parameterproviders=self._parameterproviderset,
             colors=self._colors,
+            line_style=self._line_style,
         )
         update_figure_clientside(app, get_uuid=self.uuid)
 

--- a/webviz_subsurface/plugins/_line_plotter_fmu/line_plotter_fmu.py
+++ b/webviz_subsurface/plugins/_line_plotter_fmu/line_plotter_fmu.py
@@ -34,10 +34,13 @@ class LinePlotterFMU(WebvizPluginABC):
     Each group is optional and unset options fall back to their defaults. Available \
     groups and options:
         * `observations`: `color` (default `black`), `opacity` (default `1`), \
-        `marker_size` (default `8`), `line_width` (error bar thickness, default `2`)
-        * `realizations`: `opacity` (default: dimmed automatically if statistics or \
-        observations are also shown, otherwise fully opaque), `line_width` (default `0.5`)
-        * `statistics`: `opacity` (default `1`), `line_width` (default `3`)
+        `marker_size` (default: unset, i.e. Plotly's default marker size), \
+        `line_width` (error bar thickness, default `2`)
+        * `realizations`: `opacity` (default: dimmed automatically when one or more \
+        statistical traces are shown together with realizations, otherwise fully \
+        opaque), `line_width` (default `0.5`)
+        * `statistics`: `opacity` (default `1`), `line_width` (default: unset, i.e. \
+        each statistical trace keeps its own distinct default width)
     * **`initial_data`:** Initialize data selectors (x,y,ensemble, parameter)
     * **`initial_layout`:** Initialize plot layout (x and y axis direction and type)"""
 


### PR DESCRIPTION


## Problem
Closes #1376 

In `LinePlotterFMU`, observation markers/error bars, realization lines, and statistical lines used hardcoded styling (color, opacity, width). When a dataset has many observations, they can visually cover the plot area and make the underlying simulation (realization) lines hard to see, with no way to adjust this from the configuration.

## Solution

Added a new optional `line_style` init argument to `LinePlotterFMU`, allowing per-trace-group styling to be set in the YAML configuration:

```yaml
- LinePlotterFMU:
    ...
    line_style:
      observations:
        color: black
        opacity: 0.6
        marker_size: 6
        line_width: 1        # error bar thickness
      realizations:
        opacity: 0.2
        line_width: 0.5
      statistics:
        opacity: 1
        line_width: 4
```

All groups/keys are optional — anything not specified falls back to the previous default behavior, so existing configurations render unchanged.

## Changes

- **`figures/plotly_line_plot.py`**: Added `DEFAULT_LINE_STYLE` and a `_merge_line_style()` helper to merge user overrides with defaults. `PlotlyLinePlot` now accepts a `line_style` dict and applies it when building observation, realization, and statistical traces (color/opacity/marker size for observations and their error bars; opacity/line width for realizations and statistics).
- **`controllers/build_figure.py`**: Threaded `line_style` through to `PlotlyLinePlot`.
- **`line_plotter_fmu.py`**: Added the `line_style` constructor argument, stored it, passed it to `build_figure`, and documented the exact supported keys/defaults per group in the plugin docstring.

## Backward compatibility

No behavior change for existing configurations — realization opacity still auto-dims when multiple trace types are shown (unless explicitly overridden), and all other defaults match the prior hardcoded values.
